### PR TITLE
Fix analytics period comparisons, add security headers, request limits, and production-CSP tests

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -17,11 +17,13 @@ POLAR_PRO_PRODUCT_ID=replace_me
 POLAR_HOBBY_PRODUCT_ID=replace_me
 POLAR_SERVER=sandbox
 
-# Custom domains: leave CF_API_TOKEN blank and CF_DEV_ENV=1 to fake the
-# Cloudflare API locally (fails closed with both blank)
+# Custom domains: leave CF_API_TOKEN blank and CF_DEV_ENV=simulated to fake the
+# Cloudflare API locally (fails closed with both blank). "simulated" walks a new
+# domain through checking_dns and issuing_tls on a timer so you can watch both
+# states; "instant" reports them ready at once, which is what the e2e run uses.
 CF_API_TOKEN=
 CF_ZONE_ID=
-CF_DEV_ENV=1
+CF_DEV_ENV=simulated
 
 # Better Stack: alerts on dead-lettered storage messages. Leave blank to no-op
 # locally (no alerts fire from dev/test).

--- a/.dev.vars.playwright
+++ b/.dev.vars.playwright
@@ -15,4 +15,6 @@ POLAR_SERVER=sandbox
 
 CF_API_TOKEN=
 CF_ZONE_ID=
-CF_DEV_ENV=1
+# "instant", not "1": the e2e suite asserts a domain reaches active, so the
+# staged DNS/TLS delays local dev shows off are only a timer to race.
+CF_DEV_ENV=instant

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,11 @@ analyticsDays }`). Slugs on the **shared** domain are always random (every
   are the same org-scoped route (`POST`/`GET /api/orgs/:orgId/qr-logo[/:file]`),
   gated to org members: only the signed-in app ever fetches a logo (QR
   previews/downloads bake the image in client-side), and a row may only
-  reference its own org's logos. Paid plans, ≤ 2 MB =
-  `QR_LOGO_MAX_BYTES` in `src/shared/types.ts`. Serving is immutable and
+  reference its own org's logos. Paid plans, ≤ 256 KB
+  (`QR_LOGO_MAX_BYTES`) and ≤ 512 px on a side (`QR_LOGO_MAX_DIMENSION`),
+  both in `src/shared/types.ts`; the client downscales and compresses to fit
+  before uploading, and the server rejects whatever still exceeds them.
+  Serving is immutable and
   `private`-cached. Deletes follow the row: replace/clear/delete on
   links and orgs removes the object; org teardown wipes the `{orgId}/` prefix
   (`src/worker/storage.ts`).

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bun run dev                        # https://rdyrct.localhost
 
   and copy the 6-digit code out of the latest message.
 
-- Setting `CF_DEV_ENV=1` (the `.dev.vars.example` default) stubs the Cloudflare Custom Hostnames API locally: DNS becomes ready after about 5 seconds and TLS after about 20 seconds, so "Check status" shows the same progression without a real zone. Without it, missing `CF_API_TOKEN`/`CF_ZONE_ID` fails closed instead of faking a response.
+- Setting `CF_DEV_ENV=simulated` (the `.dev.vars.example` default) stubs the Cloudflare Custom Hostnames API locally: DNS becomes ready after about 3 seconds and TLS after about 12 seconds, so "Check status" shows the same progression without a real zone. `CF_DEV_ENV=instant` reports both ready at once, which is what the e2e run uses so it does not sit through the timer. Without either, missing `CF_API_TOKEN`/`CF_ZONE_ID` fails closed instead of faking a response.
 - Billing against a real [Polar sandbox](https://sandbox.polar.sh) account needs a public URL (`wrangler dev --remote` or a tunnel) for webhooks to reach `/api/webhooks/polar`.
 
 ---
@@ -182,7 +182,7 @@ before changing link, domain, logo, or organization delete flows.
 | `POLAR_PRO_PRODUCT_ID`   | var            | Polar product id for the Pro plan                                                   |
 | `POLAR_HOBBY_PRODUCT_ID` | var            | Polar product id for the Hobby plan                                                 |
 | `CF_ZONE_ID`             | var            | Zone id used for Custom Hostnames                                                   |
-| `CF_DEV_ENV`             | var (dev only) | Set to `1` to fake the Custom Hostnames API instead of calling Cloudflare           |
+| `CF_DEV_ENV`             | var (dev only) | `simulated` fakes the Custom Hostnames API on a timer, `instant` without one        |
 
 Secrets are set with `wrangler secret put NAME` or `wrangler secret bulk prod.secrets.env` in production; locally they all come from `.dev.vars` (see `.dev.vars.example`).
 

--- a/index.html
+++ b/index.html
@@ -57,14 +57,7 @@
         ]
       }
     </script>
-    <script>
-      // theme init before paint, same trick as brnr
-      (function () {
-        const stored = localStorage.getItem("theme");
-        document.documentElement.dataset.theme =
-          stored === "light" ? "light" : "dark";
-      })();
-    </script>
+    <script src="/theme-init.js"></script>
   </head>
   <body>
     <div id="root">

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -67,9 +67,11 @@ export default defineConfig({
       reuseExistingServer: false,
       timeout: 180_000,
       gracefulShutdown: { signal: "SIGTERM", timeout: 500 },
+      // No CLOUDFLARE_ENV here: the built wrangler.json carries no
+      // `playwright` environment, so setting it only produces a warning.
+      // These tests are about response headers and need no backend state.
       env: {
         PLAYWRIGHT_TEST: "1",
-        CLOUDFLARE_ENV: "playwright",
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
-import { appUrl, playwrightPort } from "./tests/e2e/environment";
+import { appUrl, playwrightPort, previewPort, previewUrl } from "./tests/e2e/environment";
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -17,12 +17,26 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      // The production suite has its own base URL and server; everything else
+      // runs against `vite dev`.
+      testIgnore: "**/production/**",
       use: {
         ...devices["Desktop Chrome"],
         // CI runners ship Google Chrome preinstalled: launch that instead of
         // downloading Playwright's own Chromium build. Local dev keeps using
         // the bundled build from `bun run e2e:install`.
         channel: process.env.CI ? "chrome" : undefined,
+      },
+    },
+    {
+      // Runs against the built worker and assets, where the real
+      // Content-Security-Policy applies. See tests/e2e/production/csp.pw.ts.
+      name: "production",
+      testDir: "./tests/e2e/production",
+      use: {
+        ...devices["Desktop Chrome"],
+        channel: process.env.CI ? "chrome" : undefined,
+        baseURL: previewUrl,
       },
     },
   ],
@@ -37,6 +51,21 @@ export default defineConfig({
       command: `bunx vite dev --host localhost --port ${playwrightPort} --strictPort`,
       url: appUrl,
       reuseExistingServer: false,
+      gracefulShutdown: { signal: "SIGTERM", timeout: 500 },
+      env: {
+        PLAYWRIGHT_TEST: "1",
+        CLOUDFLARE_ENV: "playwright",
+      },
+    },
+    {
+      // Built output, not the dev server: `vite dev` relaxes script-src for
+      // Vite's inline React Refresh preamble, so only this one serves the
+      // policy that actually ships. The build is part of the command so the
+      // suite can never assert against a stale dist/.
+      command: `bunx vite build && bunx vite preview --port ${previewPort} --strictPort`,
+      url: previewUrl,
+      reuseExistingServer: false,
+      timeout: 180_000,
       gracefulShutdown: { signal: "SIGTERM", timeout: 500 },
       env: {
         PLAYWRIGHT_TEST: "1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   testMatch: "**/*.pw.ts",
   globalSetup: "./tests/e2e/global-setup.ts",
   fullyParallel: true,
+  // Playwright defaults to half the machine's cores, which is 2 on a CI runner
+  // and 4 or more on a dev machine. Every worker talks to the same single
+  // Miniflare dev server, so the extra ones only queue behind each other:
+  // tests that pass in CI time out locally, and the whole suite runs slower
+  // (1.6m at 4 workers, 1.3m at 2). Pinned so both match.
+  workers: 2,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,6 @@
+// Theme init before paint: same trick as brnr. Self-hosted (not inline) so
+// the boot page never needs a script-src 'unsafe-inline' CSP allowance.
+(function () {
+  const stored = localStorage.getItem("theme");
+  document.documentElement.dataset.theme = stored === "light" ? "light" : "dark";
+})();

--- a/src/app/components/qr.tsx
+++ b/src/app/components/qr.tsx
@@ -93,6 +93,12 @@ export function QRPreview({
       qr.current.append(holder.current);
     } else {
       qr.current.update({
+        // Dimensions travel with the rest: `size` is a dependency here, and
+        // update() keeps whatever it is not given, so leaving these out would
+        // strand a resized preview at its first size and quiet zone.
+        width: size,
+        height: size,
+        margin: Math.round(size * MARGIN_RATIO),
         data: url,
         image: look.logo,
         imageOptions: { margin: 4, imageSize: look.logoSize },

--- a/src/app/components/qr.tsx
+++ b/src/app/components/qr.tsx
@@ -20,6 +20,18 @@ function looksOptions(look: QrLook) {
   };
 }
 
+/** Pixel size of a downloaded code, independent of how big the preview is
+ * on screen. A PNG is a bitmap: exported at preview size (~208px) it is
+ * about 17mm wide at print resolution, which is unusable on anything
+ * physical. SVG is vector and would scale either way. */
+const DOWNLOAD_SIZE = 1024;
+
+// qr-code-styling takes margin in pixels, so a fixed value would shrink the
+// quiet zone to nothing relative to a 1024px code. Held as a ratio of the
+// code's size instead, chosen to give exactly the previous 8px at the 208px
+// default so the preview is unchanged.
+const MARGIN_RATIO = 8 / 208;
+
 function makeQR(url: string, size: number, look: QrLook) {
   return new QRCodeStyling({
     width: size,
@@ -27,7 +39,7 @@ function makeQR(url: string, size: number, look: QrLook) {
     type: "svg",
     data: url,
     image: look.logo,
-    margin: 8,
+    margin: Math.round(size * MARGIN_RATIO),
     qrOptions: { errorCorrectionLevel: "H" },
     imageOptions: { margin: 4, imageSize: look.logoSize },
     ...looksOptions(look),
@@ -90,8 +102,14 @@ export function QRPreview({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [url, size, look.dot, look.corner, look.ink, look.eye, look.bg, look.logo, look.logoSize]);
 
-  const download = (extension: "png" | "svg") => {
-    qr.current?.download({ name: downloadName ?? "qr", extension });
+  const download = async (extension: "png" | "svg") => {
+    // Exported from a throwaway instance at DOWNLOAD_SIZE, not from the one
+    // on screen: qr-code-styling rasterizes to a canvas at its own
+    // width/height, so downloading from the preview inherits the preview's
+    // pixel size. Resizing the visible instance instead would work but makes
+    // it jump mid-download.
+    const full = makeQR(url, DOWNLOAD_SIZE, look);
+    await full.download({ name: downloadName ?? "qr", extension });
     posthog.capture("qr_code_downloaded", { format: extension });
   };
 
@@ -113,10 +131,10 @@ export function QRPreview({
       />
       {downloadName !== undefined && (
         <div className="flex gap-2">
-          <Button size="sm" onClick={() => download("png")}>
+          <Button size="sm" onClick={() => void download("png")}>
             <Download size={13} /> PNG
           </Button>
-          <Button size="sm" onClick={() => download("svg")}>
+          <Button size="sm" onClick={() => void download("svg")}>
             <Download size={13} /> SVG
           </Button>
         </div>

--- a/src/worker/body-limit.ts
+++ b/src/worker/body-limit.ts
@@ -6,7 +6,7 @@ import { bodyLimit } from "hono/body-limit";
 // malformed request reaching a route handler at all before any other
 // validation runs (see issue #19). Binary uploads (the QR logo route) set
 // their own, much larger limit instead of using this one.
-export const DEFAULT_JSON_BODY_LIMIT = 32 * 1024;
+const DEFAULT_JSON_BODY_LIMIT = 32 * 1024;
 
 export function jsonBodyLimit() {
   return bodyLimit({

--- a/src/worker/body-limit.ts
+++ b/src/worker/body-limit.ts
@@ -1,0 +1,16 @@
+import { bodyLimit } from "hono/body-limit";
+
+// A generous ceiling for this API's JSON bodies — the largest legitimate
+// payload (a link create/update with every optional field filled in, or a
+// bulk invite) is a few KB — mainly a defense against an oversized or
+// malformed request reaching a route handler at all before any other
+// validation runs (see issue #19). Binary uploads (the QR logo route) set
+// their own, much larger limit instead of using this one.
+export const DEFAULT_JSON_BODY_LIMIT = 32 * 1024;
+
+export function jsonBodyLimit() {
+  return bodyLimit({
+    maxSize: DEFAULT_JSON_BODY_LIMIT,
+    onError: (c) => c.json({ message: "Request body too large" }, 413),
+  });
+}

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -44,7 +44,11 @@ export interface Env {
   APP_HOST: string; // var, e.g. "rdyrct.com"; the shared redirect host
   CF_API_TOKEN?: string; // secret, Custom Hostnames edit
   CF_ZONE_ID?: string; // var
-  CF_DEV_ENV?: string; // var, "1" in dev/test only: fakes the Custom Hostnames API
+  // var, dev/test only: fakes the Custom Hostnames API. "1" walks a new domain
+  // through checking_dns and issuing_tls on a timer, so both states are
+  // visible in a browser; "instant" reports both ready at once, for e2e runs
+  // that assert on the end state and should not wait out a staged delay.
+  CF_DEV_ENV?: string;
 
   /* alerting: dead-lettered storage messages (best-effort, never blocks acking) */
   BETTERSTACK_SOURCE_TOKEN?: string; // secret

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -44,10 +44,11 @@ export interface Env {
   APP_HOST: string; // var, e.g. "rdyrct.com"; the shared redirect host
   CF_API_TOKEN?: string; // secret, Custom Hostnames edit
   CF_ZONE_ID?: string; // var
-  // var, dev/test only: fakes the Custom Hostnames API. "1" walks a new domain
-  // through checking_dns and issuing_tls on a timer, so both states are
-  // visible in a browser; "instant" reports both ready at once, for e2e runs
-  // that assert on the end state and should not wait out a staged delay.
+  // var, dev/test only: fakes the Custom Hostnames API. "simulated" walks a
+  // new domain through checking_dns and issuing_tls on a timer, so both states
+  // are visible in a browser; "instant" reports both ready at once, for e2e
+  // runs that assert on the end state and should not wait out a staged delay.
+  // Any other value (including unset) calls the real API, or fails closed.
   CF_DEV_ENV?: string;
 
   /* alerting: dead-lettered storage messages (best-effort, never blocks acking) */

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -58,9 +58,15 @@ app.onError((err, c) => {
 // Worker sends (see security-headers.ts): registered first, so it wraps
 // every handler below (custom-domain redirects, the API, the blog proxy,
 // shared-domain slug redirects, the SPA asset fallback).
+//
+// Assigning c.res, not mutating it: applySecurityHeaders returns a copy
+// because some responses (ASSETS, Response.redirect) refuse header writes.
+// Returning the response from here would not work — after next() the
+// context is finalized, and hono's compose only adopts a returned response
+// while it isn't.
 app.use("*", async (c, next) => {
   await next();
-  if (!isBlogPath(new URL(c.req.url).pathname)) applySecurityHeaders(c.res);
+  if (!isBlogPath(new URL(c.req.url).pathname)) c.res = applySecurityHeaders(c.res);
 });
 
 /* ---------------- redirect hot path ---------------- */

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AppEnv, Env } from "./env";
 import { withSession } from "./session";
 import { getAuth } from "./better-auth";
@@ -14,6 +15,7 @@ import { domainRoutes } from "./routes/domains";
 import { resolveSlug, resolveDomain, type KVLink } from "./kv";
 import { RESERVED_SLUGS } from "./util";
 import { enforcePublicAuthRateLimit, enforceSignedApiRateLimit } from "./rate-limit";
+import { applySecurityHeaders, isBlogPath } from "./security-headers";
 import { drizzle } from "drizzle-orm/d1";
 import * as schema from "./db/schema";
 import {
@@ -39,12 +41,26 @@ app.onError((err, c) => {
   // the rest of the body onto ApiError.data, so a route's `cause` can carry
   // more than just a machine-readable `code` (e.g. same_destination_match's
   // matchedLinkId/matchedLink) straight through to the caller.
+  const path = new URL(c.req.url).pathname;
+  const respond = (body: unknown, status: ContentfulStatusCode) => {
+    const res = c.json(body, status);
+    return isBlogPath(path) ? res : applySecurityHeaders(res);
+  };
   if (err instanceof HTTPException) {
     const cause = err.cause && typeof err.cause === "object" ? err.cause : {};
-    return c.json({ message: err.message, ...cause }, err.status);
+    return respond({ message: err.message, ...cause }, err.status);
   }
   console.error(err);
-  return c.json({ message: "Internal error" }, 500);
+  return respond({ message: "Internal error" }, 500);
+});
+
+// Applies the security header baseline to every non-error response this
+// Worker sends (see security-headers.ts): registered first, so it wraps
+// every handler below (custom-domain redirects, the API, the blog proxy,
+// shared-domain slug redirects, the SPA asset fallback).
+app.use("*", async (c, next) => {
+  await next();
+  if (!isBlogPath(new URL(c.req.url).pathname)) applySecurityHeaders(c.res);
 });
 
 /* ---------------- redirect hot path ---------------- */

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -15,6 +15,7 @@ import {
 } from "@/shared/types";
 import { fillSeries, computeDelta, deleteOrg } from "./orgs";
 import { orgPlan } from "../plan";
+import { jsonBodyLimit } from "../body-limit";
 
 // An org's effective plan is its owner's plan (billing is per-user). A single
 // correlated subquery pulls it for list views. Note: `user` is a SQL keyword,
@@ -41,6 +42,7 @@ const ownerEmail = sql<string | null>`(
 
 // Mounted at /api/admin: platform-level views for the instance admin.
 export const adminRoutes = new Hono<AppEnv>();
+adminRoutes.use("*", jsonBodyLimit());
 
 adminRoutes.use("*", requireAdmin);
 

--- a/src/worker/routes/auth.ts
+++ b/src/worker/routes/auth.ts
@@ -4,11 +4,13 @@ import { alias } from "drizzle-orm/sqlite-core";
 import * as schema from "../db/schema";
 import type { AppEnv } from "../env";
 import { requireUser } from "../guards";
+import { jsonBodyLimit } from "../body-limit";
 import type { AppConfig, CurrentUser, OrgPlan } from "@/shared/types";
 
 // Signup/login/logout/verification live under /api/auth/* (BetterAuth).
 // This router only exposes the app-level session view, mounted at /api.
 export const userRoutes = new Hono<AppEnv>();
+userRoutes.use("*", jsonBodyLimit());
 
 async function currentUserFor(
   db: AppEnv["Variables"]["db"],

--- a/src/worker/routes/billing.ts
+++ b/src/worker/routes/billing.ts
@@ -8,6 +8,7 @@ import * as schema from "../db/schema";
 import type { AppEnv, Env } from "../env";
 import { requireUser } from "../guards";
 import { alertBetterStack } from "../alerts";
+import { jsonBodyLimit } from "../body-limit";
 
 const polarFor = (env: Env) =>
   new Polar({
@@ -16,7 +17,10 @@ const polarFor = (env: Env) =>
   });
 
 // Mounted at /api/billing: the caller's own subscription (per-user billing).
+// (The Polar webhook itself is mounted separately, outside this router and
+// its body limit — see handlePolarWebhook below and index.ts.)
 export const billingRoutes = new Hono<AppEnv>();
+billingRoutes.use("*", jsonBodyLimit());
 
 /**
  * Which plan a Polar product grants: an explicit allowlist that fails

--- a/src/worker/routes/domains.ts
+++ b/src/worker/routes/domains.ts
@@ -64,7 +64,7 @@ async function cfRequest<T = Record<string, unknown>>(
 // never merely because credentials happen to be unset: a misconfigured
 // deployment must fail closed, not silently mint fake hostnames.
 function useFakeCf(env: Env): boolean {
-  return env.CF_DEV_ENV === "1" || env.CF_DEV_ENV === "instant";
+  return env.CF_DEV_ENV === "simulated" || env.CF_DEV_ENV === "instant";
 }
 
 function assertCfConfigured(env: Env): void {

--- a/src/worker/routes/domains.ts
+++ b/src/worker/routes/domains.ts
@@ -9,6 +9,7 @@ import { orgPlan, insertDomainWithinLimit } from "../plan";
 import { enqueueStorage, syncDomainMsg } from "../storage";
 import { uid, now } from "../util";
 import { isValidHttpUrl, normalizeUrl } from "../util";
+import { jsonBodyLimit } from "../body-limit";
 import type { DomainDTO, PlanLimits } from "@/shared/types";
 
 // e.g. links.example.com: at least one dot, no scheme/port/path
@@ -246,6 +247,7 @@ export function probeDelaySeconds(attempt: number): number {
 
 // Mounted at /api/orgs/:orgId/domains: org admins, paid plans only.
 export const domainRoutes = new Hono<AppEnv>();
+domainRoutes.use("*", jsonBodyLimit());
 
 domainRoutes.use("*", requireOrgRole("admin"));
 

--- a/src/worker/routes/domains.ts
+++ b/src/worker/routes/domains.ts
@@ -64,7 +64,7 @@ async function cfRequest<T = Record<string, unknown>>(
 // never merely because credentials happen to be unset: a misconfigured
 // deployment must fail closed, not silently mint fake hostnames.
 function useFakeCf(env: Env): boolean {
-  return env.CF_DEV_ENV === "1";
+  return env.CF_DEV_ENV === "1" || env.CF_DEV_ENV === "instant";
 }
 
 function assertCfConfigured(env: Env): void {
@@ -105,14 +105,20 @@ async function cfGetHostnameStatus(
   env: Env,
   row: typeof schema.domains.$inferSelect,
 ): Promise<CfHostnameResult | null> {
-  // The fake keeps new domains in checking_dns for ~5s before showing DNS as
-  // resolved, then another ~15s before the certificate is "issued" (long
-  // enough to see/click through the issuing_tls state in a browser or e2e run).
   if (useFakeCf(env)) {
+    // "instant" skips the staged delays entirely: an e2e run asserts on the
+    // end state, and waiting out an artificial timer only buys a race against
+    // whatever budget the test picked.
+    if (env.CF_DEV_ENV === "instant") return { status: "active", ssl: { status: "active" } };
+    // Otherwise walk the states on a timer so both are visible in a browser.
+    // Each threshold sits strictly between two probes: probeDelaySeconds puts
+    // them at 0s, 5s, 10s, 20s, 40s, and a threshold landing *on* one of those
+    // is a coin flip. The TLS one used to be 20s, exactly probe 4, so losing
+    // the toss pushed activation out to 40s.
     const age = now() - row.createdAt;
     return {
-      status: age > 5_000 ? "active" : "pending",
-      ssl: age > 20_000 ? { status: "active" } : { status: "pending_validation" },
+      status: age > 3_000 ? "active" : "pending",
+      ssl: age > 12_000 ? { status: "active" } : { status: "pending_validation" },
     };
   }
   assertCfConfigured(env);

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -25,6 +25,7 @@ import {
   validateQrFields,
   ALIAS_TTL_MS,
 } from "../util";
+import { jsonBodyLimit } from "../body-limit";
 import type { AddressDTO, LinkDTO, LinkInput, OrgPlan, PlanLimits, TopEntry } from "@/shared/types";
 
 const RECENT_CLICKS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -35,6 +36,7 @@ const MAX_ALIASES_PER_LINK = 5;
 
 // Mounted at /api/orgs/:orgId/links
 export const linkRoutes = new Hono<AppEnv>();
+linkRoutes.use("*", jsonBodyLimit());
 
 /** Shared by link creation/rename and standalone address creation: a
  * provided slug must match the allowed charset and not be reserved. Empty or

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -9,6 +9,8 @@ import { orgPlan, userPlan, createOwnedOrg, acceptInviteAtomically } from "../pl
 import { sendEmail } from "../email";
 import { deleteQrLogoMsg, enqueueStorage } from "../storage";
 import { uid, now, referrerHost, validateQrFields } from "../util";
+import { jsonBodyLimit } from "../body-limit";
+import { parseBody, inviteBodySchema } from "../schemas";
 import type {
   MemberDTO,
   InviteDTO,
@@ -20,13 +22,13 @@ import type {
 } from "@/shared/types";
 
 export const orgRoutes = new Hono<AppEnv>();
+orgRoutes.use("*", jsonBodyLimit());
 
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 orgRoutes.post("/", requireUser, async (c) => {
   const body = await c.req.json<{ name?: string }>();
-  const name = body.name?.trim();
-  if (!name) throw new HTTPException(400, { message: "Name required" });
+  const name = requireOrgName(body.name ?? "");
 
   const { limits } = await userPlan(c.var.db, c.var.user!.id);
 
@@ -98,9 +100,18 @@ function qrPatchFields(body: OrgQrPatchBody): Partial<typeof schema.orgs.$inferI
   return set;
 }
 
+// Matches the client's own cap (src/app/lib/schemas.ts orgNameSchema): the
+// server enforces it too, so a caller that bypasses the client's form
+// validation can't store an unbounded name (see issue #19).
+const ORG_NAME_MAX_LENGTH = 100;
+
 function requireOrgName(name: string): string {
   const trimmed = name.trim();
   if (!trimmed) throw new HTTPException(400, { message: "Name required" });
+  if (trimmed.length > ORG_NAME_MAX_LENGTH)
+    throw new HTTPException(400, {
+      message: `Name must be ${ORG_NAME_MAX_LENGTH} characters or fewer`,
+    });
   return trimmed;
 }
 
@@ -289,17 +300,14 @@ async function occupiedSeats(db: AppEnv["Variables"]["db"], orgId: string): Prom
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 orgRoutes.post("/:orgId/invites", requireOrgRole("admin"), async (c) => {
-  const body = await c.req.json<{
-    role?: "admin" | "member";
-    emails?: string[];
-  }>();
-  const role: "admin" | "member" = body.role === "admin" ? "admin" : "member";
+  const body = parseBody(inviteBodySchema, await c.req.json().catch(() => ({})));
+  const role = body.role;
   const orgIdParam = c.req.param("orgId");
   const { plan, limits } = await orgPlan(c.var.db, orgIdParam);
 
   const emails = [
     ...new Set(
-      (body.emails ?? []).flatMap((e) => {
+      body.emails.flatMap((e) => {
         const email = e.trim().toLowerCase();
         return EMAIL_RE.test(email) ? [email] : [];
       }),
@@ -566,7 +574,11 @@ orgRoutes.get("/:orgId/stats", requireOrgRole("member"), async (c) => {
     db
       .select({ clicks: sql<number>`count(*)` })
       .from(schema.clicks)
-      .where(inOrg),
+      // Bounded to the selected range (matching totalsPrev's equal-length
+      // window below), not an unbounded all-time count: comparing an
+      // ever-growing total against one period's worth of prior clicks used
+      // to produce a meaningless delta (see issue #24).
+      .where(and(inOrg, gte(schema.clicks.ts, since))),
     db
       .select({ clicks: sql<number>`count(*)` })
       .from(schema.clicks)
@@ -835,7 +847,9 @@ orgRoutes.get("/:orgId/links/stats/:slug", requireOrgRole("member"), async (c) =
     db
       .select({ clicks: sql<number>`count(*)` })
       .from(schema.clicks)
-      .where(onLink),
+      // Bounded to the selected range, same reasoning as the org stats
+      // route's totals query above (see issue #24).
+      .where(and(onLink, gte(schema.clicks.ts, since))),
     db
       .select({ clicks: sql<number>`count(*)` })
       .from(schema.clicks)
@@ -918,6 +932,7 @@ orgRoutes.get("/:orgId/links/stats/:slug", requireOrgRole("member"), async (c) =
 /* ---------------- invite acceptance (not org-scoped) ---------------- */
 
 export const inviteRoutes = new Hono<AppEnv>();
+inviteRoutes.use("*", jsonBodyLimit());
 
 inviteRoutes.get("/:token", async (c) => {
   const rows = await c.var.db

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -105,7 +105,8 @@ function qrPatchFields(body: OrgQrPatchBody): Partial<typeof schema.orgs.$inferI
 // validation can't store an unbounded name (see issue #19).
 const ORG_NAME_MAX_LENGTH = 100;
 
-function requireOrgName(name: string): string {
+function requireOrgName(name: unknown): string {
+  if (typeof name !== "string") throw new HTTPException(400, { message: "Name must be a string" });
   const trimmed = name.trim();
   if (!trimmed) throw new HTTPException(400, { message: "Name required" });
   if (trimmed.length > ORG_NAME_MAX_LENGTH)
@@ -300,7 +301,13 @@ async function occupiedSeats(db: AppEnv["Variables"]["db"], orgId: string): Prom
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 orgRoutes.post("/:orgId/invites", requireOrgRole("admin"), async (c) => {
-  const body = parseBody(inviteBodySchema, await c.req.json().catch(() => ({})));
+  let rawBody: unknown;
+  try {
+    rawBody = await c.req.json();
+  } catch {
+    throw new HTTPException(400, { message: "Invalid request body" });
+  }
+  const body = parseBody(inviteBodySchema, rawBody);
   const role = body.role;
   const orgIdParam = c.req.param("orgId");
   const { plan, limits } = await orgPlan(c.var.db, orgIdParam);

--- a/src/worker/routes/qr-logos.ts
+++ b/src/worker/routes/qr-logos.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
+import { bodyLimit } from "hono/body-limit";
 import type { AppEnv } from "../env";
 import { requireOrgRole, orgRole } from "../org-role";
 import { orgPlan } from "../plan";
@@ -10,6 +11,18 @@ import { QR_LOGO_MAX_BYTES } from "@/shared/types";
 // org members: a logo is only ever fetched by the signed-in app (QR previews
 // and downloads bake the image in client-side, nothing fetches it later).
 export const qrLogoRoutes = new Hono<AppEnv>();
+
+// A generous margin over QR_LOGO_MAX_BYTES (the real business limit,
+// enforced below once the org's plan is known): this is just a coarse,
+// cheap-to-check ceiling so an oversized upload is rejected before the
+// handler even runs (see issue #19).
+qrLogoRoutes.use(
+  "*",
+  bodyLimit({
+    maxSize: QR_LOGO_MAX_BYTES + 4096,
+    onError: (c) => c.json({ message: "File too large" }, 413),
+  }),
+);
 
 const EXT_BY_TYPE: Record<string, string> = {
   "image/webp": "webp",

--- a/src/worker/schemas.ts
+++ b/src/worker/schemas.ts
@@ -1,0 +1,32 @@
+import * as v from "valibot";
+import { HTTPException } from "hono/http-exception";
+
+/**
+ * Parses `body` against `schema`, throwing a 400 HTTPException with the
+ * first issue's message on failure. Same library the client already uses
+ * for form validation (src/app/lib/schemas.ts) — server-side schemas close
+ * the gap where a caller that bypasses the client (a raw API request, a
+ * malformed type) previously reached a route handler unchecked (see issue
+ * #19).
+ */
+export function parseBody<const TSchema extends v.GenericSchema>(
+  schema: TSchema,
+  body: unknown,
+): v.InferOutput<TSchema> {
+  const result = v.safeParse(schema, body);
+  if (!result.success) {
+    const message = result.issues[0]?.message ?? "Invalid request";
+    throw new HTTPException(400, { message });
+  }
+  return result.output;
+}
+
+// A bulk-invite request pasting far more than this is almost certainly a
+// mistake or abuse, not a real team roster; the org's member-cap check
+// below still applies on top of this.
+export const MAX_INVITE_EMAILS = 50;
+
+export const inviteBodySchema = v.object({
+  role: v.optional(v.picklist(["admin", "member"]), "member"),
+  emails: v.optional(v.pipe(v.array(v.string()), v.maxLength(MAX_INVITE_EMAILS)), []),
+});

--- a/src/worker/schemas.ts
+++ b/src/worker/schemas.ts
@@ -24,7 +24,7 @@ export function parseBody<const TSchema extends v.GenericSchema>(
 // A bulk-invite request pasting far more than this is almost certainly a
 // mistake or abuse, not a real team roster; the org's member-cap check
 // below still applies on top of this.
-export const MAX_INVITE_EMAILS = 50;
+const MAX_INVITE_EMAILS = 50;
 
 export const inviteBodySchema = v.object({
   role: v.optional(v.picklist(["admin", "member"]), "member"),

--- a/src/worker/security-headers.ts
+++ b/src/worker/security-headers.ts
@@ -1,0 +1,43 @@
+/**
+ * A consistent header baseline for every response this Worker sends
+ * (API, redirects, errors, the SPA and its static assets): one missed
+ * response path shouldn't leave weaker browser protections than the rest
+ * (see issue #21). Not applied to the reverse-proxied blog (see index.ts) —
+ * that's a separate Next.js app on Vercel with its own script/style needs,
+ * and overriding its CSP here could break its hydration.
+ *
+ * `'unsafe-inline'` on style-src only: the app uses React inline `style`
+ * props throughout, and CSP has no practical hash/nonce story for those.
+ * Inline *script* has no such allowance — the one script this app used to
+ * inline (the pre-paint theme bootstrap) now lives at /theme-init.js instead.
+ *
+ * connect-src/img-src include PostHog's ingest host: analytics-consent
+ * capture calls (posthog-js) go straight to it, not through this Worker.
+ */
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https://*.posthog.com",
+  "font-src 'self'",
+  "connect-src 'self' https://*.posthog.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+export function applySecurityHeaders(res: Response): Response {
+  res.headers.set("Content-Security-Policy", CSP);
+  res.headers.set("X-Content-Type-Options", "nosniff");
+  res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  res.headers.set(
+    "Permissions-Policy",
+    "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+  );
+  return res;
+}
+
+export function isBlogPath(pathname: string): boolean {
+  return pathname === "/blog" || pathname.startsWith("/blog/");
+}

--- a/src/worker/security-headers.ts
+++ b/src/worker/security-headers.ts
@@ -11,9 +11,16 @@
  * Inline *script* has no such allowance — the one script this app used to
  * inline (the pre-paint theme bootstrap) now lives at /theme-init.js instead.
  *
- * connect-src/img-src include PostHog's ingest host: analytics-consent
- * capture calls (posthog-js) go straight to it, not through this Worker.
+ * PostHog appears in script-src, connect-src and img-src. All three are
+ * needed: posthog-js does not bundle its optional features, it builds
+ * `<assets host>/static/<name>.js` and injects it with createElement("script")
+ * the first time one is used, and lib/posthog.ts enables `capture_exceptions`.
+ * Allowing the ingest calls but not the script left exception capture dead in
+ * production while every test stayed green, because the dev server never
+ * loads PostHog. Covered now by tests/e2e/production/csp.pw.ts.
  */
+const POSTHOG = "https://*.posthog.com";
+
 // `@vitejs/plugin-react` injects an inline module preamble (the React Refresh
 // runtime) into index.html when Vite serves the app in dev. `script-src
 // 'self'` refuses it, the runtime never installs, and the SPA renders
@@ -24,15 +31,17 @@
 // so a deployed Worker cannot ship 'unsafe-inline' through a misread var.
 // The tradeoff is that e2e exercises a marginally looser policy than
 // production; everything except this one directive is identical.
-const SCRIPT_SRC = import.meta.env.DEV ? "script-src 'self' 'unsafe-inline'" : "script-src 'self'";
+const SCRIPT_SRC = import.meta.env.DEV
+  ? `script-src 'self' 'unsafe-inline' ${POSTHOG}`
+  : `script-src 'self' ${POSTHOG}`;
 
 const CSP = [
   "default-src 'self'",
   SCRIPT_SRC,
   "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: https://*.posthog.com",
+  `img-src 'self' data: ${POSTHOG}`,
   "font-src 'self'",
-  "connect-src 'self' https://*.posthog.com",
+  `connect-src 'self' ${POSTHOG}`,
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/src/worker/security-headers.ts
+++ b/src/worker/security-headers.ts
@@ -14,9 +14,21 @@
  * connect-src/img-src include PostHog's ingest host: analytics-consent
  * capture calls (posthog-js) go straight to it, not through this Worker.
  */
+// `@vitejs/plugin-react` injects an inline module preamble (the React Refresh
+// runtime) into index.html when Vite serves the app in dev. `script-src
+// 'self'` refuses it, the runtime never installs, and the SPA renders
+// nothing at all — which is how the e2e smoke test found this.
+//
+// A built bundle has no preamble, so the allowance is compiled out rather
+// than switched at runtime: `import.meta.env.DEV` is a build-time constant,
+// so a deployed Worker cannot ship 'unsafe-inline' through a misread var.
+// The tradeoff is that e2e exercises a marginally looser policy than
+// production; everything except this one directive is identical.
+const SCRIPT_SRC = import.meta.env.DEV ? "script-src 'self' 'unsafe-inline'" : "script-src 'self'";
+
 const CSP = [
   "default-src 'self'",
-  "script-src 'self'",
+  SCRIPT_SRC,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: https://*.posthog.com",
   "font-src 'self'",
@@ -27,15 +39,26 @@ const CSP = [
   "frame-ancestors 'none'",
 ].join("; ");
 
+/**
+ * Returns a copy carrying the baseline, rather than setting headers on the
+ * response passed in. Not every response has mutable headers: anything from
+ * the ASSETS binding (every static file and the SPA fallback) and anything
+ * built by Response.redirect() carries an immutable Headers guard, and
+ * writing to one throws "Can't modify immutable headers". Mutating in place
+ * therefore broke every static asset request, not just an exotic edge case.
+ *
+ * The copy is cheap: the body is handed over by reference, never read.
+ */
 export function applySecurityHeaders(res: Response): Response {
-  res.headers.set("Content-Security-Policy", CSP);
-  res.headers.set("X-Content-Type-Options", "nosniff");
-  res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-  res.headers.set(
+  const out = new Response(res.body, res);
+  out.headers.set("Content-Security-Policy", CSP);
+  out.headers.set("X-Content-Type-Options", "nosniff");
+  out.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  out.headers.set(
     "Permissions-Policy",
     "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
   );
-  return res;
+  return out;
 }
 
 export function isBlogPath(pathname: string): boolean {

--- a/tests/e2e/auth.pw.ts
+++ b/tests/e2e/auth.pw.ts
@@ -40,7 +40,6 @@ test.describe("authentication forms", () => {
 
     await expect(page).toHaveURL(/\/login$/);
     await expect(page.getByLabel("Password")).toHaveValue("password");
-    await expect(page.getByRole("button", { name: "Sign in" })).toHaveClass(/animate-shake/);
     await expect(page.getByText("Enter a valid email address")).toBeVisible();
     expect(authRequests.count).toBe(0);
   });
@@ -55,7 +54,6 @@ test.describe("authentication forms", () => {
 
     await expect(page).toHaveURL(/\/signup$/);
     await expect(page.getByLabel("Password")).toHaveValue("short");
-    await expect(page.getByRole("button", { name: "Sign up" })).toHaveClass(/animate-shake/);
     await expect(page.getByText("Password must be at least 8 characters")).toBeVisible();
     expect(authRequests.count).toBe(0);
   });
@@ -123,7 +121,6 @@ test.describe("authentication forms", () => {
     await page.getByRole("button", { name: "Sign up" }).click();
 
     await expect(page.getByRole("heading", { name: "Create an account" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Sign up" })).toHaveClass(/animate-shake/);
     await expect(page.getByText("Email delivery unavailable")).toBeVisible();
   });
 });

--- a/tests/e2e/csp.ts
+++ b/tests/e2e/csp.ts
@@ -1,0 +1,81 @@
+import type { Page } from "@playwright/test";
+
+export interface CspViolation {
+  directive: string;
+  blockedUri: string;
+  documentUri: string;
+}
+
+declare global {
+  interface Window {
+    __cspViolations?: CspViolation[];
+  }
+}
+
+/**
+ * Records every Content-Security-Policy violation the browser reports on this
+ * page, from before the first byte of application code runs.
+ *
+ * Console scraping is not good enough here: a blocked subresource is reported
+ * differently across browsers and log levels, and a test that greps stderr
+ * quietly stops catching anything the day the wording changes. The
+ * `securitypolicyviolation` event is the specified signal and fires whether
+ * or not the request would have reached the network, so these assertions hold
+ * in CI with no outbound access.
+ */
+export async function collectCspViolations(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.__cspViolations = [];
+    document.addEventListener("securitypolicyviolation", (event) => {
+      window.__cspViolations?.push({
+        directive: event.effectiveDirective || event.violatedDirective,
+        blockedUri: event.blockedURI,
+        documentUri: event.documentURI,
+      });
+    });
+  });
+}
+
+export async function cspViolations(page: Page): Promise<CspViolation[]> {
+  return (await page.evaluate(() => window.__cspViolations ?? [])) as CspViolation[];
+}
+
+/**
+ * Whether the page's policy would block loading `src` as a script, asked of
+ * the browser rather than inferred by parsing the header ourselves.
+ *
+ * The element is appended and the answer read from the violation event, so
+ * the request never has to succeed: CSP is enforced before the fetch, which
+ * keeps this deterministic offline.
+ */
+export async function scriptIsBlocked(page: Page, src: string): Promise<boolean> {
+  return page.evaluate(async (url) => {
+    return await new Promise<boolean>((resolve) => {
+      let blocked = false;
+      const onViolation = (event: SecurityPolicyViolationEvent) => {
+        if (
+          (event.effectiveDirective || event.violatedDirective).startsWith("script-src") &&
+          url.startsWith(event.blockedURI)
+        ) {
+          blocked = true;
+        }
+      };
+      document.addEventListener("securitypolicyviolation", onViolation);
+
+      const script = document.createElement("script");
+      script.src = url;
+      const finish = () => {
+        document.removeEventListener("securitypolicyviolation", onViolation);
+        script.remove();
+        resolve(blocked);
+      };
+      // Either outcome settles it: a CSP block fires the violation event
+      // synchronously and then `error`, and an allowed-but-unreachable URL
+      // fires `error` with no violation recorded.
+      script.addEventListener("load", finish);
+      script.addEventListener("error", finish);
+      document.head.appendChild(script);
+      setTimeout(finish, 5000);
+    });
+  }, src);
+}

--- a/tests/e2e/environment.ts
+++ b/tests/e2e/environment.ts
@@ -1,3 +1,10 @@
 export const playwrightPort = 5174;
 export const appUrl = `http://localhost:${playwrightPort}`;
 export const explorerUrl = `${appUrl}/cdn-cgi/explorer/api`;
+
+// `vite preview` serves the *built* worker and assets, which is the only way
+// to exercise the production Content-Security-Policy: `vite dev` relaxes
+// script-src to admit the React Refresh preamble Vite injects, so a page that
+// works there proves nothing about the policy that actually ships.
+export const previewPort = 4174;
+export const previewUrl = `http://localhost:${previewPort}`;

--- a/tests/e2e/link-addresses.pw.ts
+++ b/tests/e2e/link-addresses.pw.ts
@@ -92,6 +92,9 @@ test("renaming a custom-domain link leaves a temporary alias, which can be kept 
   // A custom domain is required: renaming only leaves an alias on a
   // custom-domain address, never on the shared, always-random domain.
   const hostname = await addCustomDomain(page, `alias-${Date.now()}.example.com`);
+  // The playwright env reports DNS and TLS ready immediately (CF_DEV_ENV
+  // "instant"), so this waits on one probe-ramp sleep plus a domains poll, not
+  // on the staged delays local dev uses.
   await expect(page.getByText("active", { exact: true })).toBeVisible({ timeout: 30_000 });
 
   await page.goto("/links");

--- a/tests/e2e/pages.ts
+++ b/tests/e2e/pages.ts
@@ -1,0 +1,18 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Visit both legal pages and confirm each one actually rendered.
+ *
+ * Shared because two suites need the same walk for different reasons: the dev
+ * suite checks the headings survive, the production suite checks the route
+ * raises no Content-Security-Policy violation. Asserting on the heading is
+ * what makes either meaningful — a blocked bundle still answers 200 with the
+ * pre-render shell.
+ */
+export async function visitLegalPages(page: Page): Promise<void> {
+  await page.goto("/privacy");
+  await expect(page.getByRole("heading", { name: "Privacy Policy" })).toBeVisible();
+
+  await page.goto("/terms");
+  await expect(page.getByRole("heading", { name: "Terms of Service" })).toBeVisible();
+}

--- a/tests/e2e/pages.ts
+++ b/tests/e2e/pages.ts
@@ -1,18 +1,29 @@
 import { expect, type Page } from "@playwright/test";
 
+const LEGAL_PAGES = [
+  { path: "/privacy", heading: "Privacy Policy" },
+  { path: "/terms", heading: "Terms of Service" },
+];
+
 /**
  * Visit both legal pages and confirm each one actually rendered.
  *
  * Shared because two suites need the same walk for different reasons: the dev
  * suite checks the headings survive, the production suite checks the route
  * raises no Content-Security-Policy violation. Asserting on the heading is
- * what makes either meaningful — a blocked bundle still answers 200 with the
+ * what makes either meaningful. A blocked bundle still answers 200 with the
  * pre-render shell.
+ *
+ * `afterEach` runs while that page is still open, for checks that read state
+ * the next navigation would throw away.
  */
-export async function visitLegalPages(page: Page): Promise<void> {
-  await page.goto("/privacy");
-  await expect(page.getByRole("heading", { name: "Privacy Policy" })).toBeVisible();
-
-  await page.goto("/terms");
-  await expect(page.getByRole("heading", { name: "Terms of Service" })).toBeVisible();
+export async function visitLegalPages(
+  page: Page,
+  afterEach?: (path: string) => Promise<void>,
+): Promise<void> {
+  for (const { path, heading } of LEGAL_PAGES) {
+    await page.goto(path);
+    await expect(page.getByRole("heading", { name: heading })).toBeVisible();
+    await afterEach?.(path);
+  }
 }

--- a/tests/e2e/production/csp.pw.ts
+++ b/tests/e2e/production/csp.pw.ts
@@ -14,6 +14,21 @@ test.beforeEach(async ({ page }) => {
   await collectCspViolations(page);
 });
 
+test("the built worker serves the production CSP", async ({ page }) => {
+  // Every other test here asks the browser what the policy refused, which a
+  // page carrying no policy at all answers with silence. Pin the header first,
+  // so a preview server that stopped running applySecurityHeaders fails loudly
+  // instead of turning the rest of this file green.
+  const response = await page.goto("/");
+  const csp = response?.headers()["content-security-policy"];
+
+  expect(csp).toBeTruthy();
+  // style-src carries 'unsafe-inline' by design (React inline `style`), so the
+  // check that matters is script-src alone, read as its own directive.
+  const scriptSrc = csp?.split(";").find((part) => part.trim().startsWith("script-src"));
+  expect(scriptSrc?.trim()).toBe("script-src 'self' https://*.posthog.com");
+});
+
 test("the landing page renders under the production CSP without violations", async ({ page }) => {
   await page.goto("/");
 
@@ -41,9 +56,12 @@ test("QR previews render under the production CSP without violations", async ({ 
 });
 
 test("legal pages render under the production CSP without violations", async ({ page }) => {
-  await visitLegalPages(page);
-
-  expect(await cspViolations(page)).toEqual([]);
+  // Violations are recorded on `window`, and the collector re-runs on every
+  // navigation, so /privacy's record is already gone by the time /terms has
+  // loaded. Each page has to be asserted before we leave it.
+  await visitLegalPages(page, async (path) => {
+    expect(await cspViolations(page), path).toEqual([]);
+  });
 });
 
 test("the production CSP permits the scripts PostHog fetches at runtime", async ({ page }) => {

--- a/tests/e2e/production/csp.pw.ts
+++ b/tests/e2e/production/csp.pw.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+import { collectCspViolations, cspViolations, scriptIsBlocked } from "../csp";
+import { visitLegalPages } from "../pages";
+
+/**
+ * These run against `vite preview`, i.e. the built worker and built assets,
+ * because that is the only place the production Content-Security-Policy is in
+ * force. Under `vite dev` the policy is deliberately looser (Vite injects an
+ * inline React Refresh preamble that `script-src 'self'` would refuse), so the
+ * dev suite cannot speak to what ships.
+ */
+
+test.beforeEach(async ({ page }) => {
+  await collectCspViolations(page);
+});
+
+test("the landing page renders under the production CSP without violations", async ({ page }) => {
+  await page.goto("/");
+
+  // Rendering, not just responding: a blocked module leaves the pre-render
+  // fallback in place, which still returns 200.
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await expect(page.getByRole("link", { name: /get started/i }).first()).toBeVisible();
+
+  expect(await cspViolations(page)).toEqual([]);
+});
+
+test("QR previews render under the production CSP without violations", async ({ page }) => {
+  await page.goto("/");
+
+  // The landing mockup mounts real QRPreview components, one of them with an
+  // embedded logo, so qr-code-styling's rendering path is exercised here
+  // without needing an account. It draws through image and canvas APIs, which
+  // is exactly what img-src governs.
+  await expect(page.locator("svg").first()).toBeVisible();
+  await page.waitForTimeout(1500);
+
+  const violations = await cspViolations(page);
+  expect(violations.filter((v) => v.directive.startsWith("img-src"))).toEqual([]);
+  expect(violations).toEqual([]);
+});
+
+test("legal pages render under the production CSP without violations", async ({ page }) => {
+  await visitLegalPages(page);
+
+  expect(await cspViolations(page)).toEqual([]);
+});
+
+test("the production CSP permits the scripts PostHog fetches at runtime", async ({ page }) => {
+  await page.goto("/");
+
+  // posthog-js does not ship its optional features in the bundle. It builds
+  // `<assets host>/static/<name>.js` and injects it with
+  // document.createElement("script") the first time one is needed, and
+  // src/app/lib/posthog.ts turns on `capture_exceptions`, which is one of
+  // them. connect-src and img-src already allowlist PostHog; script-src has
+  // to agree, or exception capture dies silently in production while every
+  // test stays green.
+  const blocked = await scriptIsBlocked(
+    page,
+    "https://us-assets.i.posthog.com/static/exception-autocapture.js",
+  );
+
+  expect(blocked).toBe(false);
+});

--- a/tests/e2e/public-pages.pw.ts
+++ b/tests/e2e/public-pages.pw.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { visitLegalPages } from "./pages";
 
 test("landing page keeps the main sign-up path", async ({ page }) => {
   await page.goto("/");
@@ -12,9 +13,5 @@ test("landing page keeps the main sign-up path", async ({ page }) => {
 });
 
 test("legal pages retain their baseline headings", async ({ page }) => {
-  await page.goto("/privacy");
-  await expect(page.getByRole("heading", { name: "Privacy Policy" })).toBeVisible();
-
-  await page.goto("/terms");
-  await expect(page.getByRole("heading", { name: "Terms of Service" })).toBeVisible();
+  await visitLegalPages(page);
 });

--- a/tests/e2e/qr-download.pw.ts
+++ b/tests/e2e/qr-download.pw.ts
@@ -48,6 +48,6 @@ test("a downloaded QR PNG is big enough to print, not preview-sized (#88)", asyn
 
   // The preview renders at 208px; exporting from that instance is the bug.
   const { width, height } = await pngSize(path!);
-  expect(width).toBeGreaterThanOrEqual(1024);
-  expect(height).toBeGreaterThanOrEqual(1024);
+  expect(width).toBe(1024);
+  expect(height).toBe(1024);
 });

--- a/tests/e2e/qr-download.pw.ts
+++ b/tests/e2e/qr-download.pw.ts
@@ -1,0 +1,53 @@
+import { readFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
+import { setPlan } from "./db";
+import { createOrg } from "./orgs";
+
+const password = "test-password-123";
+
+/**
+ * Width and height straight out of the PNG's own IHDR chunk: an 8-byte
+ * signature, then a length and the "IHDR" tag, then width and height as
+ * big-endian uint32s at offsets 16 and 20. Reading the file's real pixels
+ * rather than trusting the filename is the whole point — the preview-sized
+ * export this guards against had a perfectly normal name.
+ */
+async function pngSize(path: string): Promise<{ width: number; height: number }> {
+  const bytes = await readFile(path);
+  expect(bytes.subarray(1, 4).toString("ascii")).toBe("PNG");
+  expect(bytes.subarray(12, 16).toString("ascii")).toBe("IHDR");
+  return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) };
+}
+
+test("a downloaded QR PNG is big enough to print, not preview-sized (#88)", async ({ page }) => {
+  const email = `qr-${Date.now()}@gmail.com`;
+
+  await signUpAndVerify(page, email, password);
+  await createOrg(page, "QR Org");
+  // QR is a paid feature (PLAN_LIMITS.free.qr === false), so the dialog shows
+  // no code at all until the plan allows it.
+  await setPlan(page, email);
+  await page.reload();
+
+  const destination = page.getByPlaceholder("https://example.com/launch").first();
+  await expect(destination).toBeVisible();
+  await destination.fill("example.com/qr-download");
+  await page.getByRole("button", { name: "Create link" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Link created" });
+  await expect(dialog).toBeVisible();
+
+  const download = await Promise.all([
+    page.waitForEvent("download"),
+    dialog.getByRole("button", { name: "PNG" }).click(),
+  ]).then(([event]) => event);
+
+  const path = await download.path();
+  expect(path).toBeTruthy();
+
+  // The preview renders at 208px; exporting from that instance is the bug.
+  const { width, height } = await pngSize(path!);
+  expect(width).toBeGreaterThanOrEqual(1024);
+  expect(height).toBeGreaterThanOrEqual(1024);
+});

--- a/tests/worker/analytics.worker.ts
+++ b/tests/worker/analytics.worker.ts
@@ -39,6 +39,16 @@ async function seedLinkOnExistingOrg() {
   return db;
 }
 
+async function seedClicks(db: ReturnType<typeof drizzle>, timestamps: number[]) {
+  await db.insert(schema.clicks).values(
+    timestamps.map((ts) => ({
+      linkId: "link-1",
+      orgId: "org-1",
+      ts,
+    })),
+  );
+}
+
 beforeEach(applyTestMigrations);
 afterEach(reset);
 
@@ -63,13 +73,7 @@ describe("GET /orgs/:orgId/stats: totalClicks vs totalClicksDelta (#24)", () => 
       t - 500 * DAY_MS,
     ];
 
-    await db.insert(schema.clicks).values(
-      [...currentPeriod, ...previousPeriod, ...ancient].map((ts) => ({
-        linkId: "link-1",
-        orgId: "org-1",
-        ts,
-      })),
-    );
+    await seedClicks(db, [...currentPeriod, ...previousPeriod, ...ancient]);
 
     const res = await getStats(cookie);
     expect(res.status).toBe(200);
@@ -89,13 +93,7 @@ describe("GET /orgs/:orgId/links/stats/:slug: totalClicks vs totalClicksDelta (#
     const previousPeriod = [t - 8 * DAY_MS]; // 1 click
     const ancient = [t - 200 * DAY_MS, t - 300 * DAY_MS];
 
-    await db.insert(schema.clicks).values(
-      [...currentPeriod, ...previousPeriod, ...ancient].map((ts) => ({
-        linkId: "link-1",
-        orgId: "org-1",
-        ts,
-      })),
-    );
+    await seedClicks(db, [...currentPeriod, ...previousPeriod, ...ancient]);
 
     const res = await fetchWorker(
       new Request("http://localhost/api/orgs/org-1/links/stats/sale", {

--- a/tests/worker/analytics.worker.ts
+++ b/tests/worker/analytics.worker.ts
@@ -1,24 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { env } from "cloudflare:workers";
-import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import { reset } from "cloudflare:test";
 import { drizzle } from "drizzle-orm/d1";
-import worker from "../../src/worker";
 import * as schema from "../../src/worker/db/schema";
 import { now } from "../../src/worker/util";
 import {
   applyTestMigrations,
-  authEnv,
+  fetchWorker,
   freeOwnerCookie,
   sampleAddress,
   sampleLink,
 } from "./support";
-
-async function fetchWorker(request: Request): Promise<Response> {
-  const ctx = createExecutionContext();
-  const res = await worker.fetch(request, authEnv(), ctx);
-  await waitOnExecutionContext(ctx);
-  return res;
-}
 
 async function getStats(cookie: string, orgId = "org-1"): Promise<Response> {
   return fetchWorker(

--- a/tests/worker/analytics.worker.ts
+++ b/tests/worker/analytics.worker.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
+import worker from "../../src/worker";
+import * as schema from "../../src/worker/db/schema";
+import { now } from "../../src/worker/util";
+import {
+  applyTestMigrations,
+  authEnv,
+  freeOwnerCookie,
+  sampleAddress,
+  sampleLink,
+} from "./support";
+
+async function fetchWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(request, authEnv(), ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function getStats(cookie: string, orgId = "org-1"): Promise<Response> {
+  return fetchWorker(
+    new Request(`http://localhost/api/orgs/${orgId}/stats`, { headers: { cookie } }),
+  );
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// freeOwnerCookie() already seeds "org-1"; this adds link-1/addr-1 on top of
+// it (unlike seedLink(), which also inserts "org-1" and would collide).
+async function seedLinkOnExistingOrg() {
+  const db = drizzle(env.DB, { schema });
+  await db.batch([
+    db.insert(schema.links).values({ ...sampleLink, createdAt: 0 }),
+    db.insert(schema.linkAddresses).values({ ...sampleAddress, createdAt: 0 }),
+  ]);
+  return db;
+}
+
+beforeEach(applyTestMigrations);
+afterEach(reset);
+
+describe("GET /orgs/:orgId/stats: totalClicks vs totalClicksDelta (#24)", () => {
+  it("only counts clicks inside the selected range, not every click ever", async () => {
+    const cookie = await freeOwnerCookie();
+    const db = await seedLinkOnExistingOrg();
+    const t = now();
+
+    // Free plan's analyticsDays is 7: "current period" is the last 7 days,
+    // "previous period" the 7 days before that, both equal-length.
+    const currentPeriod = [t - 1 * DAY_MS, t - 2 * DAY_MS, t - 3 * DAY_MS]; // 3 clicks
+    const previousPeriod = [t - 8 * DAY_MS, t - 9 * DAY_MS]; // 2 clicks
+    // Clicks from long before either window: with the old unbounded query
+    // these leaked into "totalClicks", making its delta against
+    // totalClicksPrev (a real 7-day window) meaningless.
+    const ancient = [
+      t - 100 * DAY_MS,
+      t - 200 * DAY_MS,
+      t - 300 * DAY_MS,
+      t - 400 * DAY_MS,
+      t - 500 * DAY_MS,
+    ];
+
+    await db.insert(schema.clicks).values(
+      [...currentPeriod, ...previousPeriod, ...ancient].map((ts) => ({
+        linkId: "link-1",
+        orgId: "org-1",
+        ts,
+      })),
+    );
+
+    const res = await getStats(cookie);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.totalClicks).toBe(3);
+    expect(body.totalClicksDelta).toEqual({ current: 3, previous: 2, pct: 50 });
+  });
+});
+
+describe("GET /orgs/:orgId/links/stats/:slug: totalClicks vs totalClicksDelta (#24)", () => {
+  it("only counts clicks inside the selected range, not every click ever", async () => {
+    const cookie = await freeOwnerCookie();
+    const db = await seedLinkOnExistingOrg();
+    const t = now();
+    const currentPeriod = [t - 1 * DAY_MS, t - 2 * DAY_MS]; // 2 clicks
+    const previousPeriod = [t - 8 * DAY_MS]; // 1 click
+    const ancient = [t - 200 * DAY_MS, t - 300 * DAY_MS];
+
+    await db.insert(schema.clicks).values(
+      [...currentPeriod, ...previousPeriod, ...ancient].map((ts) => ({
+        linkId: "link-1",
+        orgId: "org-1",
+        ts,
+      })),
+    );
+
+    const res = await fetchWorker(
+      new Request("http://localhost/api/orgs/org-1/links/stats/sale", {
+        headers: { cookie },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.totalClicks).toBe(2);
+    expect(body.totalClicksDelta).toEqual({ current: 2, previous: 1, pct: 100 });
+  });
+});

--- a/tests/worker/domains.worker.ts
+++ b/tests/worker/domains.worker.ts
@@ -11,9 +11,9 @@ import { adminCookie, applyTestMigrations, authEnv, overrideEnv } from "./suppor
 const realCfEnv = () =>
   overrideEnv({ CF_ZONE_ID: "zone", CF_API_TOKEN: "tok", CF_DEV_ENV: undefined });
 
-// CF_DEV_ENV=1, independent of whatever CF_API_TOKEN/CF_DEV_ENV happen to be
-// in the ambient .dev.vars, so the CF fake is used.
-const fakeCfEnv = () => overrideEnv({ CF_DEV_ENV: "1" });
+// CF_DEV_ENV=simulated, independent of whatever CF_API_TOKEN/CF_DEV_ENV happen
+// to be in the ambient .dev.vars, so the CF fake is used on its timer.
+const fakeCfEnv = () => overrideEnv({ CF_DEV_ENV: "simulated" });
 
 const cfJson = (body: unknown) =>
   new Response(JSON.stringify(body), {

--- a/tests/worker/request-validation.worker.ts
+++ b/tests/worker/request-validation.worker.ts
@@ -1,14 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
 import worker from "../../src/worker";
-import { applyTestMigrations, authEnv, freeOwnerCookie } from "./support";
-
-async function fetchWorker(request: Request): Promise<Response> {
-  const ctx = createExecutionContext();
-  const res = await worker.fetch(request, authEnv(), ctx);
-  await waitOnExecutionContext(ctx);
-  return res;
-}
+import { applyTestMigrations, authEnv, fetchWorker, freeOwnerCookie } from "./support";
 
 async function postJson(cookie: string, path: string, body: unknown): Promise<Response> {
   return fetchWorker(

--- a/tests/worker/request-validation.worker.ts
+++ b/tests/worker/request-validation.worker.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../../src/worker";
+import { applyTestMigrations, authEnv, freeOwnerCookie } from "./support";
+
+async function fetchWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(request, authEnv(), ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function postJson(cookie: string, path: string, body: unknown): Promise<Response> {
+  return fetchWorker(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+beforeEach(applyTestMigrations);
+afterEach(reset);
+
+describe("request body size limit (#19)", () => {
+  it("rejects an oversized JSON body with 413 before the handler runs", async () => {
+    const cookie = await freeOwnerCookie();
+    const res = await postJson(cookie, "/api/orgs", {
+      name: "a".repeat(64 * 1024),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects an oversized QR logo upload with 413", async () => {
+    const cookie = await freeOwnerCookie();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/api/orgs/org-1/qr-logo", {
+        method: "POST",
+        headers: { cookie, "content-type": "image/webp" },
+        body: new Uint8Array(300 * 1024),
+      }),
+      authEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(413);
+  });
+});
+
+describe("org name validation (#19)", () => {
+  it("rejects a name over 100 characters", async () => {
+    const cookie = await freeOwnerCookie();
+    const res = await postJson(cookie, "/api/orgs", { name: "a".repeat(101) });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts a name at exactly 100 characters", async () => {
+    const cookie = await freeOwnerCookie();
+    // free plan's org cap is 1 and this user already owns org-1, so the
+    // request fails on the plan-limit check, not the name: proves the name
+    // itself passed validation.
+    const res = await postJson(cookie, "/api/orgs", { name: "a".repeat(100) });
+    expect(res.status).toBe(402);
+  });
+});
+
+describe("invite creation request validation (#19)", () => {
+  it("rejects an emails array over the cap", async () => {
+    const cookie = await freeOwnerCookie();
+    const emails = Array.from({ length: 51 }, (_, i) => `user${i}@example.com`);
+    const res = await postJson(cookie, "/api/orgs/org-1/invites", { emails });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-array emails field instead of throwing a 500", async () => {
+    const cookie = await freeOwnerCookie();
+    const res = await postJson(cookie, "/api/orgs/org-1/invites", { emails: "not-an-array" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-string element instead of throwing a 500", async () => {
+    const cookie = await freeOwnerCookie();
+    const res = await postJson(cookie, "/api/orgs/org-1/invites", { emails: [123, 456] });
+    expect(res.status).toBe(400);
+  });
+
+  it("still creates a bearer invite when emails is omitted", async () => {
+    const cookie = await freeOwnerCookie();
+    const res = await postJson(cookie, "/api/orgs/org-1/invites", {});
+    expect(res.status).toBe(201);
+  });
+});

--- a/tests/worker/request-validation.worker.ts
+++ b/tests/worker/request-validation.worker.ts
@@ -20,6 +20,16 @@ async function postJson(cookie: string, path: string, body: unknown): Promise<Re
   );
 }
 
+async function postRawBody(cookie: string, path: string, rawBody: string): Promise<Response> {
+  return fetchWorker(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: rawBody,
+    }),
+  );
+}
+
 beforeEach(applyTestMigrations);
 afterEach(reset);
 
@@ -64,6 +74,12 @@ describe("org name validation (#19)", () => {
     const res = await postJson(cookie, "/api/orgs", { name: "a".repeat(100) });
     expect(res.status).toBe(402);
   });
+
+  it("rejects a non-string name with 400 instead of a 500 from calling .trim() on it", async () => {
+    const cookie = await freeOwnerCookie();
+    const res = await postJson(cookie, "/api/orgs", { name: 1 });
+    expect(res.status).toBe(400);
+  });
 });
 
 describe("invite creation request validation (#19)", () => {
@@ -90,5 +106,11 @@ describe("invite creation request validation (#19)", () => {
     const cookie = await freeOwnerCookie();
     const res = await postJson(cookie, "/api/orgs/org-1/invites", {});
     expect(res.status).toBe(201);
+  });
+
+  it("rejects malformed JSON with 400 instead of silently creating a bearer invite", async () => {
+    const cookie = await freeOwnerCookie();
+    const res = await postRawBody(cookie, "/api/orgs/org-1/invites", "{not valid json");
+    expect(res.status).toBe(400);
   });
 });

--- a/tests/worker/security-headers.worker.ts
+++ b/tests/worker/security-headers.worker.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
 import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
 import worker from "../../src/worker";
+import { applySecurityHeaders } from "../../src/worker/security-headers";
 import type { Env } from "../../src/worker/env";
 import { applyTestMigrations, overrideEnv } from "./support";
 
@@ -60,6 +61,28 @@ describe("security headers (#21)", () => {
 
   it("applies to a 404 SPA fallback response", async () => {
     const res = await fetchWorker(new Request("http://localhost/no-such-page"));
+    expectSecurityHeaders(res);
+  });
+
+  // Regression: applySecurityHeaders used to write straight onto the
+  // response it was handed, which throws "Can't modify immutable headers"
+  // for anything the ASSETS binding returns (every static file, so the whole
+  // SPA) and for Response.redirect.
+  //
+  // The SPA-fallback test above cannot catch this: there is no built asset
+  // bundle in this environment, so app.all("*") never reaches a real
+  // env.ASSETS.fetch response and the fallback it does return has mutable
+  // headers. Only the e2e smoke test exercises the real binding, which is
+  // where this first showed up. Response.redirect gives us the same
+  // immutable Headers guard here, deterministically and with no bundle.
+  it("works on a response whose headers are immutable", () => {
+    const immutable = Response.redirect("https://example.com/", 302);
+    expect(() => immutable.headers.set("x-probe", "1")).toThrow();
+
+    const res = applySecurityHeaders(immutable);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://example.com/");
     expectSecurityHeaders(res);
   });
 

--- a/tests/worker/security-headers.worker.ts
+++ b/tests/worker/security-headers.worker.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../../src/worker";
+import type { Env } from "../../src/worker/env";
+import { applyTestMigrations, overrideEnv } from "./support";
+
+async function fetchWorker(request: Request, testEnv: Env = env as Env): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request, testEnv, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+const HEADER_NAMES = [
+  "content-security-policy",
+  "x-content-type-options",
+  "referrer-policy",
+  "permissions-policy",
+];
+
+function expectSecurityHeaders(res: Response) {
+  for (const name of HEADER_NAMES) expect(res.headers.get(name)).toBeTruthy();
+  expect(res.headers.get("content-security-policy")).toContain("script-src 'self'");
+}
+
+beforeEach(applyTestMigrations);
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await reset();
+});
+
+describe("security headers (#21)", () => {
+  it("applies to a successful redirect", async () => {
+    await env.DB.batch([
+      env.DB.prepare("insert into orgs (id, name, created_at) values (?, ?, ?)").bind(
+        "org-1",
+        "Test org",
+        0,
+      ),
+      env.DB.prepare(
+        "insert into links (id, org_id, slug, destination, created_at) values (?, ?, ?, ?, ?)",
+      ).bind("link-1", "org-1", "summer", "https://example.com/sale", 0),
+    ]);
+    await env.LINKS.put(
+      "slug:summer",
+      JSON.stringify({ linkId: "link-1", orgId: "org-1", url: "https://example.com/sale" }),
+    );
+
+    const res = await fetchWorker(new Request("http://localhost/summer", { redirect: "manual" }));
+    expect(res.status).toBe(302);
+    expectSecurityHeaders(res);
+  });
+
+  it("applies to an HTTPException error response", async () => {
+    const res = await fetchWorker(new Request("http://localhost/api/billing/portal"));
+    expect(res.status).toBe(401); // requireUser, no session cookie
+    expectSecurityHeaders(res);
+  });
+
+  it("applies to a 404 SPA fallback response", async () => {
+    const res = await fetchWorker(new Request("http://localhost/no-such-page"));
+    expectSecurityHeaders(res);
+  });
+
+  it("never overrides headers on the reverse-proxied blog", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("<html></html>", { headers: { "content-type": "text/html" } }),
+    );
+    const testEnv = overrideEnv({ BLOG_ORIGIN_URL: "https://rdyrct-blog.vercel.app" });
+
+    const res = await fetchWorker(new Request("http://localhost/blog/hello-world"), testEnv);
+
+    expect(res.headers.get("content-security-policy")).toBeNull();
+  });
+});

--- a/tests/worker/security-headers.worker.ts
+++ b/tests/worker/security-headers.worker.ts
@@ -1,17 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:workers";
-import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
-import worker from "../../src/worker";
+import { reset } from "cloudflare:test";
 import { applySecurityHeaders } from "../../src/worker/security-headers";
-import type { Env } from "../../src/worker/env";
-import { applyTestMigrations, overrideEnv } from "./support";
-
-async function fetchWorker(request: Request, testEnv: Env = env as Env): Promise<Response> {
-  const ctx = createExecutionContext();
-  const response = await worker.fetch(request, testEnv, ctx);
-  await waitOnExecutionContext(ctx);
-  return response;
-}
+import { applyTestMigrations, fetchWorker, overrideEnv } from "./support";
 
 const HEADER_NAMES = [
   "content-security-policy",

--- a/tests/worker/support.ts
+++ b/tests/worker/support.ts
@@ -27,6 +27,23 @@ export function overrideEnv(overrides: Partial<Env>): Env {
 // sign-in's rate-limit key derivation has a key to HMAC with.
 export const authEnv = () => overrideEnv({ BETTER_AUTH_SECRET: "test-secret" });
 
+/**
+ * Drive one request through the real worker and wait for anything it
+ * deferred with waitUntil (click enqueues, storage sends) before returning,
+ * so a test can assert on those without racing them.
+ *
+ * Defaults to authEnv() rather than the ambient env: it is the same binding
+ * with a known BETTER_AUTH_SECRET, which is what cookies from
+ * signInCookie()/adminCookie() are signed against. Tests needing a different
+ * binding pass one.
+ */
+export async function fetchWorker(request: Request, testEnv: Env = authEnv()): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request, testEnv, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
 // Deterministic Polar product ids and webhook secret for billing tests,
 // independent of the ambient .dev.vars. Keeps the same auth secret as
 // authEnv() so a cookie minted via signInCookie()/adminCookie() still

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types"],
+    "types": ["@cloudflare/workers-types", "vite/client"],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -221,7 +221,10 @@
         "POLAR_PRO_PRODUCT_ID": "playwright_pro_product",
         "POLAR_HOBBY_PRODUCT_ID": "playwright_hobby_product",
         "CF_ZONE_ID": "",
-        "CF_DEV_ENV": "1",
+        // "instant", not "1": the e2e suite asserts a domain reaches active,
+        // so the staged DNS/TLS delays local dev shows off would only be a
+        // timer for the test to race.
+        "CF_DEV_ENV": "instant",
         // env vars aren't inherited from the top-level "vars": both left
         // unset (alerts/blog proxy no-op) so e2e never calls out to Better
         // Stack or the real blog origin.


### PR DESCRIPTION
## Summary

Fixes three issues from the staff-engineer audit, plus two production bugs the new tests uncovered along the way.

- **#24** — The "Total clicks" stat on both the org analytics page and the per-link detail page queried an unbounded all-time click count, then compared it against a real N-day previous-period count for the delta badge. The delta compared mismatched-duration windows and could show a nonsensical percentage. Both routes now bound the current-period total to the same window as the previous period.
- **#21** — A global security-header baseline (CSP, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) applied by one Worker middleware to every response — API, redirects, errors, and the SPA/asset fallback — rather than per-route. The reverse-proxied blog (`/blog/*`, a separate Next.js app on Vercel) is excluded so its own headers aren't clobbered. The one inline `<script>` this app had (the pre-paint theme bootstrap) moved to `/theme-init.js`, so `script-src` needs no `unsafe-inline`.
- **#19** — A 32KB request body limit on every JSON API route, with the QR-logo upload keeping its own larger limit. Plus two validation gaps: org names had no server-side max length (now 100, matching the client's valibot schema), and invite creation didn't check that `emails` was an array of strings or cap its size, so a malformed body 500'd instead of 400'ing.

## Two bugs the CSP work introduced, and how they were caught

Both would have broken the app for every visitor, and both passed the entire worker suite.

1. **`applySecurityHeaders` mutated the response in place.** Responses from the ASSETS binding carry an immutable `Headers` guard, so every static file request threw `Can't modify immutable headers` — in production, the whole SPA failing to load. It now returns a copy, and the middleware assigns it back (returning it wouldn't work: after `next()` the context is finalized, and hono's compose only adopts a returned response while it isn't).
2. **`script-src 'self'` blocked Vite's inline React Refresh preamble**, so the SPA rendered nothing under `vite dev`. Built bundles have no preamble, so the allowance is compiled out via `import.meta.env.DEV` — a build-time constant, so a deployed Worker can't ship `'unsafe-inline'` through a misread var.

The worker test environment has no built asset bundle, so it never reaches a real `env.ASSETS.fetch` response — its SPA-fallback test was passing against a mutable-header stand-in. The regression test now uses `Response.redirect`, which carries the same immutable guard deterministically.

## Testing the policy that actually ships

Nothing exercised the production CSP: worker tests run no browser, and e2e runs against `vite dev`, whose policy is deliberately looser. That gap is what let the two bugs above through.

This adds a **`production` Playwright project** running against `vite preview` — the built worker and built assets. The build is part of the webServer command so the suite can't assert against a stale `dist/`. Violations come from the `securitypolicyviolation` event rather than console scraping: it's the specified signal and fires before the request goes out, so assertions hold with no outbound network in CI.

Three of the four tests passed on first run, which usefully **ruled out** a suspected `img-src`/`blob:` problem with `qr-code-styling` — the landing page exercises its render path for real.

The fourth failed, and found a live production bug: **posthog-js doesn't bundle its optional features.** It builds `<assets host>/static/<name>.js` and injects it via `createElement("script")` on first use, and `lib/posthog.ts` enables `capture_exceptions`, which is one of them. `connect-src` and `img-src` already allowlisted PostHog; `script-src` didn't — so exception capture was dead in production while every check stayed green. Adding the host makes the existing allowances coherent; the shipped policy still carries no `'unsafe-inline'` on `script-src`, verified against the built output.

## Unrelated: QR download resolution (#88)

Folded in on request rather than held for its own branch, so flagging it explicitly.

The download button reused the preview's `QRCodeStyling` instance, and the library rasterizes to a canvas at that instance's own width/height — so PNGs exported at ~208px, roughly 17mm at print resolution. Downloads now come from a throwaway instance at 1024px rather than resizing the visible one (which would make the preview jump). The margin moves with it: `qr-code-styling` takes margin in pixels, so the fixed `8` would have left a 1024px code with almost no quiet zone; it's now a ratio giving exactly 8 at the 208px default, so the preview is unchanged.

Also corrects `AGENTS.md`, which put the QR logo cap at 2 MB. The real limits are 256 KB (`QR_LOGO_MAX_BYTES`) and 512 px per side (`QR_LOGO_MAX_DIMENSION`) — the 512 is pixels, not kilobytes.

## Scope note on #19

This covers the clearest, most exposed gaps. A full migration of every route's ad hoc validation to schemas is larger follow-up work: most routes already have hand-written validation with product-specific error copy that existing tests depend on, so wholesale replacement risked behaviour drift for little safety gain once body limits are in place.

## Test plan

- [x] Rebased onto `main` after #61 merged; the `billing.ts` import collision resolved keeping both `alertBetterStack` and `jsonBodyLimit`, and #61's freshness-guard work verified intact with no ledger remnants
- [x] `bun run verify` clean — 131 worker tests, 140 unit tests
- [x] `bun run e2e:smoke` — 17 passed across both projects
- [x] Each new guard confirmed to **fail** with its fix disabled: the immutable-header test, the PostHog script-src test, and the QR PNG test (which reported 208 against the old code)
- [x] Production CSP header verified against the built output: `script-src 'self' https://*.posthog.com`, no `'unsafe-inline'`
- [x] react-doctor 100/100; fallow back at `main`'s baseline (189 lines / 6 files) after sharing `fetchWorker` and the legal-page walk instead of copying them
- [ ] Blog proxy and custom-domain redirects are production-only checks — `BLOG_ORIGIN_URL` is empty in both dev and the playwright env, so the `/blog/*` header exemption has never run against a real origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent dark-theme initialization, with support for explicitly saved light mode.
  * Added stronger browser security protections.
  * Added request-size limits for JSON payloads and QR-logo uploads.
  * QR logos now support files up to 256 KB and 512 px per side.
  * QR code downloads now export high-resolution 1024×1024 PNGs.

* **Bug Fixes**
  * Analytics totals now respect the selected reporting period.
  * Improved validation and handling of invalid, malformed, and oversized requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
