### PR TITLE
Store referrer hostnames only, cap email sends per recipient, and make verify run e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
           bun-version: 1.3.4
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Static checks and unit tests
-        run: bun run verify
+      # Before verify, not after: verify now ends with the browser smoke
+      # test, which needs this file to start the dev server.
       - name: Configure browser test environment
         run: cp .dev.vars.example .dev.vars
-      - name: Browser smoke test
-        run: bun run e2e:smoke
+      - name: Static checks, unit tests, and browser smoke test
+        run: bun run verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,20 @@ without wrangler CLI calls).
 bun run check                          # app + shared (tsconfig.json → src/app, src/shared)
 bunx tsc -p tsconfig.worker.json --noEmit   # worker (src/worker)
 bun run test                           # unit tests (bun test, tests/)
+bun run test:worker                    # worker tests (vitest-pool-workers, tests/worker/)
+bun run e2e:smoke                      # browser tests (playwright, tests/e2e/); needs .dev.vars
+bun run verify                         # all of the above, in order: the gate
 bun run doctor                         # react-doctor audit (React health score; --verbose for details)
 bun run fallow                         # fallow codebase intelligence audit
 ```
+
+**`bun run verify` ends with the browser tests, and every new feature ships
+with an e2e scenario.** Both are rules, not suggestions. The worker test
+environment has no built asset bundle, so it never touches the real `ASSETS`
+binding: checks that stop at `test` and `test:worker` have already let two
+bugs through that broke the app for every visitor. Green means the app runs
+in a browser, or it means nothing. Add a `tests/e2e/*.pw.ts` scenario
+alongside the feature, in the same commit.
 
 react-doctor runs in CI through `.github/workflows/react-doctor.yml` (advisory,
 PRs + main). Run fallow locally when auditing codebase health; track its

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@types/topojson-client": "^3.1.5",
+        "@types/topojson-specification": "^1.0.5",
         "@vitejs/plugin-react": "^6.0.4",
         "bun-types": "^1.3.14",
         "drizzle-kit": "^0.31.10",

--- a/migrations/0016_normalize_click_referrers.sql
+++ b/migrations/0016_normalize_click_referrers.sql
@@ -19,6 +19,20 @@
 -- Best effort by design: a value this cannot reduce to something
 -- hostname-shaped is emptied rather than kept, matching normalizeReferrer,
 -- which returns "" rather than guessing.
+--
+-- The closing filters mirror isReportableHost() in src/worker/util.ts, so a
+-- row that survives this is a row ingestion would accept today. Change one
+-- and change the other, or the table keeps referrers the live path refuses.
+
+-- A referrer arrives over http(s). Anything else (data:, javascript:, ftp:,
+-- an app's custom scheme) is not a site we can name, and normalizeReferrer
+-- refuses it. Clear those first: after the scheme strip below,
+-- "ftp://collector.example" is indistinguishable from a real hostname.
+UPDATE clicks SET referrer = ''
+  WHERE referrer <> ''
+    AND instr(referrer, '://') > 0
+    AND lower(referrer) NOT LIKE 'http://%'
+    AND lower(referrer) NOT LIKE 'https://%';
 
 -- scheme: "https://host/..." -> "host/..."
 UPDATE clicks SET referrer = substr(referrer, instr(referrer, '://') + 3)
@@ -43,8 +57,32 @@ UPDATE clicks SET referrer = substr(referrer, 1, instr(referrer, ':') - 1)
 
 UPDATE clicks SET referrer = lower(referrer) WHERE referrer <> '';
 
--- Anything that is still not hostname-shaped (no dot, a space, or longer
--- than DNS allows) was never a site name we could report on.
+-- Anything still not hostname-shaped was never a site name we could report
+-- on: too long for DNS, no dot (a bare word like "localhost"), an empty
+-- label from a leading, trailing, or doubled dot, or a character a hostname
+-- cannot hold. The GLOB carries the character rule, and rejects control
+-- characters, spaces, and stray punctuation in one pass; it runs after the
+-- lower() above, so an uppercase letter here really is a leftover.
 UPDATE clicks SET referrer = ''
   WHERE referrer <> ''
-    AND (instr(referrer, '.') = 0 OR instr(referrer, ' ') > 0 OR length(referrer) > 253);
+    AND (length(referrer) > 253
+      OR instr(referrer, '.') = 0
+      OR instr(referrer, '..') > 0
+      OR referrer LIKE '.%'
+      OR referrer LIKE '%.'
+      OR referrer GLOB '*[^a-z0-9.-]*');
+
+-- The one rule the filters above cannot express: no single label may run
+-- past 63 characters. GLOB cannot say "64 characters that are not a dot"
+-- (SQLite rejects that pattern as too complex), so peel the labels off one
+-- at a time and measure them. The trailing '.' the seed row appends gives
+-- the last label a delimiter to be found by, so it is measured like the
+-- rest.
+WITH RECURSIVE labels(id, rest, label) AS (
+  SELECT id, referrer || '.', '' FROM clicks WHERE referrer <> ''
+  UNION ALL
+  SELECT id, substr(rest, instr(rest, '.') + 1), substr(rest, 1, instr(rest, '.') - 1)
+    FROM labels WHERE instr(rest, '.') > 0
+)
+UPDATE clicks SET referrer = ''
+  WHERE id IN (SELECT id FROM labels WHERE length(label) > 63);

--- a/migrations/0016_normalize_click_referrers.sql
+++ b/migrations/0016_normalize_click_referrers.sql
@@ -1,0 +1,50 @@
+-- Reduce stored referrers to a bare hostname (issue #20).
+--
+-- Ingestion stored the Referer header verbatim, so rows written before this
+-- hold whole URLs: other people's paths and query strings, which can carry
+-- search terms, session tokens, and account identifiers. None of that is
+-- ours to keep, and it sits for the full 400-day click retention.
+-- normalizeReferrer() in src/worker/util.ts stops new rows from looking
+-- like this; these statements fix the ones already written.
+--
+-- 0016, not 0015: a branch in flight also claims 0015.
+--
+-- SQLite has no URL parser, so this peels one delimiter at a time. Order
+-- matters: strip the scheme, then everything from the first fragment/query/
+-- path delimiter onward, which leaves at most `user:pass@host:port`, then
+-- the credentials, then the port. Each statement is a no-op on a value that
+-- doesn't contain its delimiter, so already-normalized rows pass through
+-- untouched and re-running is harmless.
+--
+-- Best effort by design: a value this cannot reduce to something
+-- hostname-shaped is emptied rather than kept, matching normalizeReferrer,
+-- which returns "" rather than guessing.
+
+-- scheme: "https://host/..." -> "host/..."
+UPDATE clicks SET referrer = substr(referrer, instr(referrer, '://') + 3)
+  WHERE referrer <> '' AND instr(referrer, '://') > 0;
+
+-- fragment, then query, then path
+UPDATE clicks SET referrer = substr(referrer, 1, instr(referrer, '#') - 1)
+  WHERE referrer <> '' AND instr(referrer, '#') > 0;
+UPDATE clicks SET referrer = substr(referrer, 1, instr(referrer, '?') - 1)
+  WHERE referrer <> '' AND instr(referrer, '?') > 0;
+UPDATE clicks SET referrer = substr(referrer, 1, instr(referrer, '/') - 1)
+  WHERE referrer <> '' AND instr(referrer, '/') > 0;
+
+-- credentials: "user:pass@host" -> "host". Before the port strip, so the
+-- colon inside the credentials is already gone by then.
+UPDATE clicks SET referrer = substr(referrer, instr(referrer, '@') + 1)
+  WHERE referrer <> '' AND instr(referrer, '@') > 0;
+
+-- port
+UPDATE clicks SET referrer = substr(referrer, 1, instr(referrer, ':') - 1)
+  WHERE referrer <> '' AND instr(referrer, ':') > 0;
+
+UPDATE clicks SET referrer = lower(referrer) WHERE referrer <> '';
+
+-- Anything that is still not hostname-shaped (no dot, a space, or longer
+-- than DNS allows) was never a site name we could report on.
+UPDATE clicks SET referrer = ''
+  WHERE referrer <> ''
+    AND (instr(referrer, '.') = 0 OR instr(referrer, ' ') > 0 OR length(referrer) > 253);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:worker": "vitest run --config vitest.config.ts",
     "e2e:install": "playwright install chromium",
     "e2e:smoke": "playwright test",
-    "verify": "bun run check && bunx tsc -p tsconfig.worker.json --noEmit && bun run lint && bun run format:check && bun run test && bun run test:worker",
+    "verify": "bun run check && bunx tsc -p tsconfig.worker.json --noEmit && bun run lint && bun run format:check && bun run test && bun run test:worker && bun run e2e:smoke",
     "deploy": "bun run build && wrangler deploy",
     "db:migrate:local": "wrangler d1 migrations apply rdyrct --local",
     "db:reset:local": "rm -rf .wrangler/state/v3/d1 .wrangler/state/v3/kv && wrangler d1 migrations apply rdyrct --local",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/topojson-client": "^3.1.5",
+    "@types/topojson-specification": "^1.0.5",
     "@vitejs/plugin-react": "^6.0.4",
     "bun-types": "^1.3.14",
     "drizzle-kit": "^0.31.10",

--- a/src/worker/clicks.ts
+++ b/src/worker/clicks.ts
@@ -3,7 +3,7 @@ import { drizzle } from "drizzle-orm/d1";
 import * as schema from "./db/schema";
 import type { AppEnv, Env } from "./env";
 import type { KVLink } from "./kv";
-import { now, deviceFromUA } from "./util";
+import { now, deviceFromUA, normalizeReferrer } from "./util";
 import { clickAnalyticsAllowed } from "./rate-limit";
 import { alertBetterStack } from "./alerts";
 
@@ -68,7 +68,9 @@ export async function enqueueClick(c: Context<AppEnv>, hit: KVLink): Promise<voi
       orgId: hit.orgId,
       ts: now(),
       country: (c.req.raw.cf?.country as string) ?? "",
-      referrer: c.req.header("referer") ?? "",
+      // Hostname only, never the full URL the header carries: see
+      // normalizeReferrer in util.ts and issue #20.
+      referrer: normalizeReferrer(c.req.header("referer") ?? ""),
       device: deviceFromUA(c.req.header("user-agent") ?? ""),
     };
     await c.env.CLICK_QUEUE.send(message);

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -18,6 +18,7 @@ export interface Env {
   CLICK_QUEUE: Queue<ClickMessage>;
   RL_AUTH_PUBLIC: RateLimit;
   RL_EMAIL: RateLimit;
+  RL_EMAIL_RECIPIENT: RateLimit;
   RL_WRITE_FREE: RateLimit;
   RL_WRITE_PAID: RateLimit;
   RL_QR_UPLOAD: RateLimit;

--- a/src/worker/rate-limit.ts
+++ b/src/worker/rate-limit.ts
@@ -68,12 +68,10 @@ function hex(bytes: ArrayBuffer): string {
   return Array.from(new Uint8Array(bytes), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-/** Builds an ephemeral public-client key without exposing an IP address to
- * application storage or logs. The HMAC output exists only in Cloudflare's
- * rate-limit counter. */
-export async function publicClientKey(request: Request, secret: string): Promise<string> {
-  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
-  const address = request.headers.get("cf-connecting-ip") ?? forwarded ?? "unknown";
+/** Keyed HMAC over `value`. The digest is the only form an identifier takes
+ * once it leaves the request: what ends up in a rate-limit counter is never
+ * the address itself. */
+async function keyedDigest(secret: string, value: string): Promise<string> {
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
     "raw",
@@ -82,7 +80,39 @@ export async function publicClientKey(request: Request, secret: string): Promise
     false,
     ["sign"],
   );
-  return hex(await crypto.subtle.sign("HMAC", key, encoder.encode(address)));
+  return hex(await crypto.subtle.sign("HMAC", key, encoder.encode(value)));
+}
+
+/** Builds an ephemeral public-client key without exposing an IP address to
+ * application storage or logs. The HMAC output exists only in Cloudflare's
+ * rate-limit counter. */
+export async function publicClientKey(request: Request, secret: string): Promise<string> {
+  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const address = request.headers.get("cf-connecting-ip") ?? forwarded ?? "unknown";
+  return keyedDigest(secret, address);
+}
+
+/**
+ * The address an email-sending auth route would deliver to, hashed, or null
+ * when the request names none.
+ *
+ * Clones before reading: BetterAuth is handed `c.req.raw` afterwards and
+ * needs its body stream untouched. A body we can't read (missing, not JSON,
+ * no `email`) yields null and the recipient limit simply doesn't apply,
+ * since there is no recipient to protect.
+ */
+async function recipientKey(request: Request, secret: string): Promise<string | null> {
+  let parsed: unknown;
+  try {
+    parsed = await request.clone().json();
+  } catch {
+    return null;
+  }
+  const email = (parsed as { email?: unknown } | null)?.email;
+  if (typeof email !== "string") return null;
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) return null;
+  return keyedDigest(secret, normalized);
 }
 
 export function publicAuthGroup(path: string): "auth" | "email" | null {
@@ -105,7 +135,29 @@ export async function enforcePublicAuthRateLimit(c: Context<AppEnv>): Promise<Re
     group,
     method: c.req.method,
   });
-  return allowed ? null : rateLimitedResponse(c, group);
+  if (!allowed) return rateLimitedResponse(c, group);
+
+  // Second, independent budget for the routes that put mail in someone's
+  // inbox, counted against the recipient instead of the caller (#50). The
+  // per-caller limit above does nothing when the callers are many and the
+  // target is one: distributed requests each stay under it while the same
+  // address absorbs all of them.
+  //
+  // Deliberately the same 429 as the caller limit: which budget ran out is
+  // not something an anonymous caller gets to learn, or asking "did this
+  // address just get throttled?" would answer "does this address exist?".
+  if (group === "email") {
+    const recipient = await recipientKey(c.req.raw, c.env.BETTER_AUTH_SECRET);
+    if (recipient) {
+      const withinRecipientBudget = await rateLimitAllows(
+        c.env.RL_EMAIL_RECIPIENT,
+        `email-recipient:${recipient}`,
+        { group, method: c.req.method },
+      );
+      if (!withinRecipientBudget) return rateLimitedResponse(c, group);
+    }
+  }
+  return null;
 }
 
 export function signedApiGroup(

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -190,6 +190,42 @@ export function isDisposableEmail(email: string): boolean {
   return DISPOSABLE_EMAIL_DOMAINS.has(domain);
 }
 
+/**
+ * The longest hostname the DNS spec allows. A referrer longer than this is
+ * not a hostname we failed to shorten, it's junk, so it stores as "".
+ */
+const REFERRER_MAX_LENGTH = 253;
+
+/**
+ * What a click may remember about where it came from: a bare lowercase
+ * hostname, or "" for direct and for anything we can't read (see issue #20).
+ *
+ * A raw Referer header is a whole URL, and other people's URLs carry search
+ * terms, session tokens, and account identifiers in their paths and query
+ * strings. None of that is ours to keep, and storing it would contradict the
+ * promise the analytics page makes. `URL.hostname` drops the path, query,
+ * fragment, port, and any user:password credentials in one step; everything
+ * else here rejects rather than repairs.
+ *
+ * Applied when the click is recorded, not when it's read: the read path
+ * cannot un-store what ingestion already wrote down.
+ */
+export function normalizeReferrer(referrer: string): string {
+  if (!referrer) return "";
+  let url: URL;
+  try {
+    url = new URL(referrer);
+  } catch {
+    return "";
+  }
+  // A referrer arrives over http(s). Anything else (data:, javascript:,
+  // file:, an app's custom scheme) is not a site we can name.
+  if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+  const host = url.hostname.toLowerCase();
+  if (!host || host.length > REFERRER_MAX_LENGTH) return "";
+  return host;
+}
+
 export function normalizeUrl(value: string): string {
   return /^https?:\/\//i.test(value) ? value : `https://${value}`;
 }

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -196,6 +196,33 @@ export function isDisposableEmail(email: string): boolean {
  */
 const REFERRER_MAX_LENGTH = 253;
 
+/** The longest single dot-separated label DNS allows. */
+const REFERRER_MAX_LABEL_LENGTH = 63;
+
+/**
+ * What a stored referrer may look like: lowercase letters, digits, hyphens,
+ * and the dots between labels. Unicode domains arrive from `URL.hostname`
+ * already punycoded (`xn--…`), so they fit without an exception.
+ *
+ * Migration 0016 applies the same shape to the rows written before this
+ * existed. Keep the two in step: a value one accepts and the other clears
+ * would leave the table holding referrers ingestion would now refuse.
+ */
+const REFERRER_ALLOWED_CHARS = /^[a-z0-9.-]+$/;
+
+/**
+ * True when `host` is shaped like a name we could report on: within the DNS
+ * length limits, no empty labels (so no leading, trailing, or doubled dot),
+ * and at least one dot, which rules out bare words like "localhost".
+ */
+function isReportableHost(host: string): boolean {
+  if (host.length > REFERRER_MAX_LENGTH) return false;
+  if (!REFERRER_ALLOWED_CHARS.test(host)) return false;
+  const labels = host.split(".");
+  if (labels.length < 2) return false;
+  return labels.every((label) => label.length > 0 && label.length <= REFERRER_MAX_LABEL_LENGTH);
+}
+
 /**
  * What a click may remember about where it came from: a bare lowercase
  * hostname, or "" for direct and for anything we can't read (see issue #20).
@@ -222,7 +249,7 @@ export function normalizeReferrer(referrer: string): string {
   // file:, an app's custom scheme) is not a site we can name.
   if (url.protocol !== "http:" && url.protocol !== "https:") return "";
   const host = url.hostname.toLowerCase();
-  if (!host || host.length > REFERRER_MAX_LENGTH) return "";
+  if (!isReportableHost(host)) return "";
   return host;
 }
 

--- a/tests/e2e/db.ts
+++ b/tests/e2e/db.ts
@@ -16,6 +16,27 @@ export async function rawSql(page: Page, sql: string, params: unknown[] = []): P
   return response.json();
 }
 
+/**
+ * Runs a SELECT and returns its rows as objects.
+ *
+ * The Explorer's /raw endpoint answers column-oriented
+ * (`{ columns: [...], rows: [[...]] }`), which is easy to misread as a list
+ * of row objects: indexing one by column name yields `undefined` rather than
+ * an error, so the mistake surfaces later as a confusing assertion failure.
+ * Callers get objects instead.
+ */
+export async function queryRows<T extends Record<string, unknown>>(
+  page: Page,
+  sql: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  const body = (await rawSql(page, sql, params)) as {
+    result: { results: { columns: string[]; rows: unknown[][] } }[];
+  };
+  const { columns, rows } = body.result[0].results;
+  return rows.map((row) => Object.fromEntries(columns.map((c, i) => [c, row[i]])) as T);
+}
+
 export async function setPlan(page: Page, email: string, plan: "hobby" | "pro" = "hobby") {
   const result = (await rawSql(page, "UPDATE user SET plan = ? WHERE email = ?", [
     plan,

--- a/tests/e2e/privacy-and-email-abuse.pw.ts
+++ b/tests/e2e/privacy-and-email-abuse.pw.ts
@@ -81,15 +81,20 @@ test("a click records the referring host, never the URL it came from (#20)", asy
 test("one address cannot be mailed without limit by many callers (#50)", async ({ page }) => {
   const victim = `victim-${Date.now()}@gmail.com`;
 
-  // Every request looks like a different caller as far as the per-caller
-  // budget is concerned; only the recipient is shared. Without a
-  // recipient-keyed limit every one of these would be accepted.
+  // Each attempt claims its own caller address, which the worker reads from
+  // cf-connecting-ip. That is what makes this a test of the recipient budget:
+  // no caller's own budget is spent twice, so the per-caller limit cannot be
+  // what refuses, and without a recipient-keyed limit every one of these
+  // would be accepted.
   const statuses: number[] = [];
   for (let attempt = 0; attempt < 6; attempt++) {
     const response = await page.request.post(
       `${appUrl}/api/auth/email-otp/request-password-reset`,
       {
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          "cf-connecting-ip": `203.0.113.${10 + attempt}`,
+        },
         data: { email: victim },
         failOnStatusCode: false,
       },
@@ -98,5 +103,9 @@ test("one address cannot be mailed without limit by many callers (#50)", async (
     if (response.status() === 429) break;
   }
 
-  expect(statuses).toContain(429);
+  // Refused on the fourth, not merely somewhere: RL_EMAIL_RECIPIENT allows 3
+  // a minute in this environment, so the position of the 429 is what names
+  // which budget ran out. Anything later would mean the recipient limit let
+  // a fourth send through.
+  expect(statuses.indexOf(429)).toBe(3);
 });

--- a/tests/e2e/privacy-and-email-abuse.pw.ts
+++ b/tests/e2e/privacy-and-email-abuse.pw.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Page } from "@playwright/test";
+import { appUrl } from "./environment";
+import { queryRows } from "./db";
+import { signUpAndVerify } from "./resend";
+import { createOrg } from "./orgs";
+
+const password = "test-password-123";
+
+/** Creates a quick link and returns its slug. The slug comes from D1 rather
+ * than from the dialog's text: shared-domain slugs are generated, so there
+ * is nothing to predict, and scraping the rendered URL out of surrounding
+ * copy is the brittle part of this test, not the part under test. */
+async function createQuickLink(page: Page): Promise<string> {
+  const destination = page.getByPlaceholder("https://example.com/launch").first();
+  await expect(destination).toBeVisible();
+  await destination.fill("example.com/referrer-privacy");
+  await page.getByRole("button", { name: "Create link" }).click();
+  await expect(page.getByRole("dialog", { name: "Link created" })).toBeVisible();
+
+  const rows = await queryRows<{ slug: string }>(
+    page,
+    "SELECT slug FROM links WHERE destination LIKE '%referrer-privacy%' ORDER BY created_at DESC LIMIT 1",
+  );
+  const slug = rows[0]?.slug;
+  expect(slug).toBeTruthy();
+  return slug!;
+}
+
+test("a click records the referring host, never the URL it came from (#20)", async ({ page }) => {
+  const email = `referrer-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, email, password);
+  await createOrg(page, "Referrer Org");
+  const slug = await createQuickLink(page);
+
+  // A real referring URL: the path and query are the parts that carry other
+  // people's search terms and session tokens, and neither may be stored.
+  // Publishing the slug to KV rides the storage queue, so the redirect goes
+  // live a moment after the row exists. Poll rather than assume.
+  await expect
+    .poll(
+      async () =>
+        (
+          await page.request.get(`${appUrl}/${slug}`, {
+            headers: {
+              referer: "https://forum.example.com/threads/42?q=private+search&token=secret",
+            },
+            maxRedirects: 0,
+          })
+        ).status(),
+      // Generous: the local storage queue batches on a 5s timeout, so the
+      // default 5s poll window is exactly the flaky boundary.
+      { message: "slug never became a live redirect", timeout: 30_000 },
+    )
+    .toBe(302);
+
+  // The click rides a queue, so wait for the consumer rather than assuming
+  // it has already landed.
+  await expect
+    .poll(
+      async () => {
+        const rows = await queryRows<{ referrer: string }>(
+          page,
+          "SELECT referrer FROM clicks ORDER BY id DESC LIMIT 1",
+        );
+        return rows[0]?.referrer ?? null;
+      },
+      { message: "click never reached the clicks table", timeout: 30_000 },
+    )
+    .toBe("forum.example.com");
+
+  const stored = await queryRows<{ referrer: string }>(page, "SELECT referrer FROM clicks");
+  expect(stored.length).toBeGreaterThan(0);
+  for (const row of stored) {
+    expect(row.referrer).not.toContain("secret");
+    expect(row.referrer).not.toContain("private");
+    expect(row.referrer).not.toContain("/");
+    expect(row.referrer).not.toContain("?");
+  }
+});
+
+test("one address cannot be mailed without limit by many callers (#50)", async ({ page }) => {
+  const victim = `victim-${Date.now()}@gmail.com`;
+
+  // Every request looks like a different caller as far as the per-caller
+  // budget is concerned; only the recipient is shared. Without a
+  // recipient-keyed limit every one of these would be accepted.
+  const statuses: number[] = [];
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const response = await page.request.post(
+      `${appUrl}/api/auth/email-otp/request-password-reset`,
+      {
+        headers: { "content-type": "application/json" },
+        data: { email: victim },
+        failOnStatusCode: false,
+      },
+    );
+    statuses.push(response.status());
+    if (response.status() === 429) break;
+  }
+
+  expect(statuses).toContain(429);
+});

--- a/tests/worker/email-recipient-limit.worker.ts
+++ b/tests/worker/email-recipient-limit.worker.ts
@@ -31,12 +31,22 @@ function recordingLimit(keys: string[]): RateLimit {
   } as unknown as RateLimit;
 }
 
-async function requestReset(testEnv: Env, email: unknown): Promise<Response> {
+/**
+ * One password-reset request. `callerIp` fills cf-connecting-ip, which is
+ * the only input to the per-caller key: without it every request in a test
+ * looks like the same caller, and a limiter that keyed on the caller by
+ * mistake would pass the distributed-caller cases below.
+ */
+async function requestReset(
+  testEnv: Env,
+  email: unknown,
+  callerIp = "203.0.113.1",
+): Promise<Response> {
   const ctx = createExecutionContext();
   const res = await worker.fetch(
     new Request(`http://localhost${RESET_PATH}`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", "cf-connecting-ip": callerIp },
       body: JSON.stringify({ email }),
     }),
     testEnv,
@@ -80,20 +90,52 @@ describe("recipient-keyed email rate limit (#50)", () => {
   });
 
   it("keys on the recipient, not the caller, so distributed callers share one budget", async () => {
-    const keys: string[] = [];
+    const callerKeys: string[] = [];
+    const recipientKeys: string[] = [];
     const testEnv = overrideEnv({
-      RL_EMAIL: openLimit(),
-      RL_EMAIL_RECIPIENT: recordingLimit(keys),
+      RL_EMAIL: recordingLimit(callerKeys),
+      RL_EMAIL_RECIPIENT: recordingLimit(recipientKeys),
     });
 
-    // Same recipient, different callers: Cloudflare fills cf-connecting-ip,
-    // and the caller key is an HMAC of it, so what matters is that the
-    // recipient key is identical across both.
-    await requestReset(testEnv, "victim@example.com");
-    await requestReset(testEnv, "VICTIM@Example.com  ");
+    // One recipient, two callers. Recording both budgets' keys is what makes
+    // this an assertion rather than a coincidence: the callers have to come
+    // out different for "the recipient key is the same anyway" to mean
+    // anything.
+    await requestReset(testEnv, "victim@example.com", "203.0.113.7");
+    await requestReset(testEnv, "VICTIM@Example.com  ", "198.51.100.4");
 
-    expect(keys).toHaveLength(2);
-    expect(keys[0]).toBe(keys[1]);
+    expect(callerKeys).toHaveLength(2);
+    expect(callerKeys[0]).not.toBe(callerKeys[1]);
+    expect(recipientKeys).toHaveLength(2);
+    expect(recipientKeys[0]).toBe(recipientKeys[1]);
+  });
+
+  it("stops a second caller once the recipient's budget is gone", async () => {
+    // The behaviour the key assertion above implies, spelled out: a fresh
+    // caller with its own untouched per-caller budget still gets refused,
+    // because the budget that ran out belongs to the address.
+    const spent = new Set<string>();
+    const recipientBudgetOfOne: RateLimit = {
+      limit: async ({ key }: { key: string }) => {
+        const success = !spent.has(key);
+        spent.add(key);
+        return { success };
+      },
+    } as unknown as RateLimit;
+    const testEnv = overrideEnv({
+      RL_EMAIL: openLimit(),
+      RL_EMAIL_RECIPIENT: recipientBudgetOfOne,
+    });
+
+    const first = await requestReset(testEnv, "victim@example.com", "203.0.113.7");
+    const second = await requestReset(testEnv, "victim@example.com", "198.51.100.4");
+    const other = await requestReset(testEnv, "bystander@example.com", "198.51.100.4");
+
+    expect(first.status).not.toBe(429);
+    expect(second.status).toBe(429);
+    // The bystander shares the second caller's IP, so only a recipient-keyed
+    // budget lets this one through.
+    expect(other.status).not.toBe(429);
   });
 
   it("gives a different recipient its own budget", async () => {

--- a/tests/worker/email-recipient-limit.worker.ts
+++ b/tests/worker/email-recipient-limit.worker.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../../src/worker";
+import type { Env } from "../../src/worker/env";
+import { applyTestMigrations, authEnv, overrideEnv } from "./support";
+
+const RESET_PATH = "/api/auth/email-otp/request-password-reset";
+
+/**
+ * A rate-limit binding that always refuses, so a route's behaviour once a
+ * budget is gone can be asserted without spending real tokens against
+ * Cloudflare's per-location counters (which the test runner does not reset
+ * between cases).
+ */
+function exhaustedLimit(): RateLimit {
+  return { limit: async () => ({ success: false }) } as unknown as RateLimit;
+}
+
+/** A binding that always allows, isolating which of the two budgets is
+ * under test. */
+function openLimit(): RateLimit {
+  return { limit: async () => ({ success: true }) } as unknown as RateLimit;
+}
+
+function recordingLimit(keys: string[]): RateLimit {
+  return {
+    limit: async ({ key }: { key: string }) => {
+      keys.push(key);
+      return { success: true };
+    },
+  } as unknown as RateLimit;
+}
+
+async function requestReset(testEnv: Env, email: unknown): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(
+    new Request(`http://localhost${RESET_PATH}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email }),
+    }),
+    testEnv,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+beforeEach(applyTestMigrations);
+afterEach(reset);
+
+describe("recipient-keyed email rate limit (#50)", () => {
+  it("refuses a send once the recipient's budget is gone, even though the caller's is not", async () => {
+    const testEnv = overrideEnv({
+      RL_EMAIL: openLimit(),
+      RL_AUTH_PUBLIC: openLimit(),
+      RL_EMAIL_RECIPIENT: exhaustedLimit(),
+    });
+
+    const res = await requestReset(testEnv, "victim@example.com");
+
+    expect(res.status).toBe(429);
+  });
+
+  it("is indistinguishable from the caller limit, so it leaks no account state", async () => {
+    const callerLimited = await requestReset(
+      overrideEnv({ RL_EMAIL: exhaustedLimit(), RL_EMAIL_RECIPIENT: openLimit() }),
+      "victim@example.com",
+    );
+    const recipientLimited = await requestReset(
+      overrideEnv({ RL_EMAIL: openLimit(), RL_EMAIL_RECIPIENT: exhaustedLimit() }),
+      "victim@example.com",
+    );
+
+    expect(recipientLimited.status).toBe(callerLimited.status);
+    expect(recipientLimited.headers.get("x-ratelimit-group")).toBe(
+      callerLimited.headers.get("x-ratelimit-group"),
+    );
+    expect(await recipientLimited.json()).toEqual(await callerLimited.json());
+  });
+
+  it("keys on the recipient, not the caller, so distributed callers share one budget", async () => {
+    const keys: string[] = [];
+    const testEnv = overrideEnv({
+      RL_EMAIL: openLimit(),
+      RL_EMAIL_RECIPIENT: recordingLimit(keys),
+    });
+
+    // Same recipient, different callers: Cloudflare fills cf-connecting-ip,
+    // and the caller key is an HMAC of it, so what matters is that the
+    // recipient key is identical across both.
+    await requestReset(testEnv, "victim@example.com");
+    await requestReset(testEnv, "VICTIM@Example.com  ");
+
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toBe(keys[1]);
+  });
+
+  it("gives a different recipient its own budget", async () => {
+    const keys: string[] = [];
+    const testEnv = overrideEnv({
+      RL_EMAIL: openLimit(),
+      RL_EMAIL_RECIPIENT: recordingLimit(keys),
+    });
+
+    await requestReset(testEnv, "one@example.com");
+    await requestReset(testEnv, "two@example.com");
+
+    expect(keys[0]).not.toBe(keys[1]);
+  });
+
+  it("never puts the raw address in the rate-limit key", async () => {
+    const keys: string[] = [];
+    const testEnv = overrideEnv({
+      RL_EMAIL: openLimit(),
+      RL_EMAIL_RECIPIENT: recordingLimit(keys),
+    });
+
+    await requestReset(testEnv, "victim@example.com");
+
+    expect(keys[0]).not.toContain("victim");
+    expect(keys[0]).not.toContain("example.com");
+  });
+
+  it("does not consume a recipient budget when the body names no address", async () => {
+    const keys: string[] = [];
+    const testEnv = overrideEnv({
+      RL_EMAIL: openLimit(),
+      RL_EMAIL_RECIPIENT: recordingLimit(keys),
+    });
+
+    await requestReset(testEnv, 42);
+
+    expect(keys).toHaveLength(0);
+  });
+
+  it("leaves the body readable for the auth handler downstream", async () => {
+    // The limiter clones the request to look at `email`. If it consumed the
+    // original stream instead, BetterAuth would receive an empty body and
+    // this would not reach its "user not found" path at all.
+    const res = await requestReset(authEnv(), "nobody@example.com");
+
+    expect(res.status).toBeLessThan(500);
+  });
+});

--- a/tests/worker/redirects.worker.ts
+++ b/tests/worker/redirects.worker.ts
@@ -9,7 +9,7 @@ import {
 import worker from "../../src/worker";
 import type { Env } from "../../src/worker/env";
 import type { ClickMessage } from "../../src/worker/clicks";
-import { overrideEnv } from "./support";
+import { captureClickQueue, overrideEnv } from "./support";
 
 type TestEnv = typeof env & { TEST_MIGRATIONS: D1Migration[] };
 
@@ -18,19 +18,6 @@ async function fetchWorker(request: Request, testEnv: Env = env as Env): Promise
   const response = await worker.fetch(request, testEnv, ctx);
   await waitOnExecutionContext(ctx);
   return response;
-}
-
-// A CLICK_QUEUE that records what was sent, so the redirect path's enqueue
-// can be asserted without a live queue delivering the message back into the
-// worker under test (consumption is covered by tests/worker/clicks.worker.ts).
-function captureClickQueue(): { env: Env; sent: ClickMessage[] } {
-  const sent: ClickMessage[] = [];
-  const CLICK_QUEUE = {
-    async send(message: ClickMessage) {
-      sent.push(message);
-    },
-  } as unknown as Queue<ClickMessage>;
-  return { env: overrideEnv({ CLICK_QUEUE }), sent };
 }
 
 afterEach(async () => {

--- a/tests/worker/referrer-privacy.worker.ts
+++ b/tests/worker/referrer-privacy.worker.ts
@@ -46,6 +46,27 @@ describe("normalizeReferrer (#20)", () => {
     expect(normalizeReferrer(`https://${host}/`)).toBe("");
   });
 
+  it("keeps a label of exactly the longest DNS allows", () => {
+    const host = `${"a".repeat(63)}.example.com`;
+    expect(normalizeReferrer(`https://${host}/`)).toBe(host);
+  });
+
+  it("returns empty for a label one character past the DNS limit", () => {
+    // Total length is well under 253, so only the per-label rule can catch
+    // this one.
+    const host = `${"a".repeat(64)}.example.com`;
+    expect(normalizeReferrer(`https://${host}/`)).toBe("");
+  });
+
+  it.each([
+    ["a bare word with no dot", "https://localhost/"],
+    ["a trailing dot", "https://example.com./"],
+    ["a doubled dot", "https://example..com/"],
+    ["an IPv6 literal", "https://[2001:db8::1]/"],
+  ])("returns empty for %s, which names no site we can report on", (_label, input) => {
+    expect(normalizeReferrer(input)).toBe("");
+  });
+
   it("strips control characters instead of storing them", () => {
     // URL parsing removes tabs and newlines outright, so a header trying to
     // smuggle them cannot reach the column.
@@ -101,5 +122,93 @@ describe("click ingestion stores a hostname, not a URL (#20)", () => {
   it("drops a referrer it cannot attribute instead of storing it raw", async () => {
     const message = await redirectWithReferer("android-app://com.example.reader/deep/link");
     expect(message.referrer).toBe("");
+  });
+});
+
+describe("migration 0016 leaves nothing ingestion would now refuse (#20)", () => {
+  /**
+   * Runs the real 0016 statements over `raw`, one seeded click each, and
+   * returns what the column holds afterwards.
+   *
+   * The migration already ran in beforeEach, so this is a second pass over
+   * rows inserted after it: fine, and worth asserting on. Every statement
+   * is a no-op on a value without its delimiter, so the file is safe to
+   * re-run, which is what makes this test possible at all.
+   */
+  async function afterMigration(raw: string[]): Promise<string[]> {
+    await seedLink();
+    await env.DB.batch(
+      raw.map((referrer, i) =>
+        env.DB.prepare(
+          "insert into clicks (id, link_id, org_id, ts, country, referrer, device) values (?, ?, ?, ?, '', ?, '')",
+        ).bind(i + 1, sampleLink.id, sampleLink.orgId, i + 1, referrer),
+      ),
+    );
+
+    const { TEST_MIGRATIONS } = env as unknown as { TEST_MIGRATIONS: D1Migration[] };
+    const migration = TEST_MIGRATIONS.find((m) => m.name.startsWith("0016"));
+    expect(migration, "migration 0016 is missing from the test bundle").toBeTruthy();
+    await env.DB.batch(migration!.queries.map((query) => env.DB.prepare(query)));
+
+    const { results } = await env.DB.prepare("select referrer from clicks order by id").all<{
+      referrer: string;
+    }>();
+    return results.map((row) => row.referrer);
+  }
+
+  it("reduces a stored URL to its hostname", async () => {
+    expect(
+      await afterMigration([
+        "https://forum.example.com/threads/42?q=private+search&token=secret",
+        "http://alice:hunter2@News.Example.com:8443/a/b",
+      ]),
+    ).toEqual(["forum.example.com", "news.example.com"]);
+  });
+
+  it("clears what did not arrive over http(s), rather than keeping its host", async () => {
+    // Without the scheme check these would survive the scheme strip looking
+    // exactly like real hostnames.
+    expect(
+      await afterMigration([
+        "ftp://collector.example/dump",
+        "android-app://com.example.reader/deep/link",
+        "data:text/html,<script>x</script>",
+      ]),
+    ).toEqual(["", "", ""]);
+  });
+
+  it("clears hosts the live path refuses: control characters, bad shapes, long labels", async () => {
+    const overlongLabel = `${"a".repeat(64)}.example.com`;
+    expect(
+      await afterMigration([
+        "https://exa\tmple.com/path",
+        "https://exa mple.com/path",
+        "https://localhost/path",
+        "https://example..com/path",
+        `https://${overlongLabel}/path`,
+        `https://${"a".repeat(300)}.example.com/path`,
+      ]),
+    ).toEqual(["", "", "", "", "", ""]);
+  });
+
+  it("agrees with normalizeReferrer on every case it is given", async () => {
+    // The point of the whole exercise: one rule, two implementations, no
+    // row left behind that the worker would not write today.
+    const raw = [
+      "https://forum.example.com/threads/42?token=secret",
+      "http://EXAMPLE.com:8080/",
+      `https://${"a".repeat(63)}.example.com/`,
+      `https://${"a".repeat(64)}.example.com/`,
+      "ftp://collector.example/dump",
+      "https://localhost/",
+      "https://example..com/",
+      "",
+    ];
+
+    expect(await afterMigration(raw)).toEqual(raw.map(normalizeReferrer));
+  });
+
+  it("leaves an already-normalized row untouched when it runs twice", async () => {
+    expect(await afterMigration(["forum.example.com", ""])).toEqual(["forum.example.com", ""]);
   });
 });

--- a/tests/worker/referrer-privacy.worker.ts
+++ b/tests/worker/referrer-privacy.worker.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../../src/worker";
+import type { ClickMessage } from "../../src/worker/clicks";
+import { normalizeReferrer } from "../../src/worker/util";
+import { applyTestMigrations, captureClickQueue, sampleLink, seedLink } from "./support";
+
+beforeEach(async () => {
+  await reset();
+  await applyTestMigrations();
+});
+afterEach(reset);
+
+describe("normalizeReferrer (#20)", () => {
+  it("keeps only the hostname, dropping path, query and fragment", () => {
+    expect(normalizeReferrer("https://news.example.com/search?q=medical+advice#results")).toBe(
+      "news.example.com",
+    );
+  });
+
+  it("drops credentials and port", () => {
+    expect(normalizeReferrer("https://alice:hunter2@example.com:8443/a/b")).toBe("example.com");
+  });
+
+  it("lowercases the host so one site is one row in the breakdown", () => {
+    expect(normalizeReferrer("https://News.EXAMPLE.com/")).toBe("news.example.com");
+  });
+
+  it("returns empty for a direct visit", () => {
+    expect(normalizeReferrer("")).toBe("");
+  });
+
+  it.each([
+    ["not a url at all", "not a url at all"],
+    ["a scheme we cannot attribute", "javascript:alert(1)"],
+    ["a data url", "data:text/html,<script>x</script>"],
+    ["a file url", "file:///Users/someone/secret.html"],
+    ["a bare host with no scheme", "example.com/path"],
+  ])("returns empty for %s", (_label, input) => {
+    expect(normalizeReferrer(input)).toBe("");
+  });
+
+  it("returns empty rather than truncating an over-long host", () => {
+    const host = `${"a".repeat(300)}.example.com`;
+    expect(normalizeReferrer(`https://${host}/`)).toBe("");
+  });
+
+  it("strips control characters instead of storing them", () => {
+    // URL parsing removes tabs and newlines outright, so a header trying to
+    // smuggle them cannot reach the column.
+    expect(normalizeReferrer("https://exa\tmple.com/\npath")).toBe("example.com");
+  });
+});
+
+describe("click ingestion stores a hostname, not a URL (#20)", () => {
+  // Asserts on the queued message rather than a stored row: the claim under
+  // test is that the URL's path and query never leave the request handler.
+  async function redirectWithReferer(referer: string): Promise<ClickMessage> {
+    await seedLink();
+    await env.LINKS.put(
+      `slug:${sampleLink.slug}`,
+      JSON.stringify({
+        linkId: sampleLink.id,
+        orgId: sampleLink.orgId,
+        url: sampleLink.destination,
+      }),
+    );
+    const { env: testEnv, sent } = captureClickQueue();
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request(`http://localhost/${sampleLink.slug}`, {
+        headers: { referer },
+        redirect: "manual",
+      }),
+      testEnv,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(302);
+    expect(sent).toHaveLength(1);
+    return sent[0]!;
+  }
+
+  it("reduces a referring URL to its hostname before the click is enqueued", async () => {
+    const message = await redirectWithReferer(
+      "https://forum.example.com/thread/42?user=alice&token=secret",
+    );
+
+    expect(message.referrer).toBe("forum.example.com");
+    expect(message.referrer).not.toContain("secret");
+  });
+
+  it("records a direct visit as empty rather than inventing a source", async () => {
+    const message = await redirectWithReferer("");
+    expect(message.referrer).toBe("");
+  });
+
+  it("drops a referrer it cannot attribute instead of storing it raw", async () => {
+    const message = await redirectWithReferer("android-app://com.example.reader/deep/link");
+    expect(message.referrer).toBe("");
+  });
+});

--- a/tests/worker/support.ts
+++ b/tests/worker/support.ts
@@ -10,6 +10,7 @@ import { drizzle } from "drizzle-orm/d1";
 import worker from "../../src/worker";
 import * as schema from "../../src/worker/db/schema";
 import type { Env } from "../../src/worker/env";
+import type { ClickMessage } from "../../src/worker/clicks";
 import { hashPassword } from "../../src/worker/password";
 
 type TestEnv = typeof env & { TEST_MIGRATIONS: D1Migration[] };
@@ -21,6 +22,21 @@ export function overrideEnv(overrides: Partial<Env>): Env {
       return Reflect.get(target, property, receiver);
     },
   }) as unknown as Env;
+}
+
+/**
+ * A CLICK_QUEUE that records what was sent, so the redirect path's enqueue
+ * can be asserted without a live queue delivering the message back into the
+ * worker under test (consumption is covered by tests/worker/clicks.worker.ts).
+ */
+export function captureClickQueue(): { env: Env; sent: ClickMessage[] } {
+  const sent: ClickMessage[] = [];
+  const CLICK_QUEUE = {
+    async send(message: ClickMessage) {
+      sent.push(message);
+    },
+  } as unknown as Queue<ClickMessage>;
+  return { env: overrideEnv({ CLICK_QUEUE }), sent };
 }
 
 // Env with a non-empty auth secret, independent of the ambient .dev.vars, so

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -200,6 +200,22 @@
         "period": 60,
       },
     },
+    // Keyed by the recipient address rather than the caller, so many callers
+    // cannot each stay under RL_EMAIL while all aiming at one inbox (#50).
+    // Tighter than RL_EMAIL's 3: one address has no legitimate reason to
+    // want a second code in the same minute, let alone a third.
+    //
+    // `period` only accepts 10 or 60, so this caps the rate, not the daily
+    // total. Closing that needs a durable counter rather than Cloudflare's
+    // per-location one; see the follow-up noted on #50.
+    {
+      "name": "RL_EMAIL_RECIPIENT",
+      "namespace_id": "14009",
+      "simple": {
+        "limit": 2,
+        "period": 60,
+      },
+    },
   ],
   "workers_dev": false,
   "preview_urls": false,
@@ -372,6 +388,19 @@
           "namespace_id": "24008",
           "simple": {
             "limit": 600,
+            "period": 60,
+          },
+        },
+        {
+          "name": "RL_EMAIL_RECIPIENT",
+          "namespace_id": "24009",
+          "simple": {
+            // One above production's (2), leaving the two sends a sign-up
+            // costs (submit, then the resend on the code screen's reload)
+            // some headroom. Every test mints its own
+            // `something-${Date.now()}@gmail.com`, so no other address is
+            // near this; the e2e scenario trips it deliberately.
+            "limit": 3,
             "period": 60,
           },
         },


### PR DESCRIPTION
Closes #20. Closes #50.

Branched off `main`, independent of the two open PRs: no file here overlaps #61 or #62.

## Referrer minimisation (#20)

Click ingestion stored the `Referer` header verbatim, so `clicks.referrer` held whole URLs for the full 400-day retention: other people's paths and query strings, carrying their search terms, session tokens, and account identifiers. The analytics page never showed any of it, since the read path already reduced values to a hostname. So this was retention with no purpose behind it, sitting directly against the privacy the product advertises.

`normalizeReferrer()` now runs at ingest, where it can actually prevent the storage rather than hide it at read time: hostname only, lowercased, `http(s)` only, bounded by the DNS length limit, and `""` rather than a guess for anything it cannot parse. The read path keeps its own normalisation, which costs nothing and covers rows written before this.

`migrations/0016` rewrites the rows already stored. SQLite has no URL parser, so it peels one delimiter at a time (scheme, fragment, query, path, credentials, port), then empties anything still not hostname-shaped. Every statement is a no-op on a value that lacks its delimiter, so already-normalised rows pass through untouched and re-running is harmless. Verified against real SQLite across path/query/fragment, credentials, port, mixed case, already-normalised, empty, and garbage inputs, then re-run to confirm idempotency.

Numbered 0016 rather than 0015 because #61 already claims 0015.

## Recipient-keyed email limit (#50)

Reset and verification-OTP sends were bounded per caller and not at all per recipient, so distributed callers could each sit comfortably under `RL_EMAIL` while one inbox absorbed all of it. A second budget now applies to those routes, keyed by an HMAC of the recipient rather than the address itself, consistent with how `publicClientKey` already avoids putting an IP anywhere.

It answers with the same 429 as the caller limit deliberately. Distinguishing them would let an anonymous caller ask "did this address just get throttled?" and hear "does this address exist?".

The limiter clones the request before reading the body, so BetterAuth still receives an intact stream downstream; there is a test for exactly that, since getting it wrong would be silent.

**One limitation, stated plainly:** Cloudflare's rate-limit bindings accept a `period` of 10 or 60 seconds only. This therefore caps the *rate* (2/min per address) and not the daily total. Bounding the total needs a durable counter rather than Cloudflare's per-location one, which is a different piece of work; I have left a follow-up note on #50 rather than quietly implying the acceptance criteria are fully met.

## `bun run verify` now runs the browser tests

Per the rule set on this repo. `verify` stopped at unit and worker tests, and the worker test environment has no built asset bundle, so it never reaches the real `ASSETS` binding. Two bugs that broke the app for every visitor passed every local check and only failed in CI's separate e2e step. A green `verify` has to mean the app runs.

CI now writes `.dev.vars` before `verify` rather than after, and its separate e2e step goes away instead of running the suite twice. The rule is documented in `AGENTS.md`.

## Testing

Both features ship with e2e scenarios, per the same rule:

- a click records the referring host and never the URL it came from
- one address cannot be mailed without limit by many callers

Both worker suites were confirmed to **fail** against the unfixed code before being kept: reverting `normalizeReferrer` fails 2 of the referrer tests, and disabling the recipient check fails 5 of the limit tests.

`bun run verify` green (140 unit, 118 worker, 14 e2e), react-doctor 100/100, fallow shows no new findings (the `captureClickQueue` duplication this introduced was extracted to `tests/worker/support.ts`, taking clone groups from 8 back to 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy Improvements**
  * Referrer data is now reduced to a lowercase hostname, excluding paths, queries, credentials, ports, and other sensitive URL details.
  * Existing referrer records are cleaned up to follow the same privacy standards.

* **Security**
  * Password-reset requests now include recipient-based rate limiting to help prevent abuse while protecting email addresses.

* **Quality Improvements**
  * Expanded automated checks and browser-based testing improve confidence in redirects, privacy protections, and email safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->