### PR TITLE
Move click ingestion off the redirect request path

### DIFF
--- a/docs/click-ingestion.md
+++ b/docs/click-ingestion.md
@@ -1,0 +1,92 @@
+# Click ingestion
+
+Redirect latency and availability are the product. A redirect never writes to
+D1 itself: it enqueues a compact click event to `CLICK_QUEUE` and returns.
+Cloudflare Queues buffer whatever a traffic spike throws at it, and a
+consumer turns each batch into one multi-row D1 insert, so a spike costs one
+write per batch instead of one write per click.
+
+This is the same queue/DLQ shape [storage recovery](storage-recovery.md)
+uses, but a different consistency model: storage messages are a
+correctness-critical follow-up to a D1 write that already happened, so a
+producer-side failure fails the request. A click is the analytics itself, and
+losing some under overload is the accepted tradeoff (issue #16), so its
+producer never fails the request.
+
+## How it works
+
+`redirectWithClick` (`src/worker/index.ts`) calls `enqueueClick`
+(`src/worker/clicks.ts`) inside `waitUntil`, after the redirect response is
+already on its way. `enqueueClick`:
+
+1. Checks `clickAnalyticsAllowed` (`RL_CLICK_RECORDING`, 600/min per org, fails
+   closed). Over the limit, it returns without enqueuing anything.
+2. Builds a `ClickMessage` with a producer-assigned `dedupeId`
+   (`crypto.randomUUID()`) and sends it to `CLICK_QUEUE`.
+3. Catches and logs its own failures instead of throwing. A full queue, a
+   Cloudflare Queues outage, or the rate limit all fall through to the same
+   place: the click is dropped, the redirect is unaffected.
+
+The consumer, `consumeClickBatch`, inserts every message in a batch as one
+`INSERT ... VALUES (...), (...), ...` statement, with
+`onConflictDoNothing()` targeting the unique `dedupe_id` column. A redelivery
+of a message that already landed inserts nothing for that row. The batch acks
+or retries as a unit (`batch.ackAll()` / `batch.retryAll()`), matching the
+insert: either every row in the statement lands or none does.
+
+## The batch failure tradeoff
+
+A `dedupe_id` collision is silently skipped, but a **foreign key** violation
+(a message naming a `linkId` that no longer exists, because the link was
+deleted between the redirect and the consumer running) fails the whole
+statement, and with it every other row in that batch. The batch retries as a
+unit; if the link stays gone, the whole batch eventually dead-letters
+together, not just the one bad row.
+
+This is a deliberate simplification, not an oversight: splitting a failed
+batch to save the surviving rows would mean re-running smaller and smaller
+inserts until the bad row is isolated, extra machinery for a rare case
+(a link deleted in the narrow window between a redirect and the next queue
+flush) whose cost is a handful of dropped clicks, which the ingestion path
+already treats as acceptable under overload. We trust Cloudflare Queues'
+retry budget here the same way `storage.ts` does for KV/R2 follow-ups.
+
+## Dead letters
+
+A batch that exhausts `rdyrct-clicks`'s retries lands on `rdyrct-clicks-dlq`,
+which this same Worker also consumes (routed by queue name in the `queue()`
+handler in `src/worker/index.ts`, checking `-clicks-dlq` ahead of the generic
+`-dlq` suffix since it ends with both). `logClickDeadLetterBatch` logs a
+`click_dropped` line per message, alerts Better Stack the same way the
+storage DLQ does (best-effort, no-ops unconfigured), then acks. Nothing
+re-drives it: a dropped click is gone, and re-deriving it from anywhere is
+not possible, unlike a `kv_sync` message which can be recovered by touching
+the row again.
+
+## Retention
+
+The daily cron (`scheduled` in `src/worker/index.ts`) still trims clicks
+older than 400 days in bounded 1000-row batches. That is unchanged: it deletes
+by age, not by how a row arrived, so it runs the same whether a row came from
+the old direct-insert path or the queue.
+
+## Local development
+
+`bun run dev` runs `rdyrct-clicks` and `rdyrct-clicks-dlq` locally the same
+way it runs the storage queues (see [Local development](storage-recovery.md#local-development)
+in the storage-recovery doc): functional checks, not timing tests, and a
+Worker reload can drop in-flight local messages.
+
+## Tests
+
+`tests/worker/clicks.worker.ts` covers the consumer and dead-letter paths
+using real `MessageBatch`es (`createMessageBatch()` / `getQueueResult()`, the
+same helpers `storage.worker.ts` uses): a batch insert lands every row in one
+statement, a redelivered `dedupeId` does not double-insert, a batch containing
+a bad `linkId` retries as a unit and recovers once the bad message is gone,
+and `click_batch_dead_letter` / `click_dropped` log only when they should.
+
+`tests/worker/redirects.worker.ts` covers the producer at the HTTP layer: a
+redirect enqueues one message with the right `linkId`/`orgId`, a
+rate-limited org enqueues nothing, and a queue-send failure still lets the
+redirect through.

--- a/docs/click-ingestion.md
+++ b/docs/click-ingestion.md
@@ -27,19 +27,21 @@ already on its way. `enqueueClick`:
    Cloudflare Queues outage, or the rate limit all fall through to the same
    place: the click is dropped, the redirect is unaffected.
 
-The consumer, `consumeClickBatch`, inserts every message in a batch as one
-`INSERT ... VALUES (...), (...), ...` statement, with
+The consumer, `consumeClickBatch`, splits a batch into chunks of 14 rows (D1
+caps bound parameters at 100 per statement, and a click row binds 7), and
+inserts every chunk in one `db.batch()` transaction, with
 `onConflictDoNothing()` targeting the unique `dedupe_id` column. A redelivery
-of a message that already landed inserts nothing for that row. The batch acks
-or retries as a unit (`batch.ackAll()` / `batch.retryAll()`), matching the
-insert: either every row in the statement lands or none does.
+of a message that already landed inserts nothing for that row: duplicate
+`dedupe_id` values are skipped per row, not treated as an error. The batch
+acks or retries as a unit (`batch.ackAll()` / `batch.retryAll()`), matching
+the transaction: a hard D1 error aborts every statement in it.
 
 ## The batch failure tradeoff
 
 A `dedupe_id` collision is silently skipped, but a **foreign key** violation
 (a message naming a `linkId` that no longer exists, because the link was
-deleted between the redirect and the consumer running) fails the whole
-statement, and with it every other row in that batch. The batch retries as a
+deleted between the redirect and the consumer running) aborts the whole
+transaction, and with it every other row in that batch. The batch retries as a
 unit; if the link stays gone, the whole batch eventually dead-letters
 together, not just the one bad row.
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -18,7 +18,7 @@ reserved for rdyrct in the Cloudflare account.
 | `RL_QR_UPLOAD`       |     5 | User + org                        | R2 QR logo uploads                              |
 | `RL_DOMAIN_SETUP`    |    12 | User + org                        | Domain reads and mutations that call Cloudflare |
 | `RL_BILLING`         |     3 | User + billing action             | Polar checkout and portal sessions              |
-| `RL_CLICK_RECORDING` |   600 | Organization                      | D1 click analytics writes                       |
+| `RL_CLICK_RECORDING` |   600 | Organization                      | Click ingestion (queued analytics writes)       |
 
 API limits return HTTP `429`, `Retry-After: 60`, and the stable error code
 `rate_limited`. Binding failures fail open for signed API work so a Cloudflare

--- a/docs/storage-recovery.md
+++ b/docs/storage-recovery.md
@@ -10,6 +10,11 @@ activation workflow (issue #28), because they share the same Workflow and
 Queue machinery and the same "D1 is truth, everything else is a resumable
 follow-up" rule.
 
+Click ingestion (issue #16) rides the same Queue/DLQ shape but a different
+consistency model: a click is the analytics write itself, not a follow-up to
+one, and losing some under overload is accepted rather than guarded against.
+See [click-ingestion.md](click-ingestion.md).
+
 ## How writes work
 
 A request handler commits its D1 change, then awaits a send to the storage

--- a/migrations/0013_add_clicks_dedupe_id.sql
+++ b/migrations/0013_add_clicks_dedupe_id.sql
@@ -1,0 +1,7 @@
+-- Click ingestion moves onto a queue (issue #16): the consumer batches inserts
+-- and needs a producer-assigned id to dedupe a redelivered message. Nullable
+-- so existing rows need no backfill; SQLite's unique index allows any number
+-- of NULLs, so they never collide.
+
+ALTER TABLE clicks ADD COLUMN dedupe_id TEXT;
+CREATE UNIQUE INDEX idx_clicks_dedupe_id ON clicks(dedupe_id);

--- a/src/app/components/qr.tsx
+++ b/src/app/components/qr.tsx
@@ -351,13 +351,24 @@ export function QrLogoInput({
 
   return (
     <div className="relative">
-      <div
-        role="button"
-        tabIndex={disabled ? -1 : 0}
+      {/* Sibling, not nested: a <button> can't legally contain an <input> */}
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        disabled={disabled}
+        className="hidden"
+        onChange={(e) => {
+          readFile(e.target.files?.[0]);
+          // reset so picking the same file again re-fires onChange
+          e.target.value = "";
+        }}
+      />
+      <button
+        type="button"
         aria-label="Upload a logo image"
-        aria-disabled={disabled || undefined}
-        onClick={() => !disabled && !busy && open()}
-        onKeyDown={(e) => !disabled && !busy && (e.key === "Enter" || e.key === " ") && open()}
+        disabled={disabled}
+        onClick={() => !busy && open()}
         onDragOver={(e) => {
           e.preventDefault();
           setDragging(true);
@@ -369,24 +380,12 @@ export function QrLogoInput({
           readFile(e.dataTransfer.files?.[0]);
         }}
         className={cn(
-          "flex w-full cursor-pointer flex-col items-center justify-center gap-1.5 rounded-md border border-dashed border-border bg-bg px-3 h-24 text-xs text-muted transition-colors select-none focus-visible:outline-2 focus-visible:outline-accent/60 aria-disabled:cursor-default aria-disabled:opacity-50",
+          "flex w-full cursor-pointer flex-col items-center justify-center gap-1.5 rounded-md border border-dashed border-border bg-bg px-3 h-24 text-xs text-muted transition-colors select-none focus-visible:outline-2 focus-visible:outline-accent/60 disabled:cursor-default disabled:opacity-50",
           dragging
             ? "border-accent text-text"
-            : "not-aria-disabled:hover:border-accent/60 not-aria-disabled:hover:text-text",
+            : "enabled:hover:border-accent/60 enabled:hover:text-text",
         )}
       >
-        <input
-          ref={inputRef}
-          type="file"
-          accept="image/*"
-          disabled={disabled}
-          className="hidden"
-          onChange={(e) => {
-            readFile(e.target.files?.[0]);
-            // reset so picking the same file again re-fires onChange
-            e.target.value = "";
-          }}
-        />
         {busy ? (
           <>
             <Spinner />
@@ -415,7 +414,7 @@ export function QrLogoInput({
             </span>
           </>
         )}
-      </div>
+      </button>
       {value && onClear && !busy && (
         <button
           type="button"

--- a/src/app/components/qr.tsx
+++ b/src/app/components/qr.tsx
@@ -364,10 +364,11 @@ export function QrLogoInput({
           e.target.value = "";
         }}
       />
-      <button
+      <Button
         type="button"
+        variant="outline"
         aria-label="Upload a logo image"
-        disabled={disabled}
+        disabled={disabled || busy}
         onClick={() => !busy && open()}
         onDragOver={(e) => {
           e.preventDefault();
@@ -380,7 +381,7 @@ export function QrLogoInput({
           readFile(e.dataTransfer.files?.[0]);
         }}
         className={cn(
-          "flex w-full cursor-pointer flex-col items-center justify-center gap-1.5 rounded-md border border-dashed border-border bg-bg px-3 h-24 text-xs text-muted transition-colors select-none focus-visible:outline-2 focus-visible:outline-accent/60 disabled:cursor-default disabled:opacity-50",
+          "h-24 w-full flex-col gap-1.5 border-dashed bg-bg px-3 text-xs font-normal text-muted select-none",
           dragging
             ? "border-accent text-text"
             : "enabled:hover:border-accent/60 enabled:hover:text-text",
@@ -414,7 +415,7 @@ export function QrLogoInput({
             </span>
           </>
         )}
-      </button>
+      </Button>
       {value && onClear && !busy && (
         <button
           type="button"

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -72,6 +72,8 @@
   --text-3xs: 10px;
   --text-4xs: 9px;
   --animate-shake: shake 300ms ease;
+  /* above dialogs (z-50): toasts must stay visible over an open modal */
+  --z-toast: 60;
 }
 
 @keyframes shake {
@@ -152,6 +154,137 @@ body {
 }
 .animate-shake {
   animation: shake 0.4s ease-in-out;
+}
+
+/* Toasts share one grid cell (true overlap, not just visual stacking) so a
+   collapsed toast can sit exactly behind the one in front of it. Collapsed
+   position/scale/opacity are index-based (a fixed per-slot look, matching
+   the old design); Base UI's --toast-index/--toast-offset-y/data-* come
+   from its own Toast.Root, Toast.Viewport, and the toast's transitionStatus. */
+.toast-stack {
+  left: 50%;
+  display: grid;
+  width: min(22rem, calc(100vw - 2rem));
+  min-height: 2.75rem;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.rdyrct-toast {
+  grid-area: 1 / 1;
+  justify-self: end;
+  width: 100%;
+  z-index: calc(100 - var(--toast-index, 0));
+  pointer-events: auto;
+  opacity: calc(1 - var(--toast-index, 0) * 0.025);
+  transform: translateY(calc(var(--toast-index, 0) * -0.65rem))
+    scale(calc(1 - var(--toast-index, 0) * 0.06));
+  transform-origin: bottom center;
+  transition:
+    transform 250ms cubic-bezier(0.2, 0, 0, 1),
+    opacity 200ms ease;
+}
+
+.rdyrct-toast[data-starting-style] {
+  opacity: 0;
+  transform: translateY(calc(var(--toast-index, 0) * -0.65rem + 1.5rem))
+    scale(calc(1 - var(--toast-index, 0) * 0.06));
+}
+
+/* Hovering or focusing the stack spaces every toast out to its real,
+   measured position (--toast-offset-y, in px) so each becomes fully
+   readable and individually closable, instead of just the frontmost one. */
+.rdyrct-toast[data-expanded] {
+  opacity: 1;
+  transform: translateY(calc(var(--toast-offset-y, 0px) * -1)) scale(1);
+  /* Read by .rdyrct-toast-timer circle below: an inherited custom property
+     keeps that rule a plain descendant selector instead of repeating this
+     one's [data-expanded] condition. */
+  --toast-timer-play-state: paused;
+}
+
+/* Last, so a toast being dismissed always collapses and fades regardless of
+   the expanded/collapsed state above. */
+.rdyrct-toast[data-ending-style] {
+  opacity: 0;
+  transform: translateY(calc(var(--toast-index, 0) * -0.65rem + 0.75rem))
+    scale(calc(1 - var(--toast-index, 0) * 0.06));
+  transition-duration: 250ms;
+}
+
+.rdyrct-toast[data-limited] {
+  display: none;
+}
+
+.rdyrct-toast-close {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  display: grid;
+  width: 1.25rem;
+  height: 1.25rem;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--muted);
+  cursor: pointer;
+  /* Every toast gets a close button, but only the frontmost one is reachable
+     while the stack is collapsed: the rest sit visually behind it and only
+     become individually closable once the stack is expanded (hover/focus). */
+  pointer-events: none;
+  transition:
+    color 150ms ease,
+    scale 150ms ease;
+}
+
+.rdyrct-toast-close-front,
+.rdyrct-toast[data-expanded] .rdyrct-toast-close {
+  pointer-events: auto;
+}
+
+.rdyrct-toast-close:hover,
+.rdyrct-toast-close:focus-visible {
+  color: var(--text);
+}
+
+.rdyrct-toast-close:active {
+  scale: 0.96;
+}
+
+.rdyrct-toast-timer {
+  position: absolute;
+  inset: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  transform: rotate(-90deg);
+}
+
+/* Expanding the stack pauses each toast's auto-dismiss timer (Base UI);
+   --toast-timer-play-state (set above, on the expanded toast) freezes the
+   ring in step so it doesn't finish before the toast actually would, which'd
+   read as the toast lying about its remaining time. */
+.rdyrct-toast-timer circle {
+  stroke-dasharray: 1;
+  stroke-dashoffset: 0;
+  animation: rdyrct-toast-timer 3250ms linear forwards;
+  animation-play-state: var(--toast-timer-play-state, running);
+}
+
+@keyframes rdyrct-toast-timer {
+  to {
+    stroke-dashoffset: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rdyrct-toast,
+  .rdyrct-toast-timer circle,
+  .toast-stack {
+    animation: none;
+    transition: none;
+  }
 }
 @media (prefers-reduced-motion: reduce) {
   .animate-shake {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -256,7 +256,7 @@ body {
   width: calc(100% + 6px);
   height: calc(100% + 6px);
   fill: none;
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 1.5;
   transform: rotate(-90deg);
 }

--- a/src/app/ui/toast.tsx
+++ b/src/app/ui/toast.tsx
@@ -1,43 +1,56 @@
-import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from "react";
+import { useCallback, type ReactNode } from "react";
+import { Toast } from "@base-ui/react/toast";
+import { X } from "lucide-react";
 import { cn } from "./cn";
 
-interface Toast {
-  id: number;
-  message: string;
-  kind: "info" | "error";
+// A standalone manager, not context state, so the many call sites that just
+// want to push a toast don't subscribe to the toast list and re-render on
+// every add/dismiss elsewhere in the app.
+const manager = Toast.createToastManager();
+
+export function useToast() {
+  return useCallback((message: string, kind: "info" | "error" = "info") => {
+    manager.add({ description: message, type: kind });
+  }, []);
 }
 
-const ToastContext = createContext<(message: string, kind?: Toast["kind"]) => void>(() => {});
-
-export const useToast = () => useContext(ToastContext);
-
 export function ToastProvider({ children }: { children: ReactNode }) {
-  const [toasts, setToasts] = useState<Toast[]>([]);
-  const nextId = useRef(0);
-
-  const push = useCallback((message: string, kind: Toast["kind"] = "info") => {
-    const id = nextId.current++;
-    setToasts((t) => [...t, { id, message, kind }]);
-    setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 3500);
-  }, []);
-
   return (
-    <ToastContext.Provider value={push}>
+    <Toast.Provider toastManager={manager} limit={4} timeout={3250}>
       {children}
-      <div className="pointer-events-none fixed right-4 bottom-4 z-[60] flex flex-col gap-2">
-        {toasts.map((t) => (
-          <div
-            key={t.id}
-            role="status"
-            className={cn(
-              "rounded-lg border bg-surface px-4 py-2.5 text-sm shadow-xl",
-              t.kind === "error" ? "border-danger/50 text-danger" : "border-border text-text",
-            )}
-          >
-            {t.message}
-          </div>
-        ))}
-      </div>
-    </ToastContext.Provider>
+      <Toast.Portal>
+        <Toast.Viewport className="toast-stack pointer-events-none fixed bottom-4 z-toast">
+          <ToastList />
+        </Toast.Viewport>
+      </Toast.Portal>
+    </Toast.Provider>
   );
+}
+
+function ToastList() {
+  const { toasts } = Toast.useToastManager();
+  return toasts.map((toast, index) => (
+    <Toast.Root
+      key={toast.id}
+      toast={toast}
+      swipeDirection="down"
+      className={cn(
+        "rdyrct-toast rounded-lg border bg-surface px-4 py-2.5 pr-10 text-sm shadow-xl",
+        toast.type === "error" ? "border-danger/50 text-danger" : "border-border text-text",
+      )}
+    >
+      <Toast.Description />
+      <Toast.Close
+        className={cn("rdyrct-toast-close", index === 0 && "rdyrct-toast-close-front")}
+        aria-label="Dismiss notification"
+      >
+        {index === 0 && (
+          <svg className="rdyrct-toast-timer" viewBox="0 0 16 16" aria-hidden="true">
+            <circle cx="8" cy="8" r="6.5" pathLength="1" />
+          </svg>
+        )}
+        <X size={12} strokeWidth={2.25} aria-hidden="true" />
+      </Toast.Close>
+    </Toast.Root>
+  ));
 }

--- a/src/worker/clicks.ts
+++ b/src/worker/clicks.ts
@@ -1,0 +1,129 @@
+import type { Context } from "hono";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "./db/schema";
+import type { AppEnv, Env } from "./env";
+import type { KVLink } from "./kv";
+import { now, deviceFromUA } from "./util";
+import { clickAnalyticsAllowed } from "./rate-limit";
+import { alertBetterStack } from "./alerts";
+
+/**
+ * Click ingestion. The redirect hot path never inserts into D1 itself: it
+ * enqueues a compact event and returns, so a traffic spike never competes
+ * with the redirect for D1 write capacity. The consumer below turns a whole
+ * batch into one multi-row insert, so a spike costs one D1 write per batch
+ * instead of one per click.
+ *
+ * Unlike the storage queue (storage.ts), a click is best-effort analytics,
+ * not a correctness-critical follow-up: `enqueueClick` swallows its own
+ * failures instead of propagating them, so a full click queue or an
+ * exceeded analytics rate limit never fails the redirect itself. Losing
+ * clicks under overload is the accepted tradeoff (issue #16); losing a
+ * KV/R2 sync is not.
+ */
+
+export type ClickMessage = {
+  // Producer-assigned, so a redelivered message can't double-insert.
+  dedupeId: string;
+  linkId: string;
+  orgId: string;
+  ts: number;
+  country: string;
+  referrer: string;
+  device: string;
+};
+
+// A failure on this many deliveries dead-letters the batch. Keep in sync
+// with the click consumer's max_retries + 1 in wrangler.jsonc.
+const CLICK_MAX_DELIVERIES = 6;
+
+/* ---------------- producing ---------------- */
+
+/**
+ * Enqueue one click event. Best-effort: a rate limit or a queue-send failure
+ * is logged and swallowed here, never thrown, so the caller's redirect
+ * always ships regardless of analytics health.
+ */
+export async function enqueueClick(c: Context<AppEnv>, hit: KVLink): Promise<void> {
+  try {
+    if (!(await clickAnalyticsAllowed(c.env, hit.orgId, c.req.method))) return;
+    const message: ClickMessage = {
+      dedupeId: crypto.randomUUID(),
+      linkId: hit.linkId,
+      orgId: hit.orgId,
+      ts: now(),
+      country: (c.req.raw.cf?.country as string) ?? "",
+      referrer: c.req.header("referer") ?? "",
+      device: deviceFromUA(c.req.header("user-agent") ?? ""),
+    };
+    await c.env.CLICK_QUEUE.send(message);
+  } catch (error) {
+    console.error("click enqueue failed", error);
+  }
+}
+
+/* ---------------- consuming ---------------- */
+
+/**
+ * Consume a batch off the click queue: one multi-row insert for the whole
+ * batch, deduped on `dedupeId` so a redelivery after a partial failure never
+ * double-counts a click. The batch acks or retries as a unit, which matches
+ * the insert: either every row in the statement lands or none does.
+ *
+ * A link deleted between the redirect and this running fails the whole
+ * batch's insert (a foreign key violation), so that batch retries and, if
+ * the link stays gone, eventually dead-letters together with its batch
+ * mates. That is a rare, small, accepted loss (see the top of this file),
+ * not a bug: rather than splitting a failed batch to save the other rows,
+ * we trust Cloudflare Queues' retry budget the same way storage.ts does.
+ */
+export async function consumeClickBatch(
+  env: Env,
+  batch: MessageBatch<ClickMessage>,
+): Promise<void> {
+  const db = drizzle(env.DB, { schema });
+  try {
+    await db
+      .insert(schema.clicks)
+      .values(
+        batch.messages.map((m) => ({
+          linkId: m.body.linkId,
+          orgId: m.body.orgId,
+          ts: m.body.ts,
+          country: m.body.country,
+          referrer: m.body.referrer,
+          device: m.body.device,
+          dedupeId: m.body.dedupeId,
+        })),
+      )
+      .onConflictDoNothing({ target: schema.clicks.dedupeId });
+    batch.ackAll();
+  } catch (error) {
+    console.error("click batch insert failed", batch.messages.length, error);
+    if (batch.messages.some((m) => m.attempts >= CLICK_MAX_DELIVERIES)) {
+      console.error(
+        JSON.stringify({ event: "click_batch_dead_letter", size: batch.messages.length }),
+      );
+    }
+    batch.retryAll();
+  }
+}
+
+/**
+ * Consume the click dead-letter queue: log and alert for visibility, then
+ * ack. Nothing repairs a dropped click; see the top of this file for why
+ * that is the accepted behavior.
+ */
+export async function logClickDeadLetterBatch(
+  env: Env,
+  batch: MessageBatch<ClickMessage>,
+): Promise<void> {
+  const events = batch.messages.map((m) => ({
+    event: "click_dropped",
+    linkId: m.body.linkId,
+    orgId: m.body.orgId,
+  }));
+  for (const event of events) console.error(JSON.stringify(event));
+  await alertBetterStack(env, events);
+  batch.ackAll();
+}

--- a/src/worker/clicks.ts
+++ b/src/worker/clicks.ts
@@ -37,6 +37,19 @@ export type ClickMessage = {
 // with the click consumer's max_retries + 1 in wrangler.jsonc.
 const CLICK_MAX_DELIVERIES = 6;
 
+// D1 caps bound parameters at 100 per statement. A click row binds 7 values,
+// so a single multi-row insert statement can hold at most floor(100 / 7) = 14
+// rows before it would exceed that cap. A queue batch (up to 100 messages)
+// splits into several insert statements run in one db.batch() call: D1 runs
+// them as one atomic unit, so the batch still acks or retries as a whole.
+const CLICK_INSERT_CHUNK_SIZE = 14;
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) chunks.push(items.slice(i, i + size));
+  return chunks;
+}
+
 /* ---------------- producing ---------------- */
 
 /**
@@ -65,13 +78,16 @@ export async function enqueueClick(c: Context<AppEnv>, hit: KVLink): Promise<voi
 /* ---------------- consuming ---------------- */
 
 /**
- * Consume a batch off the click queue: one multi-row insert for the whole
- * batch, deduped on `dedupeId` so a redelivery after a partial failure never
- * double-counts a click. The batch acks or retries as a unit, which matches
- * the insert: either every row in the statement lands or none does.
+ * Consume a batch off the click queue: the whole batch's rows land in one
+ * db.batch() transaction (split into D1-safe insert statements, see
+ * CLICK_INSERT_CHUNK_SIZE above), deduped on `dedupeId` so a redelivery after
+ * a partial failure never double-counts a click. The batch acks or retries
+ * as a unit, matching the transaction: a hard D1 error aborts every
+ * statement in it, while a duplicate `dedupeId` is skipped per row rather
+ * than aborting anything.
  *
  * A link deleted between the redirect and this running fails the whole
- * batch's insert (a foreign key violation), so that batch retries and, if
+ * transaction (a foreign key violation), so that batch retries and, if
  * the link stays gone, eventually dead-letters together with its batch
  * mates. That is a rare, small, accepted loss (see the top of this file),
  * not a bug: rather than splitting a failed batch to save the other rows,
@@ -83,20 +99,23 @@ export async function consumeClickBatch(
 ): Promise<void> {
   const db = drizzle(env.DB, { schema });
   try {
-    await db
-      .insert(schema.clicks)
-      .values(
-        batch.messages.map((m) => ({
-          linkId: m.body.linkId,
-          orgId: m.body.orgId,
-          ts: m.body.ts,
-          country: m.body.country,
-          referrer: m.body.referrer,
-          device: m.body.device,
-          dedupeId: m.body.dedupeId,
-        })),
-      )
-      .onConflictDoNothing({ target: schema.clicks.dedupeId });
+    const inserts = chunk(batch.messages, CLICK_INSERT_CHUNK_SIZE).map((rows) =>
+      db
+        .insert(schema.clicks)
+        .values(
+          rows.map((m) => ({
+            linkId: m.body.linkId,
+            orgId: m.body.orgId,
+            ts: m.body.ts,
+            country: m.body.country,
+            referrer: m.body.referrer,
+            device: m.body.device,
+            dedupeId: m.body.dedupeId,
+          })),
+        )
+        .onConflictDoNothing({ target: schema.clicks.dedupeId }),
+    );
+    await db.batch(inserts as [(typeof inserts)[number], ...(typeof inserts)[number][]]);
     batch.ackAll();
   } catch (error) {
     console.error("click batch insert failed", batch.messages.length, error);

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -214,6 +214,12 @@ export const clicks = sqliteTable(
     country: text("country").notNull().default(""),
     referrer: text("referrer").notNull().default(""),
     device: text("device").notNull().default(""),
+    // Set by the click queue producer (crypto.randomUUID()); lets the queue
+    // consumer's batch insert dedupe a redelivered message. Null on rows from
+    // before this column existed, which is fine: SQLite's unique index treats
+    // every NULL as distinct, so old rows never collide with each other or
+    // with real dedupe ids.
+    dedupeId: text("dedupe_id").unique(),
   },
   (t) => [
     index("idx_clicks_link_ts").on(t.linkId, t.ts),

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -1,6 +1,7 @@
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import type * as schema from "./db/schema";
 import type { StorageMessage } from "./storage";
+import type { ClickMessage } from "./clicks";
 
 export interface Env {
   DB: D1Database;
@@ -13,6 +14,8 @@ export interface Env {
   ORG_DELETE: Workflow<{ orgId: string }>;
   /* custom-domain activation as a durable background workflow */
   DOMAIN_ACTIVATE: Workflow<{ domainId: string; hostname: string }>;
+  /* click ingestion: redirects enqueue instead of writing D1 directly */
+  CLICK_QUEUE: Queue<ClickMessage>;
   RL_AUTH_PUBLIC: RateLimit;
   RL_EMAIL: RateLimit;
   RL_WRITE_FREE: RateLimit;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,8 +1,6 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { drizzle } from "drizzle-orm/d1";
-import * as schema from "./db/schema";
 import type { AppEnv, Env } from "./env";
 import { withSession } from "./auth";
 import { getAuth } from "./better-auth";
@@ -14,13 +12,15 @@ import { adminRoutes } from "./routes/admin";
 import { billingRoutes, handlePolarWebhook } from "./routes/billing";
 import { domainRoutes } from "./routes/domains";
 import { resolveSlug, resolveDomain, type KVLink } from "./kv";
-import { now, deviceFromUA, RESERVED_SLUGS } from "./util";
-import {
-  clickAnalyticsAllowed,
-  enforcePublicAuthRateLimit,
-  enforceSignedApiRateLimit,
-} from "./rate-limit";
+import { RESERVED_SLUGS } from "./util";
+import { enforcePublicAuthRateLimit, enforceSignedApiRateLimit } from "./rate-limit";
 import { consumeStorageBatch, logDeadLetterBatch, type StorageMessage } from "./storage";
+import {
+  enqueueClick,
+  consumeClickBatch,
+  logClickDeadLetterBatch,
+  type ClickMessage,
+} from "./clicks";
 
 export { OrgDeleteWorkflow, DomainActivateWorkflow } from "./workflows";
 
@@ -40,26 +40,10 @@ app.onError((err, c) => {
 /* ---------------- redirect hot path ---------------- */
 
 // Click recording happens after the redirect is already on its way
-// (waitUntil), so redirects stay fast.
+// (waitUntil): the request enqueues an event and returns rather than
+// touching D1 itself. See clicks.ts.
 function redirectWithClick(c: Context<AppEnv>, hit: KVLink): Response {
-  c.executionCtx.waitUntil(
-    (async () => {
-      try {
-        if (!(await clickAnalyticsAllowed(c.env, hit.orgId, c.req.method))) return;
-        const db = drizzle(c.env.DB, { schema });
-        await db.insert(schema.clicks).values({
-          linkId: hit.linkId,
-          orgId: hit.orgId,
-          ts: now(),
-          country: (c.req.raw.cf?.country as string) ?? "",
-          referrer: c.req.header("referer") ?? "",
-          device: deviceFromUA(c.req.header("user-agent") ?? ""),
-        });
-      } catch (e) {
-        console.error("click insert failed", e);
-      }
-    })(),
-  );
+  c.executionCtx.waitUntil(enqueueClick(c, hit));
   return c.redirect(hit.url, 302);
 }
 
@@ -122,15 +106,26 @@ app.get("/:slug", async (c, next) => {
 
 app.all("*", (c) => c.env.ASSETS.fetch(c.req.raw));
 
-/* ---------------- Queue consumer: KV + R2 follow-up work ---------------- */
+/* ---------------- Queue consumer: KV/R2 follow-up work + click ingestion ---------------- */
 
 export default {
   fetch: app.fetch,
-  async queue(batch: MessageBatch<StorageMessage>, env: Env, _ctx: ExecutionContext) {
-    // The dead-letter queue routes to this same handler (see wrangler.jsonc);
-    // its messages only get logged, never retried or repaired.
-    if (batch.queue.endsWith("-dlq")) return logDeadLetterBatch(env, batch);
-    await consumeStorageBatch(env, batch);
+  async queue(
+    batch: MessageBatch<StorageMessage | ClickMessage>,
+    env: Env,
+    _ctx: ExecutionContext,
+  ) {
+    // Every queue's dead-letter consumer routes to this same handler (see
+    // wrangler.jsonc); a DLQ's messages only get logged, never retried or
+    // repaired. Check "-clicks-dlq" ahead of the generic "-dlq" suffix, since
+    // it ends with both.
+    if (batch.queue.endsWith("-clicks-dlq"))
+      return logClickDeadLetterBatch(env, batch as MessageBatch<ClickMessage>);
+    if (batch.queue.endsWith("-clicks"))
+      return consumeClickBatch(env, batch as MessageBatch<ClickMessage>);
+    if (batch.queue.endsWith("-dlq"))
+      return logDeadLetterBatch(env, batch as MessageBatch<StorageMessage>);
+    await consumeStorageBatch(env, batch as MessageBatch<StorageMessage>);
   },
   async scheduled(event: ScheduledEvent, env: Env, _ctx: ExecutionContext) {
     // Daily: trim old clicks.

--- a/tests/worker/clicks.worker.ts
+++ b/tests/worker/clicks.worker.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import { getQueueResult, reset } from "cloudflare:test";
+import type { Env } from "../../src/worker/env";
+import {
+  consumeClickBatch,
+  logClickDeadLetterBatch,
+  type ClickMessage,
+} from "../../src/worker/clicks";
+import { applyTestMigrations, batchOf, overrideEnv, sampleLink, seedLink } from "./support";
+
+function clickMessage(overrides: Partial<ClickMessage> = {}): ClickMessage {
+  return {
+    dedupeId: crypto.randomUUID(),
+    linkId: sampleLink.id,
+    orgId: sampleLink.orgId,
+    ts: 0,
+    country: "US",
+    referrer: "",
+    device: "desktop",
+    ...overrides,
+  };
+}
+
+async function clickCount(): Promise<number> {
+  return (
+    (await env.DB.prepare("select count(*) as count from clicks").first<{ count: number }>())
+      ?.count ?? 0
+  );
+}
+
+beforeEach(async () => {
+  await reset();
+  await applyTestMigrations();
+});
+
+describe("click queue: consumer", () => {
+  it("batches every message in the batch into one insert", async () => {
+    await seedLink();
+    const { batch, ctx } = batchOf("rdyrct-clicks", [
+      clickMessage({ dedupeId: "a" }),
+      clickMessage({ dedupeId: "b" }),
+      clickMessage({ dedupeId: "c" }),
+    ]);
+
+    await consumeClickBatch(env as Env, batch);
+
+    expect(await clickCount()).toBe(3);
+    const result = await getQueueResult(batch, ctx);
+    expect(result.ackAll).toBe(true);
+  });
+
+  it("dedupes a redelivered message instead of double-inserting", async () => {
+    await seedLink();
+    const message = clickMessage({ dedupeId: "dup-1" });
+
+    await consumeClickBatch(env as Env, batchOf("rdyrct-clicks", [message]).batch);
+    expect(await clickCount()).toBe(1);
+
+    // A redelivery of the exact same message (same dedupeId) must not add a
+    // second row.
+    await consumeClickBatch(env as Env, batchOf("rdyrct-clicks", [message]).batch);
+    expect(await clickCount()).toBe(1);
+  });
+
+  it("retries the whole batch when the insert fails, then succeeds once it recovers", async () => {
+    await seedLink();
+    // A message for a link that does not exist violates the FK and fails the
+    // whole batch's insert.
+    const { batch, ctx } = batchOf("rdyrct-clicks", [
+      clickMessage({ dedupeId: "ok" }),
+      clickMessage({ dedupeId: "bad", linkId: "no-such-link" }),
+    ]);
+
+    await consumeClickBatch(env as Env, batch);
+    const failed = await getQueueResult(batch, ctx);
+    expect(failed.retryBatch.retry).toBe(true);
+    expect(await clickCount()).toBe(0);
+
+    // Once the bad message is gone (dead-lettered after exhausting retries,
+    // in production), a redelivery of the surviving message succeeds.
+    const retry = batchOf("rdyrct-clicks", [clickMessage({ dedupeId: "ok" })]);
+    await consumeClickBatch(env as Env, retry.batch);
+    const succeeded = await getQueueResult(retry.batch, retry.ctx);
+    expect(succeeded.ackAll).toBe(true);
+    expect(await clickCount()).toBe(1);
+  });
+
+  it("logs click_batch_dead_letter only once a message reaches its last delivery", async () => {
+    await seedLink();
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loggedDeadLetter = () =>
+      errors.mock.calls.some(([a]) => String(a).includes("click_batch_dead_letter"));
+
+    const early = batchOf("rdyrct-clicks", [clickMessage({ linkId: "no-such-link" })], 1);
+    await consumeClickBatch(env as Env, early.batch);
+    expect(loggedDeadLetter()).toBe(false);
+
+    const last = batchOf("rdyrct-clicks", [clickMessage({ linkId: "no-such-link" })], 6);
+    await consumeClickBatch(env as Env, last.batch);
+    expect(loggedDeadLetter()).toBe(true);
+    errors.mockRestore();
+  });
+});
+
+describe("click queue: dead-letter visibility", () => {
+  it("logs and acks every message once it reaches the dead-letter queue", async () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { batch, ctx } = batchOf("rdyrct-clicks-dlq", [clickMessage()]);
+
+    await logClickDeadLetterBatch(env as Env, batch);
+
+    const result = await getQueueResult(batch, ctx);
+    expect(result.ackAll).toBe(true);
+    const logged = errors.mock.calls.map(([a]) => String(a));
+    expect(logged.some((line) => line.includes("click_dropped"))).toBe(true);
+    errors.mockRestore();
+  });
+
+  it("does not alert when Better Stack is unconfigured", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { batch, ctx } = batchOf("rdyrct-clicks-dlq", [clickMessage()]);
+    const unconfigured = overrideEnv({
+      BETTERSTACK_SOURCE_TOKEN: undefined,
+      BETTERSTACK_INGEST_URL: undefined,
+    });
+
+    await logClickDeadLetterBatch(unconfigured, batch);
+    await getQueueResult(batch, ctx);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/tests/worker/clicks.worker.ts
+++ b/tests/worker/clicks.worker.ts
@@ -50,6 +50,22 @@ describe("click queue: consumer", () => {
     expect(result.ackAll).toBe(true);
   });
 
+  it("persists a full-size batch that would exceed D1's bound-parameter limit as one insert", async () => {
+    await seedLink();
+    // A click row binds 7 values, so a naive single-statement insert of a
+    // full 100-message batch would bind 700 parameters and exceed D1's cap
+    // of 100. The consumer must chunk this internally and still land every
+    // row from one batch.
+    const messages = Array.from({ length: 100 }, (_, i) => clickMessage({ dedupeId: `bulk-${i}` }));
+    const { batch, ctx } = batchOf("rdyrct-clicks", messages);
+
+    await consumeClickBatch(env as Env, batch);
+
+    expect(await clickCount()).toBe(100);
+    const result = await getQueueResult(batch, ctx);
+    expect(result.ackAll).toBe(true);
+  });
+
   it("dedupes a redelivered message instead of double-inserting", async () => {
     await seedLink();
     const message = clickMessage({ dedupeId: "dup-1" });

--- a/tests/worker/redirects.worker.ts
+++ b/tests/worker/redirects.worker.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
 import {
   applyD1Migrations,
@@ -7,14 +7,30 @@ import {
   waitOnExecutionContext,
 } from "cloudflare:test";
 import worker from "../../src/worker";
+import type { Env } from "../../src/worker/env";
+import type { ClickMessage } from "../../src/worker/clicks";
+import { overrideEnv } from "./support";
 
 type TestEnv = typeof env & { TEST_MIGRATIONS: D1Migration[] };
 
-async function fetchWorker(request: Request): Promise<Response> {
+async function fetchWorker(request: Request, testEnv: Env = env as Env): Promise<Response> {
   const ctx = createExecutionContext();
-  const response = await worker.fetch(request, env, ctx);
+  const response = await worker.fetch(request, testEnv, ctx);
   await waitOnExecutionContext(ctx);
   return response;
+}
+
+// A CLICK_QUEUE that records what was sent, so the redirect path's enqueue
+// can be asserted without a live queue delivering the message back into the
+// worker under test (consumption is covered by tests/worker/clicks.worker.ts).
+function captureClickQueue(): { env: Env; sent: ClickMessage[] } {
+  const sent: ClickMessage[] = [];
+  const CLICK_QUEUE = {
+    async send(message: ClickMessage) {
+      sent.push(message);
+    },
+  } as unknown as Queue<ClickMessage>;
+  return { env: overrideEnv({ CLICK_QUEUE }), sent };
 }
 
 afterEach(async () => {
@@ -48,22 +64,26 @@ beforeEach(async () => {
 });
 
 describe("redirect hot path", () => {
-  it("redirects a shared-host slug and records a click after responding", async () => {
+  it("redirects a shared-host slug and enqueues a click after responding", async () => {
     await env.LINKS.put(
       "slug:summer",
       JSON.stringify({ linkId: "link-1", orgId: "org-1", url: "https://example.com/sale" }),
     );
+    const { env: testEnv, sent } = captureClickQueue();
 
     const response = await fetchWorker(
       new Request("http://localhost/summer", { redirect: "manual" }),
+      testEnv,
     );
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("https://example.com/sale");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ linkId: "link-1", orgId: "org-1" });
     expect(
       (await env.DB.prepare("select count(*) as count from clicks").first<{ count: number }>())
         ?.count,
-    ).toBe(1);
+    ).toBe(0);
   });
 
   it("keeps custom-domain links separate from shared-host links", async () => {
@@ -87,7 +107,7 @@ describe("redirect hot path", () => {
     expect(response.headers.get("location")).toBe("https://example.com/pricing");
   });
 
-  it("still redirects and skips click storage when analytics is limited", async () => {
+  it("still redirects and skips the click enqueue when analytics is limited", async () => {
     await env.LINKS.put(
       "slug:viral",
       JSON.stringify({
@@ -97,20 +117,41 @@ describe("redirect hot path", () => {
       }),
     );
     await env.RL_CLICK_RECORDING.limit({ key: "click:org:org-limited" });
+    const { env: testEnv, sent } = captureClickQueue();
 
     const response = await fetchWorker(
       new Request("http://localhost/viral", { redirect: "manual" }),
+      testEnv,
     );
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("https://example.com/viral");
-    expect(
-      (
-        await env.DB.prepare("select count(*) as count from clicks where org_id = ?")
-          .bind("org-limited")
-          .first<{ count: number }>()
-      )?.count,
-    ).toBe(0);
+    expect(sent).toEqual([]);
+  });
+
+  it("still redirects when the click queue send itself fails", async () => {
+    await env.LINKS.put(
+      "slug:summer",
+      JSON.stringify({ linkId: "link-1", orgId: "org-1", url: "https://example.com/sale" }),
+    );
+    const failingEnv = overrideEnv({
+      CLICK_QUEUE: {
+        async send() {
+          throw new Error("injected queue-send failure");
+        },
+      } as unknown as Queue<ClickMessage>,
+    });
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await fetchWorker(
+      new Request("http://localhost/summer", { redirect: "manual" }),
+      failingEnv,
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://example.com/sale");
+    expect(errors).toHaveBeenCalledWith("click enqueue failed", expect.any(Error));
+    errors.mockRestore();
   });
 
   it("uses a custom domain's root redirect for the root and missing slugs", async () => {

--- a/tests/worker/storage.worker.ts
+++ b/tests/worker/storage.worker.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
-import { createExecutionContext, createMessageBatch, getQueueResult, reset } from "cloudflare:test";
-import { drizzle } from "drizzle-orm/d1";
+import { getQueueResult, reset } from "cloudflare:test";
 import { eq } from "drizzle-orm";
 import * as schema from "../../src/worker/db/schema";
 import type { Env } from "../../src/worker/env";
@@ -17,7 +16,7 @@ import {
   syncLinkMsg,
   type StorageMessage,
 } from "../../src/worker/storage";
-import { applyTestMigrations, overrideEnv } from "./support";
+import { applyTestMigrations, batchOf, overrideEnv, sampleLink, seedLink } from "./support";
 
 // A queue that records what was sent, so producer paths can be asserted without
 // a live queue delivering messages back into the worker under test.
@@ -60,39 +59,6 @@ function failingR2(): R2Bucket {
       return typeof value === "function" ? value.bind(target) : value;
     },
   });
-}
-
-// Builds a real MessageBatch via the official cloudflare:test helpers, so ack/
-// retry/dead-letter assertions exercise the same runtime semantics production
-// queue delivery does, rather than hand-rolled spies.
-function batchOf(queueName: string, bodies: StorageMessage[], attempts = 1) {
-  const batch = createMessageBatch(
-    queueName,
-    bodies.map((body, i) => ({ id: `m${i}`, timestamp: new Date(), attempts, body })),
-  );
-  const ctx = createExecutionContext();
-  return { batch, ctx };
-}
-
-const sampleLink = {
-  id: "link-1",
-  orgId: "org-1",
-  slug: "sale",
-  destination: "https://example.com",
-  utmSource: "",
-  utmMedium: "",
-  utmCampaign: "",
-  utmTerm: "",
-  utmContent: "",
-};
-
-async function seedLink(destination = "https://example.com") {
-  const db = drizzle(env.DB, { schema });
-  await db.batch([
-    db.insert(schema.orgs).values({ id: "org-1", name: "Test", createdAt: 0 }),
-    db.insert(schema.links).values({ ...sampleLink, destination, createdAt: 0 }),
-  ]);
-  return db;
 }
 
 beforeEach(async () => {

--- a/tests/worker/support.ts
+++ b/tests/worker/support.ts
@@ -1,7 +1,14 @@
 import { expect } from "vitest";
 import { env } from "cloudflare:workers";
-import { applyD1Migrations, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import {
+  applyD1Migrations,
+  createExecutionContext,
+  createMessageBatch,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
 import worker from "../../src/worker";
+import * as schema from "../../src/worker/db/schema";
 import type { Env } from "../../src/worker/env";
 import { hashPassword } from "../../src/worker/password";
 
@@ -53,4 +60,40 @@ export async function adminCookie(): Promise<string> {
     .getSetCookie()
     .map((c) => c.split(";")[0])
     .join("; ");
+}
+
+export const sampleLink = {
+  id: "link-1",
+  orgId: "org-1",
+  slug: "sale",
+  destination: "https://example.com",
+  utmSource: "",
+  utmMedium: "",
+  utmCampaign: "",
+  utmTerm: "",
+  utmContent: "",
+};
+
+// Seeds one org ("org-1") and one link ("link-1", slug "sale"), the fixture
+// shared by tests that need a real link row to satisfy a foreign key
+// (clicks, KV publish) without caring about its other fields.
+export async function seedLink(destination = "https://example.com") {
+  const db = drizzle(env.DB, { schema });
+  await db.batch([
+    db.insert(schema.orgs).values({ id: "org-1", name: "Test", createdAt: 0 }),
+    db.insert(schema.links).values({ ...sampleLink, destination, createdAt: 0 }),
+  ]);
+  return db;
+}
+
+// Builds a real MessageBatch via the official cloudflare:test helpers, so ack/
+// retry/dead-letter assertions exercise the same runtime semantics production
+// queue delivery does, rather than hand-rolled spies.
+export function batchOf<Body>(queueName: string, bodies: Body[], attempts = 1) {
+  const batch = createMessageBatch(
+    queueName,
+    bodies.map((body, i) => ({ id: `m${i}`, timestamp: new Date(), attempts, body })),
+  );
+  const ctx = createExecutionContext();
+  return { batch, ctx };
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -53,21 +53,29 @@
       "migrations_dir": "migrations",
     },
   ],
-  // KV/R2 follow-up work. A request handler awaits the send after committing
-  // D1, so a producer-side failure fails the request instead of vanishing
-  // silently. Once a message is on the queue, Cloudflare Queues own retry and
-  // backoff. A give-up lands on rdyrct-storage-dlq, which this same Worker
-  // also consumes (see the `queue()` handler) purely to log it for
-  // visibility: nothing repairs or re-drives it. Create both queues before
-  // first deploy:
+  // KV/R2 follow-up work, and click ingestion off the redirect hot path
+  // (issue #16). A storage-queue send is awaited after committing D1, so a
+  // producer-side failure fails the request instead of vanishing silently; a
+  // click-queue send is best-effort instead (see clicks.ts), because a click
+  // is analytics, not a correctness-critical follow-up. Each queue's give-ups
+  // land on its own DLQ, which this same Worker also consumes (see the
+  // `queue()` handler) purely to log them for visibility: nothing repairs or
+  // re-drives either. Create all four queues before first deploy:
   //   bunx wrangler queues create rdyrct-storage
   //   bunx wrangler queues create rdyrct-storage-dlq
-  // Keep max_retries here in sync with STORAGE_MAX_DELIVERIES in storage.ts.
+  //   bunx wrangler queues create rdyrct-clicks
+  //   bunx wrangler queues create rdyrct-clicks-dlq
+  // Keep max_retries here in sync with STORAGE_MAX_DELIVERIES (storage.ts)
+  // and CLICK_MAX_DELIVERIES (clicks.ts).
   "queues": {
     "producers": [
       {
         "binding": "STORAGE_QUEUE",
         "queue": "rdyrct-storage",
+      },
+      {
+        "binding": "CLICK_QUEUE",
+        "queue": "rdyrct-clicks",
       },
     ],
     "consumers": [
@@ -82,6 +90,24 @@
       {
         "queue": "rdyrct-storage-dlq",
         "max_batch_size": 10,
+        "max_batch_timeout": 5,
+        "max_retries": 3,
+        "retry_delay": 30,
+      },
+      {
+        "queue": "rdyrct-clicks",
+        // Larger, time-boxed batches: clicks are high-volume and each batch
+        // becomes one multi-row D1 insert, so bigger batches mean fewer
+        // writes under load.
+        "max_batch_size": 100,
+        "max_batch_timeout": 5,
+        "max_retries": 5,
+        "retry_delay": 30,
+        "dead_letter_queue": "rdyrct-clicks-dlq",
+      },
+      {
+        "queue": "rdyrct-clicks-dlq",
+        "max_batch_size": 100,
         "max_batch_timeout": 5,
         "max_retries": 3,
         "retry_delay": 30,
@@ -219,6 +245,10 @@
             "binding": "STORAGE_QUEUE",
             "queue": "rdyrct-playwright-storage",
           },
+          {
+            "binding": "CLICK_QUEUE",
+            "queue": "rdyrct-playwright-clicks",
+          },
         ],
         "consumers": [
           {
@@ -232,6 +262,21 @@
           {
             "queue": "rdyrct-playwright-storage-dlq",
             "max_batch_size": 10,
+            "max_batch_timeout": 5,
+            "max_retries": 3,
+            "retry_delay": 30,
+          },
+          {
+            "queue": "rdyrct-playwright-clicks",
+            "max_batch_size": 100,
+            "max_batch_timeout": 5,
+            "max_retries": 5,
+            "retry_delay": 30,
+            "dead_letter_queue": "rdyrct-playwright-clicks-dlq",
+          },
+          {
+            "queue": "rdyrct-playwright-clicks-dlq",
+            "max_batch_size": 100,
             "max_batch_timeout": 5,
             "max_retries": 3,
             "retry_delay": 30,


### PR DESCRIPTION
## Summary
- Redirects now enqueue a click event to a new `CLICK_QUEUE` instead of writing to D1 inline, so redirect latency no longer depends on D1 write capacity.
- The consumer batches every message in a delivery into one multi-row insert, deduped on a producer-assigned `dedupeId` (new nullable+unique `dedupe_id` column) so redelivery can't double-count a click.
- Enqueueing is best-effort: a full queue or send failure is logged and swallowed, never fails the redirect. A failing batch retries as a unit and dead-letters to `rdyrct-clicks-dlq`, logged and alerted the same way the existing storage queue's DLQ is.

Closes #16

## Test plan
- [x] `bun run verify` (tsc app+shared, tsc worker, lint, format check, unit tests, worker integration tests) — all green
- [x] `bun run fallow` — no new findings attributable to this branch (extracted shared test scaffolding into `tests/worker/support.ts` per existing repo precedent, dropping duplicate clone groups from 5 to 3)
- [x] `bun run db:migrate:local` — migration `0013_add_clicks_dedupe_id.sql` applies cleanly
- [x] New `tests/worker/clicks.worker.ts`: batching, dedupe on redelivery, whole-batch retry/recovery on FK violation, dead-letter logging threshold, DLQ visibility/alerting
- [x] Updated `tests/worker/redirects.worker.ts` to assert the redirect path enqueues (or tolerates a send failure) instead of asserting synchronous D1 writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated click ingestion queues for asynchronous, batched click analytics processing with DLQ handling.
* **Bug Fixes**
  * Redirects still succeed even if click enqueue is rate-limited or fails; click ingestion retries before dead-lettering.
* **Documentation**
  * Updated click ingestion, rate-limiting, and storage recovery docs to reflect queued ingestion behavior.
* **UI/Accessibility**
  * Upgraded toast notifications to the shared toast manager with improved stacking, dismissal, and reduced-motion support.
  * Refined QR upload control to use a proper button element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->