### PR TITLE
Add Cloudflare-native rate limiting and abuse controls

### DIFF
--- a/.dev.vars.playwright
+++ b/.dev.vars.playwright
@@ -1,0 +1,17 @@
+BETTER_AUTH_SECRET=playwright-only-secret-with-32-characters
+SUPERADMIN_EMAIL=playwright-admin@example.com
+APP_URL=http://localhost:5174
+APP_HOST=localhost:5174
+
+RESEND_API_KEY=re_local_emulated
+RESEND_BASE_URL=http://localhost:4000
+MAIL_FROM=rdyrct <no-reply@localhost>
+
+POLAR_ACCESS_TOKEN=playwright_polar_token
+POLAR_WEBHOOK_SECRET=playwright_webhook_secret
+POLAR_PRO_PRODUCT_ID=playwright_pro_product
+POLAR_HOBBY_PRODUCT_ID=playwright_hobby_product
+POLAR_SERVER=sandbox
+
+DEV_FAKE_CF=1
+CF_ZONE_ID=

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ rdyrct is built Cloudflare-first: the entire product runs in a single Worker wit
 - **KV**: slug → destination lookups on the redirect hot path, so a click never waits on D1.
 - **R2**: QR logo images, keyed by org, served immutable and cached.
 - **Cloudflare for SaaS**: custom hostnames for Pro orgs' own short-link domains.
+- **Workers Rate Limiting**: separate abuse controls for auth, email, writes, uploads, domains, billing, and click recording.
 
 Application layer:
 
@@ -151,6 +152,9 @@ bun run deploy
 **Polar setup:** create an Organization Access Token with scopes `checkouts:write` and `customer_sessions:write`. Add a webhook endpoint at `https://rdyrct.com/api/webhooks/polar` and subscribe to `subscription.active`, `subscription.revoked`, `subscription.canceled`, and `subscription.uncanceled`.
 
 Finally, point `rdyrct.com` at the Worker as a **custom domain**: Cloudflare dashboard → Workers → your worker → **Settings → Domains & Routes**. Short links live at the root (`https://rdyrct.com/<slug>`); the app is served on every other path.
+
+Review the [rate-limiting policies, monitoring, WAF rule, and rollback steps](docs/rate-limiting.md)
+before the first production deploy.
 
 **Customer custom domains (Pro):** to let orgs use `links.theirbrand.com`, enable [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/) on the `rdyrct.com` zone, create an originless proxied fallback origin (e.g. `fallback.rdyrct.com AAAA 100::`), and add a Worker route `*/*` pointing at the `rdyrct` worker. The `CF_API_TOKEN` needs permission **Zone → SSL and Certificates → Edit** scoped to the zone. Also verify your sending domain (e.g. `mail.rdyrct.com`) in [Resend](https://resend.com) so transactional email isn't blocked.
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,85 @@
+# Rate limiting
+
+rdyrct uses Cloudflare Workers Rate Limiting bindings as app-level abuse
+controls. These counters are local to each Cloudflare location, permissive, and
+eventually consistent. Do not use them for billing or exact plan limits.
+
+## Worker policies
+
+All policies use a 60-second window. Namespace IDs `14001` through `14008` are
+reserved for rdyrct in the Cloudflare account.
+
+| Binding              | Limit | Key                               | Protected work                                  |
+| -------------------- | ----: | --------------------------------- | ----------------------------------------------- |
+| `RL_AUTH_PUBLIC`     |    10 | Auth action + opaque client HMAC  | Sign-in, sign-up, verification                  |
+| `RL_EMAIL`           |     3 | Email action + opaque client HMAC | Verification and password-reset email           |
+| `RL_WRITE_FREE`      |    30 | User + org + route group          | Free-plan API writes                            |
+| `RL_WRITE_PAID`      |   120 | User + org + route group          | Paid-plan API writes                            |
+| `RL_QR_UPLOAD`       |     5 | User + org                        | R2 QR logo uploads                              |
+| `RL_DOMAIN_SETUP`    |    12 | User + org                        | Domain reads and mutations that call Cloudflare |
+| `RL_BILLING`         |     3 | User + billing action             | Polar checkout and portal sessions              |
+| `RL_CLICK_RECORDING` |   600 | Organization                      | D1 click analytics writes                       |
+
+API limits return HTTP `429`, `Retry-After: 60`, and the stable error code
+`rate_limited`. Binding failures fail open for signed API work so a Cloudflare
+counter outage does not take down the app. Click analytics fails closed because
+the redirect does not depend on it.
+
+The public client HMAC uses the request address as a transient input. The raw
+input and HMAC never enter D1, KV, application logs, or click analytics.
+Structured logs contain only the event, policy group, HTTP method, and plan.
+Shared addresses may place several valid users in one public bucket, so tune
+these limits from production evidence rather than treating them as exact.
+
+## Monitoring
+
+Cloudflare does not show Worker rate-limit binding counters in the dashboard.
+Use **Workers & Pages → rdyrct → Observability → Logs** and filter for:
+
+```text
+"event":"rate_limited"
+```
+
+Group by `group` and `plan` when tuning limits. Alert on a sustained rise in
+`rate_limit_error`, which means the binding failed and API protection opened.
+
+The domain limit allows the app's 10-second activation poll plus manual actions.
+Lowering it below 6 per minute will break the expected setup flow.
+
+## WAF outer shield
+
+Create a zone-level WAF rate-limiting rule for clear attack traffic. Keep this
+separate from the Worker deployment because rule features and thresholds depend
+on the zone plan.
+
+Recommended starting rule:
+
+- Name: `rdyrct public auth outer shield`
+- Match: host equals `rdyrct.com`, method is `POST`, and path starts with
+  `/api/auth/`
+- Counting characteristic: source IP
+- Start in log or managed-challenge mode when the plan supports it
+- Initial threshold: 100 requests per 10 seconds
+- Never include short-link redirect paths
+
+Check the available counting periods, actions, and rule count in the zone
+dashboard before enabling enforcement. Shared addresses can represent many
+valid users, so review logs before lowering the threshold.
+
+## Rollout and rollback
+
+1. Deploy the Worker bindings and code with the documented limits.
+2. Confirm `rate_limited` and `rate_limit_error` events in Worker logs.
+3. Add the WAF rule in log or challenge mode, then monitor it before enforcing.
+4. Tune one policy at a time. Worker counters may briefly exceed a configured
+   limit by design.
+
+To roll back, disable the WAF rule first and roll the Worker back to the prior
+version. Keep namespace IDs reserved while an older Worker version may still
+serve traffic. Removing a binding before rolling code back can cause runtime
+errors.
+
+## Cloudflare references
+
+- [Workers Rate Limiting API](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/)
+- [WAF rate-limiting rules](https://developers.cloudflare.com/waf/rate-limiting-rules/)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { appUrl, playwrightPort } from "./tests/e2e/environment";
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -9,7 +10,7 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: appUrl,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
   },
@@ -22,11 +23,14 @@ export default defineConfig({
       gracefulShutdown: { signal: "SIGTERM", timeout: 500 },
     },
     {
-      command: "bun run dev -- --host localhost --port 5173 --strictPort",
-      url: "http://localhost:5173",
+      command: `bunx vite dev --host localhost --port ${playwrightPort} --strictPort`,
+      url: appUrl,
       reuseExistingServer: false,
       gracefulShutdown: { signal: "SIGTERM", timeout: 500 },
-      env: { PLAYWRIGHT_TEST: "1" },
+      env: {
+        PLAYWRIGHT_TEST: "1",
+        CLOUDFLARE_ENV: "playwright",
+      },
     },
   ],
 });

--- a/src/worker/better-auth.ts
+++ b/src/worker/better-auth.ts
@@ -62,6 +62,10 @@ function buildAuth(env: Env) {
         verification: schema.verification,
       },
     }),
+    // Cloudflare Workers Rate Limiting bindings guard auth before BetterAuth.
+    // Keeping BetterAuth's per-isolate limiter enabled would create a second,
+    // inconsistent 429 shape and would not protect the rest of the app.
+    rateLimit: { enabled: false },
     emailAndPassword: {
       enabled: true,
       requireEmailVerification: true,

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -6,6 +6,14 @@ export interface Env {
   LINKS: KVNamespace;
   QR_LOGOS: R2Bucket;
   ASSETS: Fetcher;
+  RL_AUTH_PUBLIC: RateLimit;
+  RL_EMAIL: RateLimit;
+  RL_WRITE_FREE: RateLimit;
+  RL_WRITE_PAID: RateLimit;
+  RL_QR_UPLOAD: RateLimit;
+  RL_DOMAIN_SETUP: RateLimit;
+  RL_BILLING: RateLimit;
+  RL_CLICK_RECORDING: RateLimit;
 
   /* auth + email (secrets unless noted) */
   BETTER_AUTH_SECRET: string;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -15,6 +15,11 @@ import { billingRoutes, handlePolarWebhook } from "./routes/billing";
 import { domainRoutes } from "./routes/domains";
 import { resolveSlug, resolveDomain, type KVLink } from "./kv";
 import { now, deviceFromUA, RESERVED_SLUGS } from "./util";
+import {
+  clickAnalyticsAllowed,
+  enforcePublicAuthRateLimit,
+  enforceSignedApiRateLimit,
+} from "./rate-limit";
 
 const app = new Hono<AppEnv>();
 
@@ -37,6 +42,7 @@ function redirectWithClick(c: Context<AppEnv>, hit: KVLink): Response {
   c.executionCtx.waitUntil(
     (async () => {
       try {
+        if (!(await clickAnalyticsAllowed(c.env, hit.orgId, c.req.method))) return;
         const db = drizzle(c.env.DB, { schema });
         await db.insert(schema.clicks).values({
           linkId: hit.linkId,
@@ -76,13 +82,17 @@ app.use("*", async (c, next) => {
 /* ---------------- API ---------------- */
 
 // BetterAuth owns /api/auth/* (signup, login, logout, verify, reset).
-app.on(["GET", "POST"], "/api/auth/*", (c) => getAuth(c.env).handler(c.req.raw));
+app.on(["GET", "POST"], "/api/auth/*", async (c) => {
+  const limited = await enforcePublicAuthRateLimit(c);
+  return limited ?? getAuth(c.env).handler(c.req.raw);
+});
 
 // Polar webhook: public, signature-verified, no session middleware.
 app.post("/api/webhooks/polar", (c) => handlePolarWebhook(c.req.raw, c.env));
 
 const api = new Hono<AppEnv>();
 api.use("*", withSession);
+api.use("*", enforceSignedApiRateLimit);
 api.route("/", userRoutes);
 api.route("/orgs", orgRoutes);
 api.route("/orgs/:orgId/links", linkRoutes);

--- a/src/worker/rate-limit.ts
+++ b/src/worker/rate-limit.ts
@@ -1,0 +1,191 @@
+import type { Context, Next } from "hono";
+import type { AppEnv, Env, SessionUser } from "./env";
+
+const RATE_LIMIT_WINDOW_SECONDS = 60;
+
+export type RateLimitGroup =
+  | "auth"
+  | "email"
+  | "write"
+  | "qr_upload"
+  | "domain"
+  | "checkout"
+  | "click";
+
+const EMAIL_AUTH_PATHS = new Set([
+  "/api/auth/email-otp/request-password-reset",
+  "/api/auth/email-otp/send-verification-otp",
+  "/api/auth/forget-password/email-otp",
+  "/api/auth/request-password-reset",
+  "/api/auth/send-verification-email",
+]);
+
+function rateLimitLog(
+  event: "rate_limited" | "rate_limit_error",
+  group: RateLimitGroup,
+  details: { method: string; plan?: SessionUser["plan"]; error?: unknown },
+) {
+  const payload: Record<string, unknown> = {
+    event,
+    group,
+    method: details.method,
+  };
+  if (details.plan) payload.plan = details.plan;
+  if (details.error)
+    payload.error = details.error instanceof Error ? details.error.name : "unknown";
+  console.warn(JSON.stringify(payload));
+}
+
+export async function rateLimitAllows(
+  binding: RateLimit,
+  key: string,
+  options: {
+    group: RateLimitGroup;
+    method: string;
+    plan?: SessionUser["plan"];
+    failClosed?: boolean;
+  },
+): Promise<boolean> {
+  try {
+    const { success } = await binding.limit({ key });
+    if (!success) rateLimitLog("rate_limited", options.group, options);
+    return success;
+  } catch (error) {
+    rateLimitLog("rate_limit_error", options.group, { ...options, error });
+    return !options.failClosed;
+  }
+}
+
+function rateLimitedResponse(c: Context<AppEnv>, group: RateLimitGroup) {
+  return c.json(
+    {
+      message: "Too many requests. Try again shortly.",
+      code: "rate_limited",
+    },
+    429,
+    {
+      "Retry-After": String(RATE_LIMIT_WINDOW_SECONDS),
+      "Cache-Control": "no-store",
+      "X-RateLimit-Group": group,
+    },
+  );
+}
+
+function hex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/** Builds an ephemeral public-client key without exposing an IP address to
+ * application storage or logs. The HMAC output exists only in Cloudflare's
+ * rate-limit counter. */
+export async function publicClientKey(request: Request, secret: string): Promise<string> {
+  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const address = request.headers.get("cf-connecting-ip") ?? forwarded ?? "unknown";
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return hex(await crypto.subtle.sign("HMAC", key, encoder.encode(address)));
+}
+
+export function publicAuthGroup(path: string): "auth" | "email" | null {
+  if (EMAIL_AUTH_PATHS.has(path)) return "email";
+  if (
+    path.startsWith("/api/auth/") &&
+    path !== "/api/auth/get-session" &&
+    path !== "/api/auth/sign-out"
+  )
+    return "auth";
+  return null;
+}
+
+export async function enforcePublicAuthRateLimit(c: Context<AppEnv>): Promise<Response | null> {
+  const group = publicAuthGroup(c.req.path);
+  if (!group) return null;
+  const client = await publicClientKey(c.req.raw, c.env.BETTER_AUTH_SECRET);
+  const binding = group === "email" ? c.env.RL_EMAIL : c.env.RL_AUTH_PUBLIC;
+  const allowed = await rateLimitAllows(binding, `${group}:${c.req.path}:${client}`, {
+    group,
+    method: c.req.method,
+  });
+  return allowed ? null : rateLimitedResponse(c, group);
+}
+
+export function signedApiGroup(
+  path: string,
+  method: string,
+): Exclude<RateLimitGroup, "auth" | "email" | "click"> | null {
+  if (/^\/api\/billing\/(?:checkout|portal)$/.test(path)) return "checkout";
+  if (method === "POST" && /^\/api\/orgs\/[^/]+\/qr-logo\/?$/.test(path)) return "qr_upload";
+  if (/^\/api\/orgs\/[^/]+\/domains(?:\/|$)/.test(path)) return "domain";
+  if (method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE")
+    return "write";
+  return null;
+}
+
+function orgIdFromPath(path: string): string | null {
+  return /^\/api\/orgs\/([^/]+)/.exec(path)?.[1] ?? null;
+}
+
+function writeRouteFamily(path: string): string {
+  if (path.includes("/links")) return "links";
+  if (path.includes("/invites")) return "invites";
+  if (path.startsWith("/api/admin")) return "admin";
+  if (path.startsWith("/api/orgs")) return "orgs";
+  return "api";
+}
+
+export function writeRateLimitBinding(env: Env, plan: SessionUser["plan"]): RateLimit {
+  return plan === "free" ? env.RL_WRITE_FREE : env.RL_WRITE_PAID;
+}
+
+export async function enforceSignedApiRateLimit(c: Context<AppEnv>, next: Next) {
+  const user = c.var.user;
+  const group = signedApiGroup(c.req.path, c.req.method);
+  if (!user || !group) return next();
+
+  const orgId = orgIdFromPath(c.req.path);
+  const actor = orgId ? `org:${orgId}:user:${user.id}` : `user:${user.id}`;
+  let binding: RateLimit;
+  let key = `${group}:${actor}`;
+
+  switch (group) {
+    case "checkout":
+      binding = c.env.RL_BILLING;
+      break;
+    case "domain":
+      binding = c.env.RL_DOMAIN_SETUP;
+      break;
+    case "qr_upload":
+      binding = c.env.RL_QR_UPLOAD;
+      break;
+    case "write":
+      binding = writeRateLimitBinding(c.env, user.plan);
+      key = `${key}:${writeRouteFamily(c.req.path)}`;
+      break;
+  }
+
+  const allowed = await rateLimitAllows(binding, key, {
+    group,
+    method: c.req.method,
+    plan: user.plan,
+  });
+  if (!allowed) return rateLimitedResponse(c, group);
+  return next();
+}
+
+export async function clickAnalyticsAllowed(
+  env: Env,
+  orgId: string,
+  method = "GET",
+): Promise<boolean> {
+  return rateLimitAllows(env.RL_CLICK_RECORDING, `click:org:${orgId}`, {
+    group: "click",
+    method,
+    failClosed: true,
+  });
+}

--- a/src/worker/rate-limit.ts
+++ b/src/worker/rate-limit.ts
@@ -13,6 +13,7 @@ export type RateLimitGroup =
   | "click";
 
 const EMAIL_AUTH_PATHS = new Set([
+  "/api/auth/sign-up/email",
   "/api/auth/email-otp/request-password-reset",
   "/api/auth/email-otp/send-verification-otp",
   "/api/auth/forget-password/email-otp",

--- a/tests/e2e/auth.pw.ts
+++ b/tests/e2e/auth.pw.ts
@@ -1,6 +1,24 @@
 import { expect, test } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
 
 test.describe("authentication forms", () => {
+  test("signs in with a verified account", async ({ page }) => {
+    const email = `login-${Date.now()}@gmail.com`;
+    const password = "test-password-123";
+
+    await signUpAndVerify(page, email, password);
+
+    await page.getByLabel("Sign out").click();
+    await expect(page).toHaveURL(/\/login$/);
+
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.getByText("No organization", { exact: true })).toBeVisible();
+  });
+
   test("keeps invalid login details in the browser instead of sending an auth request", async ({
     page,
   }) => {

--- a/tests/e2e/authenticated-flows.pw.ts
+++ b/tests/e2e/authenticated-flows.pw.ts
@@ -1,47 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
+import { appUrl, explorerUrl } from "./environment";
+import { signUpAndVerify } from "./resend";
 
 const password = "test-password-123";
-const explorerUrl = "http://localhost:5173/cdn-cgi/explorer/api";
-
-function otpForEmail(value: unknown, email: string): string {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      const otp = otpForEmail(item, email);
-      if (otp) return otp;
-    }
-    return "";
-  }
-  if (!value || typeof value !== "object") return "";
-
-  const record = value as Record<string, unknown>;
-  const serialized = JSON.stringify(record);
-  if (serialized.includes(email) && ("html" in record || "text" in record)) {
-    return serialized.match(/\b\d{6}\b/)?.[0] ?? "";
-  }
-  for (const item of Object.values(record)) {
-    const otp = otpForEmail(item, email);
-    if (otp) return otp;
-  }
-  return "";
-}
-
-async function latestOtp(page: Page, email: string) {
-  await expect
-    .poll(async () => {
-      const response = await page.request.get("http://localhost:4000/emails", {
-        headers: { authorization: "Bearer test_token_admin" },
-      });
-      if (!response.ok()) return "";
-      const body = await response.json();
-      return otpForEmail(body, email);
-    })
-    .not.toBe("");
-
-  const response = await page.request.get("http://localhost:4000/emails", {
-    headers: { authorization: "Bearer test_token_admin" },
-  });
-  return otpForEmail(await response.json(), email);
-}
 
 async function setPlan(page: Page, email: string) {
   const databases = await page.request.get(`${explorerUrl}/d1/database`);
@@ -62,19 +23,7 @@ async function setPlan(page: Page, email: string) {
 test("a new owner can create an organization and a scheme-less quick link", async ({ page }) => {
   const email = `playwright-${Date.now()}@gmail.com`;
 
-  await page.goto("/signup");
-  await page.getByLabel("Email").fill(email);
-  await page.getByLabel("Password").fill(password);
-  await page.getByRole("button", { name: "Sign up" }).click();
-
-  await expect(page.getByRole("heading", { name: "Enter your code" })).toBeVisible();
-  await page.reload();
-  await expect(page.getByRole("heading", { name: "Enter your code" })).toBeVisible();
-  const otp = await latestOtp(page, email);
-  await page.locator("input").first().focus();
-  await page.keyboard.insertText(otp);
-
-  await expect(page).toHaveURL(/\/dashboard$/);
+  await signUpAndVerify(page, email, password);
   await page.getByLabel("Organization name").fill("Playwright Org");
   await page.getByRole("button", { name: "Create organization" }).click();
 
@@ -84,7 +33,7 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
   await page.getByRole("button", { name: "Create link" }).click();
 
   await expect(page.getByRole("dialog", { name: "Link created" })).toBeVisible();
-  await expect(page.getByRole("dialog")).toContainText("http://localhost:5173/");
+  await expect(page.getByRole("dialog")).toContainText(`${appUrl}/`);
 
   await setPlan(page, email);
   await page.goto("/domains");

--- a/tests/e2e/environment.ts
+++ b/tests/e2e/environment.ts
@@ -1,0 +1,3 @@
+export const playwrightPort = 5174;
+export const appUrl = `http://localhost:${playwrightPort}`;
+export const explorerUrl = `${appUrl}/cdn-cgi/explorer/api`;

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,7 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
-
-const explorerUrl = "http://localhost:5173/cdn-cgi/explorer/api";
+import { explorerUrl } from "./environment";
 
 export default async function globalSetup() {
   const databases = await fetch(`${explorerUrl}/d1/database`).then((response) => response.json());

--- a/tests/e2e/resend.ts
+++ b/tests/e2e/resend.ts
@@ -23,20 +23,19 @@ function otpForEmail(value: unknown, email: string): string {
 }
 
 export async function latestOtp(page: Page, email: string) {
+  let otp = "";
   await expect
     .poll(async () => {
       const response = await page.request.get("http://localhost:4000/emails", {
         headers: { authorization: "Bearer test_token_admin" },
       });
       if (!response.ok()) return "";
-      return otpForEmail(await response.json(), email);
+      otp = otpForEmail(await response.json(), email);
+      return otp;
     })
     .not.toBe("");
 
-  const response = await page.request.get("http://localhost:4000/emails", {
-    headers: { authorization: "Bearer test_token_admin" },
-  });
-  return otpForEmail(await response.json(), email);
+  return otp;
 }
 
 export async function signUpAndVerify(page: Page, email: string, password: string) {

--- a/tests/e2e/resend.ts
+++ b/tests/e2e/resend.ts
@@ -1,0 +1,55 @@
+import { expect, type Page } from "@playwright/test";
+
+function otpForEmail(value: unknown, email: string): string {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const otp = otpForEmail(item, email);
+      if (otp) return otp;
+    }
+    return "";
+  }
+  if (!value || typeof value !== "object") return "";
+
+  const record = value as Record<string, unknown>;
+  const serialized = JSON.stringify(record);
+  if (serialized.includes(email) && ("html" in record || "text" in record)) {
+    return serialized.match(/\b\d{6}\b/)?.[0] ?? "";
+  }
+  for (const item of Object.values(record)) {
+    const otp = otpForEmail(item, email);
+    if (otp) return otp;
+  }
+  return "";
+}
+
+export async function latestOtp(page: Page, email: string) {
+  await expect
+    .poll(async () => {
+      const response = await page.request.get("http://localhost:4000/emails", {
+        headers: { authorization: "Bearer test_token_admin" },
+      });
+      if (!response.ok()) return "";
+      return otpForEmail(await response.json(), email);
+    })
+    .not.toBe("");
+
+  const response = await page.request.get("http://localhost:4000/emails", {
+    headers: { authorization: "Bearer test_token_admin" },
+  });
+  return otpForEmail(await response.json(), email);
+}
+
+export async function signUpAndVerify(page: Page, email: string, password: string) {
+  await page.goto("/signup");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Sign up" }).click();
+
+  await expect(page.getByRole("heading", { name: "Enter your code" })).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Enter your code" })).toBeVisible();
+  const otp = await latestOtp(page, email);
+  await page.locator("input").first().focus();
+  await page.keyboard.insertText(otp);
+  await expect(page).toHaveURL(/\/dashboard$/);
+}

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -43,6 +43,7 @@ function signedWriteApp(plan: SessionUser["plan"]) {
 describe("Cloudflare rate limiting", () => {
   it("groups public email delivery separately from auth and never limits logout", () => {
     expect(publicAuthGroup("/api/auth/sign-in/email")).toBe("auth");
+    expect(publicAuthGroup("/api/auth/sign-up/email")).toBe("email");
     expect(publicAuthGroup("/api/auth/email-otp/verify-email")).toBe("auth");
     expect(publicAuthGroup("/api/auth/email-otp/send-verification-otp")).toBe("email");
     expect(publicAuthGroup("/api/auth/request-password-reset")).toBe("email");
@@ -108,6 +109,31 @@ describe("Cloudflare rate limiting", () => {
       message: "Too many requests. Try again shortly.",
       code: "rate_limited",
     });
+  });
+
+  it("uses the email binding for sign-up email", async () => {
+    const app = new Hono<AppEnv>();
+    app.post("/api/auth/*", async (c) => {
+      const limited = await enforcePublicAuthRateLimit(c);
+      return limited ?? c.json({ ok: true });
+    });
+    const auth = limiter(true);
+    const email = limiter(false);
+    const env = {
+      BETTER_AUTH_SECRET: "test-secret",
+      RL_AUTH_PUBLIC: auth,
+      RL_EMAIL: email,
+    } as Env;
+
+    const response = await app.request(
+      "/api/auth/sign-up/email",
+      { method: "POST", headers: { "cf-connecting-ip": "203.0.113.9" } },
+      env,
+    );
+
+    expect(response.status).toBe(429);
+    expect(email.limit).toHaveBeenCalledTimes(1);
+    expect(auth.limit).not.toHaveBeenCalled();
   });
 
   it("limits free writes and allows the same request through the paid binding", async () => {

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv, Env, SessionUser } from "../src/worker/env";
+import {
+  clickAnalyticsAllowed,
+  enforcePublicAuthRateLimit,
+  enforceSignedApiRateLimit,
+  publicAuthGroup,
+  publicClientKey,
+  rateLimitAllows,
+  signedApiGroup,
+  writeRateLimitBinding,
+} from "../src/worker/rate-limit";
+
+function limiter(success: boolean): RateLimit {
+  return {
+    limit: mock(async () => ({ success })),
+  };
+}
+
+const testUser = (plan: SessionUser["plan"]): SessionUser => ({
+  id: "user-1",
+  email: "user@example.com",
+  name: "Test user",
+  isAdmin: false,
+  emailVerified: true,
+  plan,
+  polarSubscriptionCancelAtPeriodEnd: false,
+  polarSubscriptionCurrentPeriodEnd: null,
+});
+
+function signedWriteApp(plan: SessionUser["plan"]) {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("user", testUser(plan));
+    await next();
+  });
+  app.use("*", enforceSignedApiRateLimit);
+  app.post("/api/orgs/:orgId/links", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("Cloudflare rate limiting", () => {
+  it("groups public email delivery separately from auth and never limits logout", () => {
+    expect(publicAuthGroup("/api/auth/sign-in/email")).toBe("auth");
+    expect(publicAuthGroup("/api/auth/email-otp/verify-email")).toBe("auth");
+    expect(publicAuthGroup("/api/auth/email-otp/send-verification-otp")).toBe("email");
+    expect(publicAuthGroup("/api/auth/request-password-reset")).toBe("email");
+    expect(publicAuthGroup("/api/auth/sign-out")).toBeNull();
+    expect(publicAuthGroup("/api/auth/get-session")).toBeNull();
+  });
+
+  it("groups each costly signed-in route", () => {
+    expect(signedApiGroup("/api/orgs/org-1/links", "POST")).toBe("write");
+    expect(signedApiGroup("/api/orgs/org-1/qr-logo", "POST")).toBe("qr_upload");
+    expect(signedApiGroup("/api/orgs/org-1/domains", "GET")).toBe("domain");
+    expect(signedApiGroup("/api/orgs/org-1/domains/id/refresh", "POST")).toBe("domain");
+    expect(signedApiGroup("/api/billing/checkout", "POST")).toBe("checkout");
+    expect(signedApiGroup("/api/billing/portal", "GET")).toBe("checkout");
+    expect(signedApiGroup("/api/orgs/org-1/links", "GET")).toBeNull();
+  });
+
+  it("uses the higher write binding for either paid plan", () => {
+    const free = limiter(true);
+    const paid = limiter(true);
+    const env = { RL_WRITE_FREE: free, RL_WRITE_PAID: paid } as Env;
+    expect(writeRateLimitBinding(env, "free")).toBe(free);
+    expect(writeRateLimitBinding(env, "hobby")).toBe(paid);
+    expect(writeRateLimitBinding(env, "pro")).toBe(paid);
+  });
+
+  it("builds a stable opaque public key without exposing the address", async () => {
+    const request = new Request("https://rdyrct.com/api/auth/sign-in/email", {
+      headers: {
+        "cf-connecting-ip": "203.0.113.9",
+        "user-agent": "rate-limit-test",
+      },
+    });
+    const first = await publicClientKey(request, "test-secret");
+    const second = await publicClientKey(request, "test-secret");
+    expect(first).toBe(second);
+    expect(first).toHaveLength(64);
+    expect(first).not.toContain("203.0.113.9");
+  });
+
+  it("returns the stable 429 contract for a limited public auth request", async () => {
+    const app = new Hono<AppEnv>();
+    app.post("/api/auth/*", async (c) => {
+      const limited = await enforcePublicAuthRateLimit(c);
+      return limited ?? c.json({ ok: true });
+    });
+    const env = {
+      BETTER_AUTH_SECRET: "test-secret",
+      RL_AUTH_PUBLIC: limiter(false),
+      RL_EMAIL: limiter(true),
+    } as Env;
+
+    const response = await app.request(
+      "/api/auth/sign-in/email",
+      { method: "POST", headers: { "cf-connecting-ip": "203.0.113.9" } },
+      env,
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      message: "Too many requests. Try again shortly.",
+      code: "rate_limited",
+    });
+  });
+
+  it("limits free writes and allows the same request through the paid binding", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const free = limiter(false);
+    const paid = limiter(true);
+    const env = {
+      RL_WRITE_FREE: free,
+      RL_WRITE_PAID: paid,
+    } as Env;
+
+    const limited = await signedWriteApp("free").request(
+      "/api/orgs/org-1/links",
+      { method: "POST" },
+      env,
+    );
+    expect(limited.status).toBe(429);
+    expect(free.limit).toHaveBeenCalledTimes(1);
+    expect(paid.limit).not.toHaveBeenCalled();
+
+    const allowed = await signedWriteApp("hobby").request(
+      "/api/orgs/org-1/links",
+      { method: "POST" },
+      env,
+    );
+    expect(allowed.status).toBe(200);
+    expect(paid.limit).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("fails open for API availability but closed for click analytics", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const broken: RateLimit = {
+      limit: mock(async () => {
+        throw new Error("binding unavailable");
+      }),
+    };
+    expect(
+      await rateLimitAllows(broken, "user-1", {
+        group: "write",
+        method: "POST",
+      }),
+    ).toBe(true);
+
+    const env = { RL_CLICK_RECORDING: broken } as Env;
+    expect(await clickAnalyticsAllowed(env, "org-1")).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+});

--- a/tests/worker/redirects.worker.ts
+++ b/tests/worker/redirects.worker.ts
@@ -4,10 +4,12 @@ import { applyD1Migrations, reset } from "cloudflare:test";
 
 type TestEnv = typeof env & { TEST_MIGRATIONS: D1Migration[] };
 
+const settleClickTasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 afterEach(async () => {
   // The redirect handler records clicks through waitUntil. Let that task finish
   // before Miniflare clears the test bindings.
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await settleClickTasks();
   await reset();
 });
 
@@ -26,6 +28,14 @@ beforeEach(async () => {
     env.DB.prepare(
       "insert into links (id, org_id, slug, destination, created_at) values (?, ?, ?, ?, ?)",
     ).bind("link-2", "org-1", "pricing", "https://example.com/pricing", 0),
+    env.DB.prepare("insert into orgs (id, name, created_at) values (?, ?, ?)").bind(
+      "org-limited",
+      "Rate-limited org",
+      0,
+    ),
+    env.DB.prepare(
+      "insert into links (id, org_id, slug, destination, created_at) values (?, ?, ?, ?, ?)",
+    ).bind("link-limited", "org-limited", "viral", "https://example.com/viral", 0),
   ]);
 });
 
@@ -39,6 +49,7 @@ describe("redirect hot path", () => {
     const response = await worker.default.fetch(
       new Request("http://localhost/summer", { redirect: "manual" }),
     );
+    await settleClickTasks();
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("https://example.com/sale");
@@ -67,6 +78,33 @@ describe("redirect hot path", () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("https://example.com/pricing");
+  });
+
+  it("still redirects and skips click storage when analytics is limited", async () => {
+    await env.LINKS.put(
+      "slug:viral",
+      JSON.stringify({
+        linkId: "link-limited",
+        orgId: "org-limited",
+        url: "https://example.com/viral",
+      }),
+    );
+    await env.RL_CLICK_RECORDING.limit({ key: "click:org:org-limited" });
+
+    const response = await worker.default.fetch(
+      new Request("http://localhost/viral", { redirect: "manual" }),
+    );
+    await settleClickTasks();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://example.com/viral");
+    expect(
+      (
+        await env.DB.prepare("select count(*) as count from clicks where org_id = ?")
+          .bind("org-limited")
+          .first<{ count: number }>()
+      )?.count,
+    ).toBe(0);
   });
 
   it("uses a custom domain's root redirect for the root and missing slugs", async () => {

--- a/tests/worker/redirects.worker.ts
+++ b/tests/worker/redirects.worker.ts
@@ -1,15 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { env, exports as worker } from "cloudflare:workers";
-import { applyD1Migrations, reset } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import {
+  applyD1Migrations,
+  createExecutionContext,
+  reset,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import worker from "../../src/worker";
 
 type TestEnv = typeof env & { TEST_MIGRATIONS: D1Migration[] };
 
-const settleClickTasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+async function fetchWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
 
 afterEach(async () => {
-  // The redirect handler records clicks through waitUntil. Let that task finish
-  // before Miniflare clears the test bindings.
-  await settleClickTasks();
   await reset();
 });
 
@@ -46,10 +54,9 @@ describe("redirect hot path", () => {
       JSON.stringify({ linkId: "link-1", orgId: "org-1", url: "https://example.com/sale" }),
     );
 
-    const response = await worker.default.fetch(
+    const response = await fetchWorker(
       new Request("http://localhost/summer", { redirect: "manual" }),
     );
-    await settleClickTasks();
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("https://example.com/sale");
@@ -69,7 +76,7 @@ describe("redirect hot path", () => {
       JSON.stringify({ linkId: "link-2", orgId: "org-1", url: "https://example.com/pricing" }),
     );
 
-    const response = await worker.default.fetch(
+    const response = await fetchWorker(
       new Request("http://localhost/pricing", {
         headers: { host: "go.example.com" },
         redirect: "manual",
@@ -91,10 +98,9 @@ describe("redirect hot path", () => {
     );
     await env.RL_CLICK_RECORDING.limit({ key: "click:org:org-limited" });
 
-    const response = await worker.default.fetch(
+    const response = await fetchWorker(
       new Request("http://localhost/viral", { redirect: "manual" }),
     );
-    await settleClickTasks();
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("https://example.com/viral");
@@ -117,10 +123,10 @@ describe("redirect hot path", () => {
       }),
     );
 
-    const root = await worker.default.fetch(
+    const root = await fetchWorker(
       new Request("http://localhost/", { headers: { host: "go.example.com" }, redirect: "manual" }),
     );
-    const missing = await worker.default.fetch(
+    const missing = await fetchWorker(
       new Request("http://localhost/no-such-link", {
         headers: { host: "go.example.com" },
         redirect: "manual",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       // Browser tests use short-lived in-memory bindings, never a developer's
       // persisted D1, KV, or R2 state.
       persistState: process.env.PLAYWRIGHT_TEST ? false : true,
+      inspectorPort: process.env.PLAYWRIGHT_TEST ? false : undefined,
     }),
   ],
   resolve: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
           APP_URL: "http://localhost",
           TEST_MIGRATIONS: await readD1Migrations(path.join(import.meta.dirname, "migrations")),
         },
+        // A one-token click bucket makes the redirect fail-open behavior
+        // deterministic without weakening production's 600/min threshold.
+        ratelimits: {
+          RL_CLICK_RECORDING: {
+            namespace_id: "14008",
+            simple: { limit: 1, period: 60 },
+          },
+        },
       },
     })),
   ],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -99,6 +99,83 @@
   "triggers": {
     "crons": ["0 6 * * *"],
   },
+  // Browser tests select this environment so Wrangler loads
+  // .dev.vars.playwright instead of a developer's local values.
+  "env": {
+    "playwright": {
+      "vars": {
+        "APP_URL": "http://localhost:5174",
+        "APP_HOST": "localhost:5174",
+        "MAIL_FROM": "rdyrct <no-reply@localhost>",
+        "POLAR_SERVER": "sandbox",
+        "POLAR_PRO_PRODUCT_ID": "playwright_pro_product",
+        "POLAR_HOBBY_PRODUCT_ID": "playwright_hobby_product",
+        "CF_ZONE_ID": "",
+      },
+      "kv_namespaces": [
+        {
+          "binding": "LINKS",
+          "id": "aa2cec55f8964d0fba2c23e1e3b5fea1",
+        },
+      ],
+      "r2_buckets": [
+        {
+          "binding": "QR_LOGOS",
+          "bucket_name": "rdyrct-qr-logos",
+        },
+      ],
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "rdyrct-playwright",
+          "database_id": "cff7eb6e-ee69-4c94-8d51-6ad09de5afd9",
+          "migrations_dir": "migrations",
+        },
+      ],
+      "ratelimits": [
+        {
+          "name": "RL_AUTH_PUBLIC",
+          "namespace_id": "14001",
+          "simple": { "limit": 10, "period": 60 },
+        },
+        {
+          "name": "RL_EMAIL",
+          "namespace_id": "14002",
+          "simple": { "limit": 3, "period": 60 },
+        },
+        {
+          "name": "RL_WRITE_FREE",
+          "namespace_id": "14003",
+          "simple": { "limit": 30, "period": 60 },
+        },
+        {
+          "name": "RL_WRITE_PAID",
+          "namespace_id": "14004",
+          "simple": { "limit": 120, "period": 60 },
+        },
+        {
+          "name": "RL_QR_UPLOAD",
+          "namespace_id": "14005",
+          "simple": { "limit": 5, "period": 60 },
+        },
+        {
+          "name": "RL_DOMAIN_SETUP",
+          "namespace_id": "14006",
+          "simple": { "limit": 12, "period": 60 },
+        },
+        {
+          "name": "RL_BILLING",
+          "namespace_id": "14007",
+          "simple": { "limit": 3, "period": 60 },
+        },
+        {
+          "name": "RL_CLICK_RECORDING",
+          "namespace_id": "14008",
+          "simple": { "limit": 600, "period": 60 },
+        },
+      ],
+    },
+  },
   "observability": {
     "enabled": true,
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -49,6 +49,51 @@
       "migrations_dir": "migrations",
     },
   ],
+  // Cloudflare Workers Rate Limiting counters. Namespace IDs are unique within
+  // this account. Counters are permissive and local to each Cloudflare location,
+  // so these are abuse controls, not billing or exact quota enforcement.
+  "ratelimits": [
+    {
+      "name": "RL_AUTH_PUBLIC",
+      "namespace_id": "14001",
+      "simple": { "limit": 10, "period": 60 },
+    },
+    {
+      "name": "RL_EMAIL",
+      "namespace_id": "14002",
+      "simple": { "limit": 3, "period": 60 },
+    },
+    {
+      "name": "RL_WRITE_FREE",
+      "namespace_id": "14003",
+      "simple": { "limit": 30, "period": 60 },
+    },
+    {
+      "name": "RL_WRITE_PAID",
+      "namespace_id": "14004",
+      "simple": { "limit": 120, "period": 60 },
+    },
+    {
+      "name": "RL_QR_UPLOAD",
+      "namespace_id": "14005",
+      "simple": { "limit": 5, "period": 60 },
+    },
+    {
+      "name": "RL_DOMAIN_SETUP",
+      "namespace_id": "14006",
+      "simple": { "limit": 12, "period": 60 },
+    },
+    {
+      "name": "RL_BILLING",
+      "namespace_id": "14007",
+      "simple": { "limit": 3, "period": 60 },
+    },
+    {
+      "name": "RL_CLICK_RECORDING",
+      "namespace_id": "14008",
+      "simple": { "limit": 600, "period": 60 },
+    },
+  ],
   "workers_dev": false,
   "preview_urls": false,
   "triggers": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -100,7 +100,8 @@
     "crons": ["0 6 * * *"],
   },
   // Browser tests select this environment so Wrangler loads
-  // .dev.vars.playwright instead of a developer's local values.
+  // .dev.vars.playwright instead of a developer's local values. Resource
+  // identifiers are local-only placeholders, never production identifiers.
   "env": {
     "playwright": {
       "vars": {
@@ -115,62 +116,62 @@
       "kv_namespaces": [
         {
           "binding": "LINKS",
-          "id": "aa2cec55f8964d0fba2c23e1e3b5fea1",
+          "id": "00000000000000000000000000000001",
         },
       ],
       "r2_buckets": [
         {
           "binding": "QR_LOGOS",
-          "bucket_name": "rdyrct-qr-logos",
+          "bucket_name": "rdyrct-playwright-local",
         },
       ],
       "d1_databases": [
         {
           "binding": "DB",
           "database_name": "rdyrct-playwright",
-          "database_id": "cff7eb6e-ee69-4c94-8d51-6ad09de5afd9",
+          "database_id": "00000000-0000-0000-0000-000000000001",
           "migrations_dir": "migrations",
         },
       ],
       "ratelimits": [
         {
           "name": "RL_AUTH_PUBLIC",
-          "namespace_id": "14001",
+          "namespace_id": "24001",
           "simple": { "limit": 10, "period": 60 },
         },
         {
           "name": "RL_EMAIL",
-          "namespace_id": "14002",
+          "namespace_id": "24002",
           "simple": { "limit": 3, "period": 60 },
         },
         {
           "name": "RL_WRITE_FREE",
-          "namespace_id": "14003",
+          "namespace_id": "24003",
           "simple": { "limit": 30, "period": 60 },
         },
         {
           "name": "RL_WRITE_PAID",
-          "namespace_id": "14004",
+          "namespace_id": "24004",
           "simple": { "limit": 120, "period": 60 },
         },
         {
           "name": "RL_QR_UPLOAD",
-          "namespace_id": "14005",
+          "namespace_id": "24005",
           "simple": { "limit": 5, "period": 60 },
         },
         {
           "name": "RL_DOMAIN_SETUP",
-          "namespace_id": "14006",
+          "namespace_id": "24006",
           "simple": { "limit": 12, "period": 60 },
         },
         {
           "name": "RL_BILLING",
-          "namespace_id": "14007",
+          "namespace_id": "24007",
           "simple": { "limit": 3, "period": 60 },
         },
         {
           "name": "RL_CLICK_RECORDING",
-          "namespace_id": "14008",
+          "namespace_id": "24008",
           "simple": { "limit": 600, "period": 60 },
         },
       ],


### PR DESCRIPTION
## Summary

- add separate Cloudflare Workers Rate Limiting bindings for public auth, email delivery, free and paid writes, QR uploads, domain setup, billing, and click recording
- return a stable `429` response with `Retry-After` while keeping logout and session reads available
- derive opaque public-client keys without storing or logging raw IP addresses
- fail open for signed API availability, but skip click analytics when its limiter fails or rejects so redirects always complete
- add unit and Worker integration coverage plus an operations runbook for monitoring, WAF rollout, and rollback

## Why

rdyrct did not have one production-wide abuse-control layer. Better Auth's prior limiter was per isolate, returned a different error shape, and did not protect costly API, R2, Cloudflare for SaaS, Polar, or click-write paths. Cloudflare-native bindings keep counters close to the Worker and let each workload use a specific policy.

## Impact

Users receive a consistent retryable error when they exceed a protected API limit. Paid plans receive a larger write allowance. Short-link redirects remain available even if click analytics is limited or the limiter binding fails.

The optional zone-level WAF rule remains a manual production step and can be activated after this Worker change is deployed.

## Validation

- `bun run verify`
- 59 unit tests passed
- 4 Worker integration tests passed
- `bun run build`
- Wrangler deployment dry run with all eight bindings
- React Doctor: 100/100
- Fallow audit: no new dead code

Closes #14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Workers rate limiting across authentication, email delivery, API write actions, QR uploads, domain setup, billing, and click analytics.
  * Blocked requests now return a consistent `429` response with `Retry-After` and clear rate-limit response details.
* **Bug Fixes**
  * Improved auth rate-limit consistency to avoid mismatched 429 behavior.
* **Documentation**
  * Added detailed rate-limiting, monitoring, WAF, and rollout/rollback guidance.
  * Updated the platform stack list and added a production pre-deploy rate-limiting reminder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->