### PR TITLE
Separate entitlement from billing state, and price revenue from facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,19 @@ bun run db:migrate:remote
 bun run deploy
 ```
 
-**Polar setup:** create an Organization Access Token with scopes `checkouts:write` and `customer_sessions:write`. Add a webhook endpoint at `https://rdyrct.com/api/webhooks/polar` and subscribe to `subscription.active`, `subscription.revoked`, `subscription.canceled`, and `subscription.uncanceled`.
+**Polar setup:** create an Organization Access Token with scopes `checkouts:write` and `customer_sessions:write`. Add a webhook endpoint at `https://rdyrct.com/api/webhooks/polar` and subscribe to all five events the Worker handles. Miss one and billing state drifts:
+
+| Event                     | What it does                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `subscription.active`     | Starts the subscription: plan, customer, price, and access                      |
+| `subscription.updated`    | The full subscription snapshot: status, product, cancellation state, period end |
+| `subscription.canceled`   | Marks it as ending at the period end; access continues until then               |
+| `subscription.uncanceled` | Clears a scheduled cancellation                                                 |
+| `subscription.revoked`    | Ends it: the subscription and its access go away                                |
+
+Which subscription statuses keep access is one decision, in `src/worker/entitlement.ts`. `active`, `trialing` and `past_due` keep it, on the grounds that Polar retries a failed payment for days and sends `subscription.revoked` when it gives up. `unpaid`, `canceled`, `incomplete` and `incomplete_expired` do not, and a status with no rule keeps nothing.
+
+Paid access an admin grants by hand is a **comp**, stored apart from the subscription and never counted as revenue. A comp outranks the subscription underneath it, so revoking a subscription cannot take away access an admin gave.
 
 Finally, point `rdyrct.com` at the Worker as a **custom domain**: Cloudflare dashboard → Workers → your worker → **Settings → Domains & Routes**. Short links live at the root (`https://rdyrct.com/<slug>`); the app is served on every other path.
 

--- a/migrations/0017_split_entitlement_from_billing.sql
+++ b/migrations/0017_split_entitlement_from_billing.sql
@@ -1,0 +1,50 @@
+-- #81: user.plan carried two different facts at once, what a user may do and
+-- what a user pays, and nothing told them apart. A comp written by an admin
+-- was byte-identical to a plan written by a Polar webhook, so a
+-- subscription.revoked could strip access an admin granted by hand, and every
+-- revenue figure counted comps as money.
+--
+-- The two facts are now stored separately and `plan` becomes derived: it is
+-- coalesce(comp_plan, entitling subscription_plan, 'free'), written only by
+-- the resolver in src/worker/entitlement.ts. Nothing writes `plan` directly.
+
+-- What Polar says. Only the webhook writes these.
+alter table user add column subscription_plan text;
+alter table user add column subscription_status text;
+-- Pricing as charged, for revenue that comes from facts rather than from
+-- hardcoded list prices (#82). Amount is in the currency's minor units.
+alter table user add column subscription_amount integer;
+alter table user add column subscription_currency text;
+alter table user add column subscription_interval text;
+
+-- What an admin granted by hand. Only the comp routes write these, and a
+-- webhook can never clear them.
+alter table user add column comp_plan text;
+alter table user add column comp_granted_by text references user (id) on delete set null;
+alter table user add column comp_granted_at integer;
+alter table user add column comp_reason text;
+
+-- Backfill so that no one's access changes. A paid row with a Polar
+-- subscription behind it is a subscription; a paid row without one can only
+-- have come from the admin `Set plan` action this migration replaces.
+update user
+set subscription_plan = plan,
+    subscription_status = 'active'
+where plan <> 'free'
+  and polar_subscription_id is not null;
+
+update user
+set comp_plan = plan,
+    comp_granted_at = updated_at,
+    comp_reason = 'Backfilled: granted through the admin plan control that predates comps (#81)'
+where plan <> 'free'
+  and polar_subscription_id is null;
+
+-- Every row now derives back to the plan it already had:
+-- coalesce(comp_plan, subscription_plan, 'free') = plan, for all three cases
+-- (paid with a subscription, paid without one, free).
+
+create index if not exists idx_user_comp_plan on user (comp_plan)
+where comp_plan is not null;
+create index if not exists idx_user_subscription_plan on user (subscription_plan)
+where subscription_plan is not null;

--- a/scripts/seed-local.ts
+++ b/scripts/seed-local.ts
@@ -438,16 +438,43 @@ async function seed() {
   );
   const pool = Array.from({ length: CONFIG.extraUsersPool }, () => makeUser("free"));
 
-  const userRows = users.map(
-    (u) =>
-      `(${q(u.id)}, ${q(u.name)}, ${q(u.email)}, 1, ${q(u.plan)}, ${u.createdAt}, ${u.createdAt})`,
-  );
+  // Paid access comes from one of two places, and the seed has both so the
+  // admin views have something to tell apart (#81): most paid owners have a
+  // real subscription, and every fifth is comped instead. `plan` is derived
+  // from whichever it is.
+  const AMOUNTS = { hobby: 400, pro: 900 } as const;
+  let paidSeen = 0;
+  const billingFor = (u: SeedUser) => {
+    if (u.plan === "free") return { sub: null, comp: null };
+    const comped = paidSeen++ % 5 === 4;
+    if (comped) return { sub: null, comp: u.plan };
+    // A tenth of subscriptions are yearly, so MRR has something to normalize.
+    return { sub: { interval: paidSeen % 10 === 0 ? "year" : "month" }, comp: null };
+  };
+
+  const userRows = users.map((u) => {
+    const { sub, comp } = billingFor(u);
+    const amount =
+      u.plan === "free" || !sub
+        ? "NULL"
+        : String(AMOUNTS[u.plan] * (sub.interval === "year" ? 10 : 1));
+    return `(${q(u.id)}, ${q(u.name)}, ${q(u.email)}, 1, ${q(u.plan)}, ${
+      sub ? q(u.plan) : "NULL"
+    }, ${sub ? "'active'" : "NULL"}, ${amount}, ${sub ? "'usd'" : "NULL"}, ${
+      sub ? q(sub.interval) : "NULL"
+    }, ${comp ? q(comp) : "NULL"}, ${comp ? "'Seeded comp'" : "NULL"}, ${
+      comp ? u.createdAt : "NULL"
+    }, ${u.createdAt}, ${u.createdAt})`;
+  });
   const accountRows = users.map(
     (u) =>
       `(${q(`seed-acc-${u.id.slice(5)}`)}, ${q(u.id)}, 'credential', ${q(u.id)}, ${q(passwordHash)}, ${u.createdAt}, ${u.createdAt})`,
   );
   await sqlBatch([
-    `INSERT INTO user (id, name, email, email_verified, plan, created_at, updated_at) VALUES ${userRows.join(",")}`,
+    `INSERT INTO user (id, name, email, email_verified, plan, subscription_plan,
+       subscription_status, subscription_amount, subscription_currency, subscription_interval,
+       comp_plan, comp_reason, comp_granted_at, created_at, updated_at)
+     VALUES ${userRows.join(",")}`,
     `INSERT INTO account (id, account_id, provider_id, user_id, password, created_at, updated_at) VALUES ${accountRows.join(",")}`,
   ]);
 

--- a/scripts/seed-local.ts
+++ b/scripts/seed-local.ts
@@ -446,10 +446,13 @@ async function seed() {
   let paidSeen = 0;
   const billingFor = (u: SeedUser) => {
     if (u.plan === "free") return { sub: null, comp: null };
-    const comped = paidSeen++ % 5 === 4;
-    if (comped) return { sub: null, comp: u.plan };
+    // One counter, read before it moves. Testing the incremented value for the
+    // yearly case can never fire: every tenth is also every fifth, and every
+    // fifth already returned above as a comp.
+    const nth = paidSeen++;
+    if (nth % 5 === 4) return { sub: null, comp: u.plan };
     // A tenth of subscriptions are yearly, so MRR has something to normalize.
-    return { sub: { interval: paidSeen % 10 === 0 ? "year" : "month" }, comp: null };
+    return { sub: { interval: nth % 10 === 2 ? "year" : "month" }, comp: null };
   };
 
   const userRows = users.map((u) => {

--- a/src/app/routes/admin/comp-dialog.tsx
+++ b/src/app/routes/admin/comp-dialog.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import type { AdminUserRow } from "@/shared/types";
+import { Button } from "../../ui/button";
+import { Dialog } from "../../ui/dialog";
+import { Field, Input, Select } from "../../ui/field";
+import { BusyContent } from "../../ui/spinner";
+
+export type CompPlan = "hobby" | "pro";
+
+/**
+ * Granting paid access by hand is a comp, and a comp is recorded: who granted
+ * it, when, and why (#81). The reason is required, which is why this is a
+ * dialog rather than a menu item that fires straight away.
+ */
+export function GrantCompDialog({
+  user,
+  onClose,
+  onGrant,
+  pending,
+}: {
+  user: AdminUserRow;
+  onClose: () => void;
+  onGrant: (plan: CompPlan, reason: string) => void;
+  pending: boolean;
+}) {
+  const [plan, setPlan] = useState<CompPlan>(user.compPlan ?? "pro");
+  const [reason, setReason] = useState(user.compReason ?? "");
+  const trimmed = reason.trim();
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()} title={`Comp ${user.name}`}>
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-muted">
+          Gives {user.name} paid access without a subscription. It unlocks every org they own, it
+          counts in plan totals, and it never counts as revenue. A subscription they buy later sits
+          underneath and comes back if the comp is revoked.
+        </p>
+        <Field label="Plan">
+          <Select value={plan} onChange={(e) => setPlan(e.target.value as CompPlan)}>
+            <option value="hobby">hobby</option>
+            <option value="pro">pro</option>
+          </Select>
+        </Field>
+        <Field label="Reason" hint="Recorded with your name and shown in this list.">
+          <Input
+            value={reason}
+            maxLength={500}
+            placeholder="Design partner, launch giveaway, support goodwill…"
+            onChange={(e) => setReason(e.target.value)}
+          />
+        </Field>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            disabled={pending || !trimmed}
+            onClick={() => onGrant(plan, trimmed)}
+          >
+            <BusyContent busy={pending}>{user.compPlan ? "Update comp" : "Grant comp"}</BusyContent>
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/app/routes/admin/usage.tsx
+++ b/src/app/routes/admin/usage.tsx
@@ -18,6 +18,22 @@ function AdminTableCard({ title, children }: { title: string; children: ReactNod
   );
 }
 
+const CURRENCY_SYMBOL: Record<string, string> = { usd: "$", eur: "€", gbp: "£" };
+
+/**
+ * What to put in front of an MRR figure.
+ *
+ * MRR is a sum of the amounts subscriptions charge, so it is only in a
+ * currency when they all share one. Several currencies add up to a number in
+ * none of them, and a hardcoded `$` would report euros as dollars, so the
+ * mark comes off and the warning under the card says why.
+ */
+function mrrPrefix(currencies: string[]): string | undefined {
+  if (currencies.length !== 1) return undefined;
+  const code = currencies[0];
+  return CURRENCY_SYMBOL[code] ?? `${code.toUpperCase()} `;
+}
+
 /**
  * Access and money are separate figures (#82). "Paid users" is how many people
  * hold a paid plan, comps included; "Subscribers" is how many people pay.
@@ -29,7 +45,7 @@ function BusinessStats({ s }: { s: AdminUsage }) {
       <StatCard label="Users" value={s.users} />
       <StatCard label="Paid users" value={s.proUsers} />
       <StatCard label="Subscribers" value={s.payingSubscribers} />
-      <StatCard label="MRR" value={s.mrr} prefix="$" />
+      <StatCard label="MRR" value={s.mrr} prefix={mrrPrefix(s.mrrCurrencies)} />
       <StatCard label="Signups · 7d" value={s.signups7d} delta={s.signups7dDelta} />
       <StatCard label="Weekly active users" value={s.wau} />
     </div>
@@ -43,7 +59,11 @@ function RevenueDetail({ s }: { s: AdminUsage }) {
     <Card>
       <p className="mb-3 text-2xs tracking-wider text-muted uppercase">Revenue detail</p>
       <div className="grid grid-cols-3 gap-4">
-        <StatCard label="Committed MRR" value={s.committedMrr} prefix="$" />
+        <StatCard
+          label="Committed MRR"
+          value={s.committedMrr}
+          prefix={mrrPrefix(s.mrrCurrencies)}
+        />
         <StatCard label="Comped" value={s.compedUsers} />
         <StatCard label="Cancelling" value={s.pendingCancellations} />
       </div>

--- a/src/app/routes/admin/usage.tsx
+++ b/src/app/routes/admin/usage.tsx
@@ -18,15 +18,41 @@ function AdminTableCard({ title, children }: { title: string; children: ReactNod
   );
 }
 
+/**
+ * Access and money are separate figures (#82). "Paid users" is how many people
+ * hold a paid plan, comps included; "Subscribers" is how many people pay.
+ * MRR counts only the second group, at the amounts Polar reported.
+ */
 function BusinessStats({ s }: { s: AdminUsage }) {
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
       <StatCard label="Users" value={s.users} />
       <StatCard label="Paid users" value={s.proUsers} />
+      <StatCard label="Subscribers" value={s.payingSubscribers} />
       <StatCard label="MRR" value={s.mrr} prefix="$" />
       <StatCard label="Signups · 7d" value={s.signups7d} delta={s.signups7dDelta} />
       <StatCard label="Weekly active users" value={s.wau} />
     </div>
+  );
+}
+
+/** The figures behind MRR, which a single number hides: what renews, what is
+ * comped, and what is on its way out. */
+function RevenueDetail({ s }: { s: AdminUsage }) {
+  return (
+    <Card>
+      <p className="mb-3 text-2xs tracking-wider text-muted uppercase">Revenue detail</p>
+      <div className="grid grid-cols-3 gap-4">
+        <StatCard label="Committed MRR" value={s.committedMrr} prefix="$" />
+        <StatCard label="Comped" value={s.compedUsers} />
+        <StatCard label="Cancelling" value={s.pendingCancellations} />
+      </div>
+      {s.mrrCurrencies.length > 1 && (
+        <p className="mt-3 text-xs text-danger">
+          Mixed currencies ({s.mrrCurrencies.join(", ")}): MRR adds them up without converting.
+        </p>
+      )}
+    </Card>
   );
 }
 
@@ -57,6 +83,7 @@ function BusinessRow({ s }: { s: AdminUsage }) {
           <p className="mt-3 text-xs text-muted">{s.paidConversionRate}% paid conversion</p>
         )}
       </Card>
+      <RevenueDetail s={s} />
       <Card>
         <p className="mb-3 text-2xs tracking-wider text-muted uppercase">Signups per day · 30d</p>
         <AreaChart data={s.signups} />

--- a/src/app/routes/admin/users.tsx
+++ b/src/app/routes/admin/users.tsx
@@ -18,6 +18,7 @@ import { sortRows } from "../../lib/sort";
 import { shortDate } from "../../lib/dates";
 import { lastSeenLabel } from "../../lib/last-seen";
 import { Pager } from "../../ui/pagination";
+import { GrantCompDialog, type CompPlan } from "./comp-dialog";
 
 const PAGE_SIZE = 25;
 
@@ -98,26 +99,63 @@ const planBadgeColor: Record<OrgPlan, "mint" | "accent" | "muted"> = {
   free: "muted",
 };
 
-const PLAN_OPTIONS: OrgPlan[] = ["free", "hobby", "pro"];
+/** Where a user's paid access comes from, which is not the same question as
+ * what it unlocks (#81). A comp outranks a subscription, so it is named
+ * first. */
+function BillingCell({ user }: { user: AdminUserRow }) {
+  if (user.compPlan)
+    return (
+      <>
+        <Badge color="butter">comped</Badge>
+        <div className="mt-0.5 text-xs text-muted">
+          {user.compReason}
+          {user.compGrantedBy && ` · ${user.compGrantedBy}`}
+        </div>
+      </>
+    );
+  if (!user.subscriptionPlan) return <span className="text-xs text-muted">no subscription</span>;
+  if (user.subscriptionStatus === "past_due")
+    return (
+      <>
+        <Badge color="pink">past due</Badge>
+        <div className="mt-0.5 text-xs text-muted">payment failing, access kept</div>
+      </>
+    );
+  return (
+    <>
+      <Badge color="mint">paid</Badge>
+      {user.cancelAtPeriodEnd && (
+        <div className="mt-0.5 text-xs text-muted">cancels at period end</div>
+      )}
+    </>
+  );
+}
 
-/** The three "Set plan: …" menu items, with a checkmark on the current one. */
-function PlanMenuItems({
-  current,
-  onSetPlan,
+/** Grant, change, or revoke a comp. There is no "set plan": a plan an admin
+ * writes by hand is a comp, and it is recorded as one. */
+function CompMenuItems({
+  user,
+  onGrant,
+  onRevoke,
 }: {
-  current: OrgPlan;
-  onSetPlan: (plan: OrgPlan) => void;
+  user: AdminUserRow;
+  onGrant: () => void;
+  onRevoke: () => void;
 }) {
   return (
     <>
-      {PLAN_OPTIONS.map((plan) => (
-        <MenuItem key={plan} onClick={() => onSetPlan(plan)}>
-          <span className="w-3.5">
-            {current === plan && <Check size={13} className="text-accent" />}
-          </span>
-          Set plan: {plan}
+      <MenuItem onClick={onGrant}>
+        <span className="w-3.5">
+          {user.compPlan && <Check size={13} className="text-accent" />}
+        </span>
+        {user.compPlan ? `Change comp (${user.compPlan})` : "Comp a paid plan…"}
+      </MenuItem>
+      {user.compPlan && (
+        <MenuItem onClick={onRevoke}>
+          <span className="w-3.5" />
+          Revoke comp
         </MenuItem>
-      ))}
+      )}
     </>
   );
 }
@@ -172,12 +210,14 @@ function DangerMenuItems({
 function UserRow({
   user,
   isSelf,
-  onSetPlan,
+  onGrantComp,
+  onRevokeComp,
   onConfirm,
 }: {
   user: AdminUserRow;
   isSelf: boolean;
-  onSetPlan: (plan: OrgPlan) => void;
+  onGrantComp: () => void;
+  onRevokeComp: () => void;
   onConfirm: (kind: UserAction) => void;
 }) {
   return (
@@ -194,6 +234,9 @@ function UserRow({
       <Td>
         <Badge color={planBadgeColor[user.plan]}>{user.plan}</Badge>
       </Td>
+      <Td>
+        <BillingCell user={user} />
+      </Td>
       <Td className="text-xs text-muted">{shortDate(user.createdAt)}</Td>
       <Td className="text-xs text-muted">{lastSeenLabel(user.lastSeen)}</Td>
       <Td>
@@ -209,7 +252,7 @@ function UserRow({
           }
         >
           <AdminToggleMenuItem user={user} isSelf={isSelf} onConfirm={onConfirm} />
-          <PlanMenuItems current={user.plan} onSetPlan={onSetPlan} />
+          <CompMenuItems user={user} onGrant={onGrantComp} onRevoke={onRevokeComp} />
           <DangerMenuItems user={user} isSelf={isSelf} onConfirm={onConfirm} />
         </Menu>
       </Td>
@@ -222,7 +265,8 @@ function UsersTable({
   meId,
   sort,
   setSort,
-  onSetPlan,
+  onGrantComp,
+  onRevokeComp,
   onConfirm,
   searchTerm,
 }: {
@@ -230,7 +274,8 @@ function UsersTable({
   meId: string | undefined;
   sort: Sort;
   setSort: (s: Sort) => void;
-  onSetPlan: (user: AdminUserRow, plan: OrgPlan) => void;
+  onGrantComp: (user: AdminUserRow) => void;
+  onRevokeComp: (user: AdminUserRow) => void;
   onConfirm: (kind: UserAction, user: AdminUserRow) => void;
   searchTerm: string;
 }) {
@@ -242,6 +287,7 @@ function UsersTable({
           <Th>Email</Th>
           <SortTh label="Orgs" sortKey="orgs" sort={sort} onSort={setSort} className="text-right" />
           <Th>Plan</Th>
+          <Th>Billing</Th>
           <SortTh label="Joined" sortKey="joined" sort={sort} onSort={setSort} />
           <SortTh label="Last seen" sortKey="lastSeen" sort={sort} onSort={setSort} />
           <Th className="text-right">Actions</Th>
@@ -253,13 +299,14 @@ function UsersTable({
             key={u.id}
             user={u}
             isSelf={u.id === meId}
-            onSetPlan={(plan) => onSetPlan(u, plan)}
+            onGrantComp={() => onGrantComp(u)}
+            onRevokeComp={() => onRevokeComp(u)}
             onConfirm={(kind) => onConfirm(kind, u)}
           />
         ))}
         {rows.length === 0 && (
           <tr>
-            <Td colSpan={7} className="py-8 text-center text-muted">
+            <Td colSpan={8} className="py-8 text-center text-muted">
               No users match “{searchTerm}”.
             </Td>
           </tr>
@@ -306,6 +353,7 @@ export function AdminUsersPage() {
     kind: UserAction;
     user: AdminUserRow;
   } | null>(null);
+  const [compFor, setCompFor] = useState<AdminUserRow | null>(null);
   const [q, setQ] = useState("");
   const [sort, setSort] = useState<Sort>({ key: "joined", dir: -1 });
   const [page, setPage] = useState(0);
@@ -318,11 +366,33 @@ export function AdminUsersPage() {
       body,
     }: {
       userId: string;
-      body: { isAdmin?: boolean; banned?: boolean; plan?: OrgPlan };
+      body: { isAdmin?: boolean; banned?: boolean };
     }) => api(`/admin/users/${userId}`, { method: "PATCH", body }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "users"] });
       setConfirm(null);
+    },
+    onError: withErrorToast(toast),
+  });
+
+  // Comps have their own routes: they write the comp columns and re-derive
+  // the plan, and they can never be mistaken for a Polar subscription (#81).
+  const grantComp = useMutation({
+    mutationFn: ({ userId, plan, reason }: { userId: string; plan: CompPlan; reason: string }) =>
+      api(`/admin/users/${userId}/comp`, { method: "POST", body: { plan, reason } }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "users"] });
+      setCompFor(null);
+      toast("Comp granted");
+    },
+    onError: withErrorToast(toast),
+  });
+
+  const revokeComp = useMutation({
+    mutationFn: (userId: string) => api(`/admin/users/${userId}/comp`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "users"] });
+      toast("Comp revoked");
     },
     onError: withErrorToast(toast),
   });
@@ -402,12 +472,8 @@ export function AdminUsersPage() {
         meId={me.data?.user.id}
         sort={sort}
         setSort={setSort}
-        onSetPlan={(u, plan) =>
-          patchUser.mutate(
-            { userId: u.id, body: { plan } },
-            { onSuccess: () => toast("Plan updated") },
-          )
-        }
+        onGrantComp={(u) => setCompFor(u)}
+        onRevokeComp={(u) => revokeComp.mutate(u.id)}
         onConfirm={(kind, u) => setConfirm({ kind, user: u })}
         searchTerm={q.trim()}
       />
@@ -419,6 +485,15 @@ export function AdminUsersPage() {
         onConfirm={runAction}
         pending={patchUser.isPending || remove.isPending}
       />
+
+      {compFor && (
+        <GrantCompDialog
+          user={compFor}
+          onClose={() => setCompFor(null)}
+          onGrant={(plan, reason) => grantComp.mutate({ userId: compFor.id, plan, reason })}
+          pending={grantComp.isPending}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/routes/admin/users.tsx
+++ b/src/app/routes/admin/users.tsx
@@ -121,6 +121,17 @@ function BillingCell({ user }: { user: AdminUserRow }) {
         <div className="mt-0.5 text-xs text-muted">payment failing, access kept</div>
       </>
     );
+  // `subscriptionPlan` is the Polar snapshot, not a grant: `unpaid`,
+  // `canceled` and anything Polar adds later leave the subscription on the row
+  // while it entitles nothing. `plan` is derived from the status (#81), so a
+  // free plan here means exactly that. Name the status instead of "paid".
+  if (user.plan === "free")
+    return (
+      <>
+        <Badge color="muted">{user.subscriptionStatus ?? "unknown"}</Badge>
+        <div className="mt-0.5 text-xs text-muted">subscription grants no access</div>
+      </>
+    );
   return (
     <>
       <Badge color="mint">paid</Badge>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -295,9 +295,23 @@ export interface AdminUsage {
     orgName: string;
     clicks: number;
   }[];
-  /** Business row */
+  /** Business row.
+   *
+   * These are separate figures on purpose (#82). `planCounts` describes
+   * feature access and includes comped users; `payingSubscribers` counts real
+   * Polar subscriptions and excludes them. `mrr` is monthly-normalized from
+   * the amounts Polar reported, so a yearly subscription contributes a
+   * twelfth and a discounted one contributes what it charges.
+   * `committedMrr` drops subscriptions scheduled to cancel. */
   planCounts: { free: number; hobby: number; pro: number };
+  payingSubscribers: number;
+  compedUsers: number;
+  pendingCancellations: number;
   mrr: number;
+  committedMrr: number;
+  /** Currencies seen across live subscriptions. More than one means `mrr`
+   * mixes them and the figure needs conversion before it means anything. */
+  mrrCurrencies: string[];
   paidConversionRate: number | null;
   signups7d: number;
   signups7dDelta: DeltaValue | null;
@@ -369,7 +383,18 @@ export interface AdminUserRow {
   emailVerified: boolean;
   /** Email domain is a known throwaway provider. Display-only, computed on read. */
   disposable: boolean;
+  /** Effective plan: what this user may do. A comp counts here (#81). */
   plan: OrgPlan;
+  /** What Polar says, separately from what the user may do. `null` means no
+   * subscription; the status is Polar's own string (`active`, `past_due`, …). */
+  subscriptionPlan: Exclude<OrgPlan, "free"> | null;
+  subscriptionStatus: string | null;
+  cancelAtPeriodEnd: boolean;
+  /** What an admin granted by hand, and who granted it. */
+  compPlan: Exclude<OrgPlan, "free"> | null;
+  compReason: string | null;
+  compGrantedAt: number | null;
+  compGrantedBy: string | null;
   createdAt: number;
   orgCount: number;
   /** Last session activity (ms epoch), null if never signed in. */

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -15,9 +15,32 @@ export const user = sqliteTable("user", {
   banned: integer("banned", { mode: "boolean" }).notNull().default(false),
   // Billing lives on the user, not the org: one Free/Hobby/Pro subscription
   // per person. An org's effective limits are its owner's plan (see plan.ts).
+  //
+  // DERIVED. `plan` is what the user may do, and it is coalesce(comp_plan,
+  // entitling subscription_plan, 'free'). Only entitlement.ts writes it, and
+  // it always writes it from the two columns below in the same statement.
+  // Anything that sets it by hand puts entitlement out of step with billing,
+  // which is the bug #81 fixed.
   plan: text("plan", { enum: ["free", "hobby", "pro"] })
     .notNull()
     .default("free"),
+  // What Polar says: written by the webhook, never by an admin. Null means no
+  // subscription. `subscriptionStatus` is Polar's own status string, kept raw
+  // so a status we have no rule for is still visible (see entitlement.ts).
+  subscriptionPlan: text("subscription_plan", { enum: ["hobby", "pro"] }),
+  subscriptionStatus: text("subscription_status"),
+  // Pricing as actually charged, in the currency's minor units, so revenue is
+  // computed from facts rather than from list-price constants (#82).
+  subscriptionAmount: integer("subscription_amount"),
+  subscriptionCurrency: text("subscription_currency"),
+  subscriptionInterval: text("subscription_interval"),
+  // What an admin granted by hand: written by the comp routes, never by a
+  // webhook. A comp outranks the subscription, so revoking a subscription
+  // cannot take away access an admin gave.
+  compPlan: text("comp_plan", { enum: ["hobby", "pro"] }),
+  compGrantedBy: text("comp_granted_by"),
+  compGrantedAt: integer("comp_granted_at", { mode: "timestamp_ms" }),
+  compReason: text("comp_reason"),
   polarCustomerId: text("polar_customer_id"),
   polarSubscriptionId: text("polar_subscription_id"),
   polarSubscriptionCancelAtPeriodEnd: integer("polar_subscription_cancel_at_period_end", {

--- a/src/worker/entitlement.ts
+++ b/src/worker/entitlement.ts
@@ -1,0 +1,87 @@
+import { sql } from "drizzle-orm";
+import type { OrgPlan } from "@/shared/types";
+
+/**
+ * What a user may do, and what a user pays, are two facts (#81).
+ *
+ * - `subscription_plan` / `subscription_status`: what Polar says. Only the
+ *   webhook writes them.
+ * - `comp_plan`: what an admin granted by hand. Only the comp routes write it.
+ * - `plan`: derived from both, and the only column anything reads to decide
+ *   access.
+ *
+ * A comp outranks a subscription, so a `subscription.revoked` cannot strip
+ * access an admin granted, and a comp cannot rewrite what Polar reported.
+ */
+
+/** Polar's subscription statuses, and whether each one keeps paid access.
+ *
+ * `past_due` keeps access on purpose. Polar retries a failed payment for days
+ * and sends `subscription.revoked` when it gives up, so cutting access at the
+ * first failure punishes an expired card rather than a non-payer. The state is
+ * recorded and shown in admin instead.
+ *
+ * `canceled` does not keep access. A subscription the customer cancelled for
+ * the end of the period stays `active` with `cancel_at_period_end` until it
+ * ends; the status only reads `canceled` once it is actually over.
+ */
+export const SUBSCRIPTION_ACCESS: Record<string, boolean> = {
+  active: true,
+  trialing: true,
+  past_due: true,
+  canceled: false,
+  unpaid: false,
+  incomplete: false,
+  incomplete_expired: false,
+};
+
+/** Fails closed: a status with no rule grants nothing. */
+export function subscriptionGrantsAccess(status: string | null | undefined): boolean {
+  return status ? (SUBSCRIPTION_ACCESS[status] ?? false) : false;
+}
+
+/** The same decision the SQL below makes, in TypeScript, for tests and for
+ * code holding a row it has already read. */
+export function resolveEffectivePlan(row: {
+  compPlan?: OrgPlan | null;
+  subscriptionPlan?: OrgPlan | null;
+  subscriptionStatus?: string | null;
+}): OrgPlan {
+  if (row.compPlan) return row.compPlan;
+  if (row.subscriptionPlan && subscriptionGrantsAccess(row.subscriptionStatus))
+    return row.subscriptionPlan;
+  return "free";
+}
+
+/** The statuses that keep access, as a SQL list, built from the table above so
+ * the two cannot drift. */
+const ACCESS_STATUSES = Object.entries(SUBSCRIPTION_ACCESS)
+  .flatMap(([status, allowed]) => (allowed ? [`'${status}'`] : []))
+  .join(", ");
+
+/**
+ * `plan` recomputed from the two source columns, for the SET clause of any
+ * statement that changes either of them.
+ *
+ * It reads the columns rather than taking values, so one expression serves
+ * both a webhook write (which changes `subscription_*` and leaves `comp_*`
+ * alone) and a comp write (the reverse). SQLite applies a SET clause against
+ * the row as it was before the statement, so the column being written in the
+ * same statement has to be passed in: `overrides` does that.
+ */
+export function effectivePlanSql(overrides: {
+  compPlan?: string | null;
+  subscriptionPlan?: string | null;
+  subscriptionStatus?: string | null;
+}) {
+  const comp = "compPlan" in overrides ? sql`${overrides.compPlan ?? null}` : sql`comp_plan`;
+  const plan =
+    "subscriptionPlan" in overrides
+      ? sql`${overrides.subscriptionPlan ?? null}`
+      : sql`subscription_plan`;
+  const status =
+    "subscriptionStatus" in overrides
+      ? sql`${overrides.subscriptionStatus ?? null}`
+      : sql`subscription_status`;
+  return sql`coalesce(${comp}, case when ${status} in (${sql.raw(ACCESS_STATUSES)}) then ${plan} end, 'free')`;
+}

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -122,8 +122,12 @@ export function computeRevenue(rows: SubscriptionRevenueRow[]) {
     payingSubscribers += 1;
     if (row.cancelAtPeriodEnd) pendingCancellations += 1;
     const months = row.interval ? MONTHS_PER_INTERVAL[row.interval] : undefined;
-    if (row.amount === null || !months) continue;
-    if (row.currency) currencies.add(row.currency);
+    // A row missing any of the three cannot be priced. That includes the
+    // currency: an amount added without one leaves MRR a number in no stated
+    // currency, which is worse than a figure that admits it is short a
+    // subscription. The subscriber count above still has them all.
+    if (row.amount === null || !row.currency || !months) continue;
+    currencies.add(row.currency);
     const monthly = row.amount / months;
     mrrMinor += monthly;
     // Committed MRR is what renews. Someone who cancelled today still has

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { eq, ne, gte, and, desc, lt, inArray, sql } from "drizzle-orm";
+import { eq, ne, gte, and, desc, lt, inArray, isNotNull, sql } from "drizzle-orm";
 import * as schema from "../db/schema";
 import type { AppEnv, DB } from "../env";
 import { requireAdmin } from "../guards";
@@ -15,6 +15,7 @@ import {
 } from "@/shared/types";
 import { fillSeries, computeDelta, deleteOrg } from "./orgs";
 import { orgPlan } from "../plan";
+import { effectivePlanSql, subscriptionGrantsAccess } from "../entitlement";
 import { jsonBodyLimit } from "../body-limit";
 
 // An org's effective plan is its owner's plan (billing is per-user). A single
@@ -76,11 +77,66 @@ function cumulativeSeries(
   return result;
 }
 
-function computePlanStats(planCountRows: { plan: string; n: number }[]) {
+function computePlanCounts(planCountRows: { plan: string; n: number }[]) {
   const planCounts = { free: 0, hobby: 0, pro: 0 };
   for (const r of planCountRows) planCounts[r.plan as OrgPlan] = r.n;
-  const mrr = planCounts.hobby * 4 + planCounts.pro * 9;
-  return { planCounts, mrr };
+  return planCounts;
+}
+
+/** One month's worth of a recurring amount. Anything else is left out rather
+ * than guessed: a wrong interval quietly multiplies revenue by twelve. */
+const MONTHS_PER_INTERVAL: Record<string, number> = {
+  day: 1 / 30,
+  week: 1 / 4,
+  month: 1,
+  year: 12,
+};
+
+export interface SubscriptionRevenueRow {
+  amount: number | null;
+  currency: string | null;
+  interval: string | null;
+  status: string | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+/**
+ * Revenue from what subscriptions actually charge (#82).
+ *
+ * The old figure was `hobby * 4 + pro * 9` over the `plan` column, so it
+ * counted comps as money, read every discount at list price, counted a yearly
+ * subscription as if it were monthly, and rewrote history whenever prices
+ * changed. Each of those is fixed by reading the stored amount, currency and
+ * interval Polar reported, and by counting subscriptions rather than plans.
+ *
+ * Amounts are stored in minor units; MRR is reported in whole currency units.
+ */
+export function computeRevenue(rows: SubscriptionRevenueRow[]) {
+  let mrrMinor = 0;
+  let committedMinor = 0;
+  let payingSubscribers = 0;
+  let pendingCancellations = 0;
+  const currencies = new Set<string>();
+  for (const row of rows) {
+    if (!subscriptionGrantsAccess(row.status)) continue;
+    payingSubscribers += 1;
+    if (row.cancelAtPeriodEnd) pendingCancellations += 1;
+    const months = row.interval ? MONTHS_PER_INTERVAL[row.interval] : undefined;
+    if (row.amount === null || !months) continue;
+    if (row.currency) currencies.add(row.currency);
+    const monthly = row.amount / months;
+    mrrMinor += monthly;
+    // Committed MRR is what renews. Someone who cancelled today still has
+    // access until the period ends, and still is not revenue next month.
+    if (!row.cancelAtPeriodEnd) committedMinor += monthly;
+  }
+  return {
+    payingSubscribers,
+    pendingCancellations,
+    mrr: Math.round(mrrMinor / 100),
+    committedMrr: Math.round(committedMinor / 100),
+    mrrCurrencies: [...currencies].sort(),
+  };
 }
 
 /** Every business-metrics query returns its count as the first row's `n`,
@@ -94,14 +150,19 @@ export function firstCount(rows: { n: number }[]): number {
 export function computeBusinessMetrics(rows: {
   users: { n: number }[];
   proUsers: { n: number }[];
+  compedUserRows: { n: number }[];
+  subscriptionRows: SubscriptionRevenueRow[];
   planCountRows: { plan: string; n: number }[];
   signups7dRows: { n: number }[];
   signups7dPrevRows: { n: number }[];
   wauRows: { n: number }[];
 }) {
   const totalUsers = firstCount(rows.users);
+  // Feature access, comps included: this is "how many people are on a paid
+  // plan", which is a different question from "how many people pay".
   const paidUsers = firstCount(rows.proUsers);
-  const { planCounts, mrr } = computePlanStats(rows.planCountRows);
+  const planCounts = computePlanCounts(rows.planCountRows);
+  const revenue = computeRevenue(rows.subscriptionRows);
   const paidConversionRate = totalUsers > 0 ? Math.round((paidUsers / totalUsers) * 100) : null;
   const signups7d = firstCount(rows.signups7dRows);
   const signups7dPrev = firstCount(rows.signups7dPrevRows);
@@ -111,7 +172,8 @@ export function computeBusinessMetrics(rows: {
     totalUsers,
     paidUsers,
     planCounts,
-    mrr,
+    compedUsers: firstCount(rows.compedUserRows),
+    ...revenue,
     paidConversionRate,
     signups7d,
     signups7dDelta,
@@ -244,6 +306,8 @@ adminRoutes.get("/usage", async (c) => {
     orgCreationRows,
     anomaly24hRows,
     anomaly14dRows,
+    compedUserRows,
+    subscriptionRows,
   ] = await Promise.all([
     db.select({ n: sql<number>`count(*)` }).from(schema.user),
     db.select({ n: sql<number>`count(*)` }).from(schema.orgs),
@@ -368,6 +432,22 @@ adminRoutes.get("/usage", async (c) => {
       .from(schema.clicks)
       .where(gte(schema.clicks.ts, since14d))
       .groupBy(schema.clicks.orgId),
+    // comped users: paid access an admin granted, which is not revenue (#82)
+    db
+      .select({ n: sql<number>`count(*)` })
+      .from(schema.user)
+      .where(isNotNull(schema.user.compPlan)),
+    // live subscriptions, priced as Polar reported them
+    db
+      .select({
+        amount: schema.user.subscriptionAmount,
+        currency: schema.user.subscriptionCurrency,
+        interval: schema.user.subscriptionInterval,
+        status: schema.user.subscriptionStatus,
+        cancelAtPeriodEnd: schema.user.polarSubscriptionCancelAtPeriodEnd,
+      })
+      .from(schema.user)
+      .where(isNotNull(schema.user.subscriptionPlan)),
   ]);
 
   // ── Business row ──
@@ -376,7 +456,12 @@ adminRoutes.get("/usage", async (c) => {
     totalUsers,
     paidUsers,
     planCounts,
+    compedUsers,
+    payingSubscribers,
+    pendingCancellations,
     mrr,
+    committedMrr,
+    mrrCurrencies,
     paidConversionRate,
     signups7d,
     signups7dDelta,
@@ -384,6 +469,8 @@ adminRoutes.get("/usage", async (c) => {
   } = computeBusinessMetrics({
     users,
     proUsers,
+    compedUserRows,
+    subscriptionRows,
     planCountRows,
     signups7dRows,
     signups7dPrevRows,
@@ -444,7 +531,12 @@ adminRoutes.get("/usage", async (c) => {
     })),
     topLinks: topLinkRows,
     planCounts,
+    payingSubscribers,
+    compedUsers,
+    pendingCancellations,
     mrr,
+    committedMrr,
+    mrrCurrencies,
     paidConversionRate,
     signups7d,
     signups7dDelta,
@@ -559,6 +651,18 @@ adminRoutes.get("/users", async (c) => {
       banned: schema.user.banned,
       emailVerified: schema.user.emailVerified,
       plan: schema.user.plan,
+      subscriptionPlan: schema.user.subscriptionPlan,
+      subscriptionStatus: schema.user.subscriptionStatus,
+      cancelAtPeriodEnd: schema.user.polarSubscriptionCancelAtPeriodEnd,
+      compPlan: schema.user.compPlan,
+      compReason: schema.user.compReason,
+      compGrantedAt: schema.user.compGrantedAt,
+      // Who granted the comp, by email: an admin reading this list wants a
+      // person, not an id. Null once that admin's account is gone.
+      compGrantedBy: sql<string | null>`(
+        select grantor.email from "user" as grantor
+        where grantor.id = "user".comp_granted_by
+      )`,
       createdAt: schema.user.createdAt,
       orgCount: sql<number>`(
         select count(*) from org_members where org_members.user_id = "user".id
@@ -576,6 +680,7 @@ adminRoutes.get("/users", async (c) => {
       ...r,
       disposable: isDisposableEmail(r.email),
       createdAt: r.createdAt.getTime(),
+      compGrantedAt: r.compGrantedAt?.getTime() ?? null,
     })) satisfies AdminUserRow[],
   );
 });
@@ -614,16 +719,10 @@ async function validateBannedPatch(
   return value;
 }
 
-function validatePlanPatch(value: string | undefined): OrgPlan | undefined {
-  if (value === undefined) return undefined;
-  if (value !== "free" && value !== "hobby" && value !== "pro")
-    throw new HTTPException(400, { message: "plan must be free, hobby or pro" });
-  return value;
-}
-
-// Superadmin controls: toggle platform-admin, ban/unban, and/or comp a user's
-// plan (free/hobby/pro). Plan lives on the user, so comping a paid plan
-// unlocks every org they own.
+// Superadmin controls: toggle platform-admin and ban/unban. Granting a plan
+// by hand is not here: it is a comp, and it has its own routes below, because
+// a comp written into `plan` was indistinguishable from a paid subscription
+// (#81).
 adminRoutes.patch("/users/:userId", async (c) => {
   const body = await c.req.json<{
     isAdmin?: boolean;
@@ -634,18 +733,75 @@ adminRoutes.patch("/users/:userId", async (c) => {
   const self = c.var.user!;
   const db = c.var.db;
 
-  const patch: { isAdmin?: boolean; banned?: boolean; plan?: OrgPlan } = {
+  if (body.plan !== undefined)
+    throw new HTTPException(400, {
+      message: "Plan is derived from a subscription or a comp: use the comp routes",
+    });
+  const patch: { isAdmin?: boolean; banned?: boolean } = {
     isAdmin: validateIsAdminPatch(body.isAdmin, targetId, self.id),
     banned: await validateBannedPatch(db, body.banned, targetId, self.id),
-    plan: validatePlanPatch(body.plan),
   };
-  if (patch.isAdmin === undefined && patch.banned === undefined && patch.plan === undefined)
+  if (patch.isAdmin === undefined && patch.banned === undefined)
     throw new HTTPException(400, { message: "Nothing to update" });
 
   await db.update(schema.user).set(patch).where(eq(schema.user.id, targetId));
   // Banning kicks the user out immediately: all their sessions are wiped, and
   // better-auth refuses to create new ones (see better-auth.ts).
   if (patch.banned) await db.delete(schema.session).where(eq(schema.session.userId, targetId));
+  return c.json({ ok: true });
+});
+
+/**
+ * Grant a comp: paid access an admin gives by hand, recorded as such (#81).
+ *
+ * The write touches `comp_*` and re-derives `plan`, and never the
+ * `subscription_*` columns: a comp says nothing about what Polar knows, so it
+ * must not be able to invent a subscription. The reverse holds in
+ * routes/billing.ts, where a webhook cannot clear a comp.
+ */
+adminRoutes.post("/users/:userId/comp", async (c) => {
+  const body = await c.req
+    .json<{ plan?: string; reason?: string }>()
+    .catch(() => ({}) as { plan?: string; reason?: string });
+  const plan = body.plan;
+  if (plan !== "hobby" && plan !== "pro")
+    throw new HTTPException(400, { message: "plan must be hobby or pro" });
+  const reason = (body.reason ?? "").trim();
+  // A comp with no reason is the state #81 was written about: access nobody
+  // can account for later.
+  if (!reason) throw new HTTPException(400, { message: "reason is required" });
+  if (reason.length > 500) throw new HTTPException(400, { message: "reason is too long" });
+
+  const targetId = c.req.param("userId");
+  const result = await c.var.db
+    .update(schema.user)
+    .set({
+      compPlan: plan,
+      compReason: reason,
+      compGrantedBy: c.var.user!.id,
+      compGrantedAt: new Date(),
+      plan: effectivePlanSql({ compPlan: plan }),
+    })
+    .where(eq(schema.user.id, targetId));
+  if (result.meta.changes === 0) throw new HTTPException(404, { message: "User not found" });
+  return c.json({ ok: true });
+});
+
+/** Revoke a comp. The subscription underneath, if there is one, comes back:
+ * `plan` re-derives from the columns the webhook owns. */
+adminRoutes.delete("/users/:userId/comp", async (c) => {
+  const targetId = c.req.param("userId");
+  const result = await c.var.db
+    .update(schema.user)
+    .set({
+      compPlan: null,
+      compReason: null,
+      compGrantedBy: null,
+      compGrantedAt: null,
+      plan: effectivePlanSql({ compPlan: null }),
+    })
+    .where(eq(schema.user.id, targetId));
+  if (result.meta.changes === 0) throw new HTTPException(404, { message: "User not found" });
   return c.json({ ok: true });
 });
 

--- a/src/worker/routes/billing.ts
+++ b/src/worker/routes/billing.ts
@@ -255,6 +255,11 @@ async function subscriptionUpdatedMutation(db: Db, env: Env, event: PolarEvent) 
     .update(schema.user)
     .set({
       ...subscriptionFacts(event, plan, status),
+      // Identity moves with the facts. The row holds one subscription, the
+      // most recently changed one, so writing another subscription's plan,
+      // status and price while leaving the old id in place would describe a
+      // subscription that does not exist.
+      polarSubscriptionId: event.data.id,
       polarSubscriptionCancelAtPeriodEnd: event.data.cancel_at_period_end ?? false,
       polarSubscriptionCurrentPeriodEnd: periodEnd ? new Date(periodEnd) : null,
       polarEventAt: at,

--- a/src/worker/routes/billing.ts
+++ b/src/worker/routes/billing.ts
@@ -8,6 +8,7 @@ import * as schema from "../db/schema";
 import type { AppEnv, Env } from "../env";
 import { requireUser } from "../guards";
 import { alertBetterStack } from "../alerts";
+import { effectivePlanSql } from "../entitlement";
 import { jsonBodyLimit } from "../body-limit";
 
 const polarFor = (env: Env) =>
@@ -80,6 +81,13 @@ interface PolarEvent {
     cancel_at_period_end?: boolean;
     current_period_end?: string;
     ends_at?: string | null;
+    // What this subscription actually charges, in the currency's minor units,
+    // as Polar reports it on the subscription itself (so a discounted
+    // subscription reports the discounted amount). Revenue is computed from
+    // these rather than from list-price constants (#82).
+    amount?: number | null;
+    currency?: string | null;
+    recurring_interval?: string | null;
     // How fresh this snapshot is. `modified_at` is null until the
     // subscription's first change, so `created_at` is the fallback; both are
     // on every Polar object (see @polar-sh/sdk's Subscription model).
@@ -127,15 +135,39 @@ function notStale(at: Date) {
  */
 
 /** Which user an event addresses: its checkout metadata, or the subscription
- * id we already stored for them. */
+ * id we already stored for them.
+ *
+ * One row holds one subscription, and it is whichever subscription changed
+ * most recently: two concurrent subscriptions for one person resolve through
+ * `notStale`, so the later change wins and the earlier one cannot write back
+ * over it (#84). Nothing here sums two subscriptions, and the product does
+ * not sell a second one. */
 function subjectOf(event: PolarEvent) {
   const userId = String(event.data.metadata?.userId ?? "");
   return userId ? eq(schema.user.id, userId) : eq(schema.user.polarSubscriptionId, event.data.id);
 }
 
-async function subscriptionActiveMutation(db: Db, env: Env, event: PolarEvent) {
-  const userId = String(event.data.metadata?.userId ?? "");
-  if (!userId) return null;
+/**
+ * The subscription facts an event carries, plus the `plan` they derive to.
+ *
+ * A webhook writes what Polar says and never touches `comp_*`: an admin's
+ * comp outranks it, so `effectivePlanSql` reads the comp column off the row
+ * and a revoked subscription cannot strip granted access (#81).
+ */
+function subscriptionFacts(event: PolarEvent, plan: "hobby" | "pro" | null, status: string) {
+  return {
+    subscriptionPlan: plan,
+    subscriptionStatus: status,
+    subscriptionAmount: event.data.amount ?? null,
+    subscriptionCurrency: event.data.currency ?? null,
+    subscriptionInterval: event.data.recurring_interval ?? null,
+    plan: effectivePlanSql({ subscriptionPlan: plan, subscriptionStatus: status }),
+  };
+}
+
+/** Alerts and declines to write when a product id maps to no plan. Fails
+ * closed: an unrecognized product must never grant a plan (#17). */
+async function planForProductOrAlert(env: Env, event: PolarEvent, userId: string | null) {
   const plan = planForProduct(env, event.data.product_id);
   if (!plan) {
     await alertBetterStack(env, [
@@ -146,13 +178,20 @@ async function subscriptionActiveMutation(db: Db, env: Env, event: PolarEvent) {
         userId,
       },
     ]);
-    return null;
   }
+  return plan;
+}
+
+async function subscriptionActiveMutation(db: Db, env: Env, event: PolarEvent) {
+  const userId = String(event.data.metadata?.userId ?? "");
+  if (!userId) return null;
+  const plan = await planForProductOrAlert(env, event, userId);
+  if (!plan) return null;
   const at = eventAt(event);
   return db
     .update(schema.user)
     .set({
-      plan,
+      ...subscriptionFacts(event, plan, event.data.status ?? "active"),
       polarCustomerId: event.data.customer_id ?? null,
       polarSubscriptionId: event.data.id,
       polarSubscriptionCancelAtPeriodEnd: false,
@@ -167,7 +206,9 @@ function subscriptionRevokedMutation(db: Db, event: PolarEvent) {
   return db
     .update(schema.user)
     .set({
-      plan: "free",
+      // The subscription is over, so its facts go with it. A comped user
+      // keeps their comp, and `effectivePlanSql` keeps returning it.
+      ...subscriptionFacts(event, null, event.data.status ?? "canceled"),
       polarSubscriptionId: null,
       polarSubscriptionCancelAtPeriodEnd: false,
       polarSubscriptionCurrentPeriodEnd: null,
@@ -191,25 +232,33 @@ function subscriptionCanceledMutation(db: Db, event: PolarEvent) {
     .where(and(subjectOf(event), notStale(at)));
 }
 
+/**
+ * `subscription.updated` is the complete subscription, not a plan signal
+ * (#84). It used to apply only `plan`, and only while `status === "active"`,
+ * so every transition *out* of active, every cancellation state, and every
+ * period end that arrived through this event was discarded.
+ *
+ * It now writes the whole snapshot. Which statuses keep access is one
+ * decision, made in `entitlement.ts` and applied through `effectivePlanSql`.
+ */
 async function subscriptionUpdatedMutation(db: Db, env: Env, event: PolarEvent) {
-  if (event.data.status !== "active" || !event.data.product_id) return null;
+  const status = event.data.status;
+  // Polar puts both on every subscription payload. Without them there is no
+  // snapshot to apply, and guessing the missing half would write fiction.
+  if (!status || !event.data.product_id) return null;
   const userId = String(event.data.metadata?.userId ?? "");
-  const plan = planForProduct(env, event.data.product_id);
-  if (!plan) {
-    await alertBetterStack(env, [
-      {
-        event: "polar_webhook_unknown_product",
-        subscriptionId: event.data.id,
-        productId: event.data.product_id,
-        userId: userId || null,
-      },
-    ]);
-    return null;
-  }
+  const plan = await planForProductOrAlert(env, event, userId || null);
+  if (!plan) return null;
   const at = eventAt(event);
+  const periodEnd = event.data.current_period_end ?? event.data.ends_at;
   return db
     .update(schema.user)
-    .set({ plan, polarEventAt: at })
+    .set({
+      ...subscriptionFacts(event, plan, status),
+      polarSubscriptionCancelAtPeriodEnd: event.data.cancel_at_period_end ?? false,
+      polarSubscriptionCurrentPeriodEnd: periodEnd ? new Date(periodEnd) : null,
+      polarEventAt: at,
+    })
     .where(and(subjectOf(event), notStale(at)));
 }
 

--- a/tests/admin-business-metrics.test.ts
+++ b/tests/admin-business-metrics.test.ts
@@ -16,6 +16,11 @@ describe("computeBusinessMetrics", () => {
     const metrics = computeBusinessMetrics({
       users: [{ n: 100 }],
       proUsers: [{ n: 25 }],
+      compedUserRows: [{ n: 3 }],
+      subscriptionRows: [
+        { amount: 900, currency: "usd", interval: "month", status: "active", cancel: false },
+        { amount: 400, currency: "usd", interval: "month", status: "active", cancel: false },
+      ].map((s) => ({ ...s, cancelAtPeriodEnd: s.cancel })),
       planCountRows: [
         { plan: "free", n: 60 },
         { plan: "hobby", n: 15 },
@@ -29,7 +34,11 @@ describe("computeBusinessMetrics", () => {
     expect(metrics.paidUsers).toBe(25);
     expect(metrics.paidConversionRate).toBe(25);
     expect(metrics.planCounts).toEqual({ free: 60, hobby: 15, pro: 25 });
-    expect(metrics.mrr).toBe(15 * 4 + 25 * 9);
+    // Two real subscriptions, not 40 plan rows at list price: paid access and
+    // paid money are different counts now (#82).
+    expect(metrics.payingSubscribers).toBe(2);
+    expect(metrics.compedUsers).toBe(3);
+    expect(metrics.mrr).toBe(13);
     expect(metrics.signups7d).toBe(20);
     expect(metrics.signups7dDelta.pct).toBe(100);
     expect(metrics.wau).toBe(80);
@@ -39,6 +48,8 @@ describe("computeBusinessMetrics", () => {
     const metrics = computeBusinessMetrics({
       users: [],
       proUsers: [],
+      compedUserRows: [],
+      subscriptionRows: [],
       planCountRows: [],
       signups7dRows: [],
       signups7dPrevRows: [],
@@ -46,5 +57,6 @@ describe("computeBusinessMetrics", () => {
     });
     expect(metrics.totalUsers).toBe(0);
     expect(metrics.paidConversionRate).toBeNull();
+    expect(metrics.mrr).toBe(0);
   });
 });

--- a/tests/admin-revenue.test.ts
+++ b/tests/admin-revenue.test.ts
@@ -61,6 +61,15 @@ describe("computeRevenue", () => {
     expect(r.mrrCurrencies).toEqual(["eur", "usd"]);
   });
 
+  test("a subscription with no currency is a subscriber but not revenue", () => {
+    // An amount with no currency cannot be added to anything: counting it
+    // would leave MRR a number in no currency the card can name.
+    const r = computeRevenue([sub({ currency: null })]);
+    expect(r.payingSubscribers).toBe(1);
+    expect(r.mrr).toBe(0);
+    expect(r.mrrCurrencies).toEqual([]);
+  });
+
   test("no subscriptions is zero, not a division by anything", () => {
     expect(computeRevenue([])).toEqual({
       payingSubscribers: 0,

--- a/tests/admin-revenue.test.ts
+++ b/tests/admin-revenue.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { computeRevenue, type SubscriptionRevenueRow } from "../src/worker/routes/admin";
+
+const sub = (over: Partial<SubscriptionRevenueRow> = {}): SubscriptionRevenueRow => ({
+  amount: 900,
+  currency: "usd",
+  interval: "month",
+  status: "active",
+  cancelAtPeriodEnd: false,
+  ...over,
+});
+
+describe("computeRevenue", () => {
+  test("sums monthly subscriptions at the amount Polar reported", () => {
+    const r = computeRevenue([sub(), sub({ amount: 400 })]);
+    expect(r.payingSubscribers).toBe(2);
+    expect(r.mrr).toBe(13);
+    expect(r.committedMrr).toBe(13);
+  });
+
+  test("a discounted subscription contributes its discounted amount (#82)", () => {
+    // The old figure multiplied a plan count by a list price, so this row
+    // would have counted as the full $9.
+    expect(computeRevenue([sub({ amount: 450 })]).mrr).toBe(5);
+  });
+
+  test("a yearly subscription contributes a twelfth (#82)", () => {
+    expect(computeRevenue([sub({ amount: 9000, interval: "year" })]).mrr).toBe(8);
+  });
+
+  test("weekly and daily intervals normalize too", () => {
+    expect(computeRevenue([sub({ amount: 100, interval: "week" })]).mrr).toBe(4);
+    expect(computeRevenue([sub({ amount: 100, interval: "day" })]).mrr).toBe(30);
+  });
+
+  test("an interval with no rule is counted as a subscriber but not as revenue", () => {
+    const r = computeRevenue([sub({ interval: "fortnight" })]);
+    expect(r.payingSubscribers).toBe(1);
+    expect(r.mrr).toBe(0);
+  });
+
+  test("a subscription scheduled to cancel is MRR but not committed MRR", () => {
+    const r = computeRevenue([sub({ cancelAtPeriodEnd: true })]);
+    expect(r.mrr).toBe(9);
+    expect(r.committedMrr).toBe(0);
+    expect(r.pendingCancellations).toBe(1);
+  });
+
+  test("past_due keeps its revenue, since access is kept too", () => {
+    expect(computeRevenue([sub({ status: "past_due" })]).mrr).toBe(9);
+  });
+
+  test("a subscription that grants no access is neither a subscriber nor revenue", () => {
+    const r = computeRevenue([sub({ status: "unpaid" }), sub({ status: "incomplete" })]);
+    expect(r.payingSubscribers).toBe(0);
+    expect(r.mrr).toBe(0);
+  });
+
+  test("reports the currencies it added together", () => {
+    const r = computeRevenue([sub(), sub({ currency: "eur" }), sub({ currency: "usd" })]);
+    expect(r.mrrCurrencies).toEqual(["eur", "usd"]);
+  });
+
+  test("no subscriptions is zero, not a division by anything", () => {
+    expect(computeRevenue([])).toEqual({
+      payingSubscribers: 0,
+      pendingCancellations: 0,
+      mrr: 0,
+      committedMrr: 0,
+      mrrCurrencies: [],
+    });
+  });
+});

--- a/tests/e2e/billing-truth.pw.ts
+++ b/tests/e2e/billing-truth.pw.ts
@@ -1,0 +1,82 @@
+import { expect, test, type Page } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
+import { makePlatformAdmin, seedSubscriber } from "./db";
+
+const password = "test-password-123";
+
+/**
+ * The number on one /admin stat card.
+ *
+ * Read as a delta rather than asserted outright: the local database keeps
+ * whatever earlier runs left in it, so "MRR is $9" would depend on test
+ * order. "Comping someone moves MRR by nothing" does not.
+ */
+async function stat(page: Page, label: string): Promise<number> {
+  const card = page.getByText(label, { exact: true }).locator("..");
+  const text = (await card.textContent()) ?? "";
+  return Number(text.replace(label, "").replace(/[^0-9.-]/g, "")) || 0;
+}
+
+/**
+ * A comp and a subscription grant the same access and are not the same fact
+ * (#81), and only one of them is money (#82). This walks both through the
+ * admin area, which is the only place the difference is visible.
+ */
+test("an admin can comp a user, and the comp never counts as revenue", async ({ page }) => {
+  const subscriber = `playwright-sub-${Date.now()}@gmail.com`;
+  const admin = `playwright-admin-${Date.now()}@gmail.com`;
+
+  await signUpAndVerify(page, admin, password);
+  await makePlatformAdmin(page, admin);
+  // A real paying subscription: $9/mo, the way a Polar webhook leaves the row.
+  await seedSubscriber(page, subscriber, "pro", 900);
+
+  await page.goto("/admin/users");
+  const subscriberRow = page.getByRole("row", { name: new RegExp(subscriber) });
+  await expect(subscriberRow).toContainText("paid");
+
+  // The admin's own row: free, and no subscription behind it.
+  const adminRow = page.getByRole("row", { name: new RegExp(admin) });
+  await expect(adminRow).toContainText("no subscription");
+
+  // The seeded subscription is revenue: $9/mo of it.
+  await page.goto("/admin");
+  await expect(page.getByText("Subscribers", { exact: true })).toBeVisible();
+  const before = {
+    mrr: await stat(page, "MRR"),
+    subscribers: await stat(page, "Subscribers"),
+    comped: await stat(page, "Comped"),
+  };
+  expect(before.mrr).toBeGreaterThanOrEqual(9);
+
+  // Comp the admin's own account. The reason is required, so the button
+  // stays disabled until it is filled in.
+  await page.goto("/admin/users");
+  await adminRow.getByRole("button", { name: `Actions for` }).click();
+  await page.getByRole("menuitem", { name: "Comp a paid plan" }).click();
+  const dialog = page.getByRole("dialog", { name: /^Comp / });
+  await expect(dialog.getByRole("button", { name: "Grant comp" })).toBeDisabled();
+  await dialog.getByLabel("Reason").fill("Design partner");
+  await dialog.getByRole("button", { name: "Grant comp" }).click();
+
+  await expect(page.getByText("Comp granted")).toBeVisible();
+  await expect(adminRow).toContainText("comped");
+  await expect(adminRow).toContainText("Design partner");
+  await expect(adminRow).toContainText("pro");
+
+  // Access went up. Revenue did not: one more comped user, same MRR and the
+  // same subscriber count.
+  await page.goto("/admin");
+  await expect(page.getByText("Subscribers", { exact: true })).toBeVisible();
+  expect(await stat(page, "Comped")).toBe(before.comped + 1);
+  expect(await stat(page, "Subscribers")).toBe(before.subscribers);
+  expect(await stat(page, "MRR")).toBe(before.mrr);
+
+  // Revoking it takes the access away again, and leaves the subscriber alone.
+  await page.goto("/admin/users");
+  await adminRow.getByRole("button", { name: `Actions for` }).click();
+  await page.getByRole("menuitem", { name: "Revoke comp" }).click();
+  await expect(page.getByText("Comp revoked")).toBeVisible();
+  await expect(adminRow).toContainText("no subscription");
+  await expect(subscriberRow).toContainText("paid");
+});

--- a/tests/e2e/db.ts
+++ b/tests/e2e/db.ts
@@ -37,12 +37,99 @@ export async function queryRows<T extends Record<string, unknown>>(
   return rows.map((row) => Object.fromEntries(columns.map((c, i) => [c, row[i]])) as T);
 }
 
-export async function setPlan(page: Page, email: string, plan: "hobby" | "pro" = "hobby") {
-  const result = (await rawSql(page, "UPDATE user SET plan = ? WHERE email = ?", [
-    plan,
-    email,
-  ])) as { result: { meta: { changes: number } }[] };
+async function expectOneRowChanged(
+  page: Page,
+  sql: string,
+  params: unknown[],
+  what: string,
+): Promise<void> {
+  const result = (await rawSql(page, sql, params)) as {
+    result: { meta: { changes: number } }[];
+  };
   // An unmatched email leaves the UPDATE a silent no-op: fail here instead of
   // at some unrelated paid-plan gate downstream.
-  expect(result.result[0].meta.changes).toBe(1);
+  expect(result.result[0].meta.changes, what).toBe(1);
+}
+
+/**
+ * Gives a user a paying subscription, the way a Polar webhook would: the
+ * subscription columns carry the facts and `plan` is derived from them (#81).
+ * Writing `plan` on its own would produce a row no real flow can create.
+ */
+export async function setPlan(
+  page: Page,
+  email: string,
+  plan: "hobby" | "pro" = "hobby",
+  opts: { amount?: number; interval?: string; status?: string } = {},
+) {
+  const { amount = plan === "pro" ? 900 : 400, interval = "month", status = "active" } = opts;
+  // The Explorer's /raw endpoint only binds string parameters, so the amount
+  // is interpolated. It is a test-controlled integer; the assertion below
+  // keeps it that way.
+  expect(Number.isInteger(amount)).toBe(true);
+  await expectOneRowChanged(
+    page,
+    `UPDATE user
+     SET subscription_plan = ?, subscription_status = ?, subscription_amount = ${amount},
+         subscription_currency = 'usd', subscription_interval = ?,
+         polar_subscription_id = 'sub_e2e_' || id, polar_customer_id = 'cus_e2e_' || id,
+         plan = ?
+     WHERE email = ?`,
+    [plan, status, interval, status === "active" ? plan : "free", email],
+    `no user with email ${email}`,
+  );
+}
+
+/**
+ * Inserts a user who already pays, without going through signup: the test
+ * that needs one never signs in as them, and a second signup in the same
+ * browser context would have to sign the first user out first.
+ */
+export async function seedSubscriber(
+  page: Page,
+  email: string,
+  plan: "hobby" | "pro" = "pro",
+  amountMinor = 900,
+) {
+  expect(Number.isInteger(amountMinor)).toBe(true);
+  await expectOneRowChanged(
+    page,
+    `INSERT INTO user (id, name, email, email_verified, plan, subscription_plan,
+       subscription_status, subscription_amount, subscription_currency, subscription_interval,
+       polar_subscription_id, polar_customer_id, created_at, updated_at)
+     VALUES (?, 'Paying Customer', ?, 1, ?, ?, 'active', ${amountMinor}, 'usd', 'month',
+       ?, ?, unixepoch() * 1000, unixepoch() * 1000)`,
+    [`e2e-sub-${Date.now()}`, email, plan, plan, `sub_e2e_${Date.now()}`, `cus_e2e_${Date.now()}`],
+    `could not insert ${email}`,
+  );
+}
+
+/** Promotes a signed-up user to platform admin, for tests that need the
+ * admin area. Doing it in SQL keeps the test off the SUPERADMIN_EMAIL
+ * secret, which differs between machines. */
+export async function makePlatformAdmin(page: Page, email: string) {
+  await expectOneRowChanged(
+    page,
+    "UPDATE user SET is_admin = 1 WHERE email = ?",
+    [email],
+    `no user with email ${email}`,
+  );
+}
+
+/** Gives a user paid access the way an admin comp does: no subscription
+ * behind it, and no revenue. */
+export async function compUser(
+  page: Page,
+  email: string,
+  plan: "hobby" | "pro" = "pro",
+  reason = "e2e fixture",
+) {
+  await expectOneRowChanged(
+    page,
+    `UPDATE user
+     SET comp_plan = ?, comp_reason = ?, comp_granted_at = unixepoch() * 1000, plan = ?
+     WHERE email = ?`,
+    [plan, reason, plan, email],
+    `no user with email ${email}`,
+  );
 }

--- a/tests/e2e/db.ts
+++ b/tests/e2e/db.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from "@playwright/test";
 import { explorerUrl } from "./environment";
+import { subscriptionGrantsAccess } from "../../src/worker/entitlement";
 
 /** Runs raw SQL against the local D1 database via the dev Explorer API. */
 export async function rawSql(page: Page, sql: string, params: unknown[] = []): Promise<unknown> {
@@ -75,7 +76,10 @@ export async function setPlan(
          polar_subscription_id = 'sub_e2e_' || id, polar_customer_id = 'cus_e2e_' || id,
          plan = ?
      WHERE email = ?`,
-    [plan, status, interval, status === "active" ? plan : "free", email],
+    // The same rule the Worker applies, from the same table: `trialing` and
+    // `past_due` also entitle, so deciding on `active` alone would build a
+    // fixture no webhook can produce.
+    [plan, status, interval, subscriptionGrantsAccess(status) ? plan : "free", email],
     `no user with email ${email}`,
   );
 }

--- a/tests/entitlement.test.ts
+++ b/tests/entitlement.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SUBSCRIPTION_ACCESS,
+  resolveEffectivePlan,
+  subscriptionGrantsAccess,
+} from "../src/worker/entitlement";
+
+describe("subscriptionGrantsAccess", () => {
+  test("active and trialing subscriptions keep access", () => {
+    expect(subscriptionGrantsAccess("active")).toBe(true);
+    expect(subscriptionGrantsAccess("trialing")).toBe(true);
+  });
+
+  test("past_due keeps access, on purpose (#84)", () => {
+    // Polar retries a failed payment for days and revokes when it gives up.
+    // Cutting access at the first failure punishes an expired card.
+    expect(subscriptionGrantsAccess("past_due")).toBe(true);
+  });
+
+  test("unpaid, canceled and incomplete do not", () => {
+    expect(subscriptionGrantsAccess("unpaid")).toBe(false);
+    expect(subscriptionGrantsAccess("canceled")).toBe(false);
+    expect(subscriptionGrantsAccess("incomplete")).toBe(false);
+    expect(subscriptionGrantsAccess("incomplete_expired")).toBe(false);
+  });
+
+  test("fails closed on a status nobody has written a rule for", () => {
+    expect(subscriptionGrantsAccess("some_new_polar_status")).toBe(false);
+    expect(subscriptionGrantsAccess(null)).toBe(false);
+    expect(subscriptionGrantsAccess(undefined)).toBe(false);
+  });
+
+  test("every status in the table has an explicit decision", () => {
+    for (const [status, allowed] of Object.entries(SUBSCRIPTION_ACCESS))
+      expect(subscriptionGrantsAccess(status)).toBe(allowed);
+  });
+});
+
+describe("resolveEffectivePlan", () => {
+  test("no subscription and no comp is free", () => {
+    expect(resolveEffectivePlan({})).toBe("free");
+  });
+
+  test("an entitling subscription grants its plan", () => {
+    expect(resolveEffectivePlan({ subscriptionPlan: "pro", subscriptionStatus: "active" })).toBe(
+      "pro",
+    );
+  });
+
+  test("a subscription in a non-entitling status grants nothing", () => {
+    expect(resolveEffectivePlan({ subscriptionPlan: "pro", subscriptionStatus: "unpaid" })).toBe(
+      "free",
+    );
+  });
+
+  test("a comp outranks the subscription underneath it", () => {
+    expect(
+      resolveEffectivePlan({
+        compPlan: "pro",
+        subscriptionPlan: "hobby",
+        subscriptionStatus: "active",
+      }),
+    ).toBe("pro");
+  });
+
+  test("a comp survives a subscription that grants nothing", () => {
+    // This is the case #81 was written about: revoking a subscription must
+    // not strip access an admin granted by hand.
+    expect(resolveEffectivePlan({ compPlan: "hobby", subscriptionPlan: null })).toBe("hobby");
+  });
+});

--- a/tests/worker/billing.worker.ts
+++ b/tests/worker/billing.worker.ts
@@ -322,7 +322,9 @@ describe("POST /api/webhooks/polar", () => {
     expect(user.polarSubscriptionCurrentPeriodEnd).toBeNull();
   });
 
-  it("subscription.updated only applies the plan when the status is active", async () => {
+  // What each status does to access now lives in entitlement.worker.ts (#84);
+  // this keeps the original pair, which is still the common case.
+  it("subscription.updated grants the plan on an active status and not on a canceled one", async () => {
     await seedUser({ plan: "free" });
     await postWebhook({
       type: "subscription.updated",

--- a/tests/worker/entitlement.worker.ts
+++ b/tests/worker/entitlement.worker.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import { Webhook } from "standardwebhooks";
+import worker from "../../src/worker";
+import * as schema from "../../src/worker/db/schema";
+import {
+  applyTestMigrations,
+  adminCookie,
+  billingEnv,
+  POLAR_PRO_PRODUCT_ID,
+  POLAR_HOBBY_PRODUCT_ID,
+  POLAR_WEBHOOK_SECRET,
+} from "./support";
+
+// The Polar SDK is never reached by these tests (no checkout, no portal), but
+// importing the worker pulls it in, and its constructor wants a real token.
+vi.mock("@polar-sh/sdk", () => {
+  class Polar {
+    checkouts = { create: vi.fn() };
+    customerSessions = { create: vi.fn() };
+  }
+  return { Polar };
+});
+
+beforeEach(async () => {
+  await applyTestMigrations();
+});
+
+afterEach(async () => {
+  await reset();
+});
+
+const db = () => drizzle(env.DB, { schema });
+
+async function seedUser(overrides: Partial<typeof schema.user.$inferInsert> = {}) {
+  await db()
+    .insert(schema.user)
+    .values({
+      id: "user-1",
+      name: "Test User",
+      email: "user1@example.com",
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      ...overrides,
+    });
+}
+
+async function getUser(id = "user-1") {
+  const rows = await db().select().from(schema.user).where(eq(schema.user.id, id));
+  return rows[0];
+}
+
+let nextMsgId = 0;
+
+async function postWebhook(event: unknown): Promise<Response> {
+  const payload = JSON.stringify(event);
+  const msgId = `msg-${++nextMsgId}`;
+  const timestamp = new Date();
+  const signature = new Webhook(btoa(POLAR_WEBHOOK_SECRET)).sign(msgId, timestamp, payload);
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(
+    new Request("http://localhost/api/webhooks/polar", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "webhook-id": msgId,
+        "webhook-timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+        "webhook-signature": signature,
+      },
+      body: payload,
+    }),
+    billingEnv(),
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function adminFetch(cookie: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(
+    new Request(`http://localhost${path}`, {
+      ...init,
+      headers: { cookie, "content-type": "application/json", ...init.headers },
+    }),
+    billingEnv(),
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+const grantComp = (cookie: string, body: unknown, userId = "user-1") =>
+  adminFetch(cookie, `/api/admin/users/${userId}/comp`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+const revokeComp = (cookie: string, userId = "user-1") =>
+  adminFetch(cookie, `/api/admin/users/${userId}/comp`, { method: "DELETE" });
+
+/** A live pro subscription, as `subscription.active` would have left it. */
+const paying = {
+  plan: "pro" as const,
+  subscriptionPlan: "pro" as const,
+  subscriptionStatus: "active",
+  subscriptionAmount: 900,
+  subscriptionCurrency: "usd",
+  subscriptionInterval: "month",
+  polarSubscriptionId: "sub_1",
+};
+
+describe("comps (#81)", () => {
+  it("grants paid access and records who granted it and why", async () => {
+    const cookie = await adminCookie();
+    await seedUser();
+
+    const res = await grantComp(cookie, { plan: "pro", reason: "Design partner" });
+    expect(res.status).toBe(200);
+
+    const user = await getUser();
+    expect(user.plan).toBe("pro");
+    expect(user.compPlan).toBe("pro");
+    expect(user.compReason).toBe("Design partner");
+    expect(user.compGrantedBy).toBe("admin-1");
+    expect(user.compGrantedAt).not.toBeNull();
+  });
+
+  it("invents no subscription: a comp leaves every Polar column alone", async () => {
+    const cookie = await adminCookie();
+    await seedUser();
+    await grantComp(cookie, { plan: "pro", reason: "Support goodwill" });
+
+    const user = await getUser();
+    expect(user.subscriptionPlan).toBeNull();
+    expect(user.subscriptionStatus).toBeNull();
+    expect(user.subscriptionAmount).toBeNull();
+    expect(user.polarSubscriptionId).toBeNull();
+  });
+
+  it("refuses a comp with no reason", async () => {
+    const cookie = await adminCookie();
+    await seedUser();
+    const res = await grantComp(cookie, { plan: "pro", reason: "   " });
+    expect(res.status).toBe(400);
+    expect((await getUser()).plan).toBe("free");
+  });
+
+  it("refuses a comp of the free plan", async () => {
+    const cookie = await adminCookie();
+    await seedUser();
+    expect((await grantComp(cookie, { plan: "free", reason: "why" })).status).toBe(400);
+  });
+
+  it("404s for a user that does not exist", async () => {
+    const cookie = await adminCookie();
+    const res = await grantComp(cookie, { plan: "pro", reason: "why" }, "nobody");
+    expect(res.status).toBe(404);
+  });
+
+  it("no longer lets the plan be written straight onto the user", async () => {
+    const cookie = await adminCookie();
+    await seedUser();
+    const res = await adminFetch(cookie, "/api/admin/users/user-1", {
+      method: "PATCH",
+      body: JSON.stringify({ plan: "pro" }),
+    });
+    expect(res.status).toBe(400);
+    expect((await getUser()).plan).toBe("free");
+  });
+
+  it("revoking a comp drops the user back to free when nothing is behind it", async () => {
+    const cookie = await adminCookie();
+    await seedUser();
+    await grantComp(cookie, { plan: "pro", reason: "Trial run" });
+
+    expect((await revokeComp(cookie)).status).toBe(200);
+    const user = await getUser();
+    expect(user.plan).toBe("free");
+    expect(user.compPlan).toBeNull();
+    expect(user.compReason).toBeNull();
+    expect(user.compGrantedBy).toBeNull();
+  });
+
+  it("revoking a comp uncovers the subscription underneath it", async () => {
+    const cookie = await adminCookie();
+    await seedUser({ ...paying, subscriptionPlan: "hobby", plan: "hobby" });
+    await grantComp(cookie, { plan: "pro", reason: "Upgrade while we debug" });
+    expect((await getUser()).plan).toBe("pro");
+
+    await revokeComp(cookie);
+    expect((await getUser()).plan).toBe("hobby");
+  });
+
+  it("a revoked subscription cannot strip access an admin granted", async () => {
+    // The whole point of #81: these two writes used to be the same column.
+    const cookie = await adminCookie();
+    await seedUser(paying);
+    await grantComp(cookie, { plan: "pro", reason: "Comped after a support issue" });
+
+    await postWebhook({
+      type: "subscription.revoked",
+      data: { id: "sub_1", metadata: { userId: "user-1" }, created_at: "2026-01-01T00:00:00Z" },
+    });
+
+    const user = await getUser();
+    expect(user.plan).toBe("pro");
+    expect(user.compPlan).toBe("pro");
+    // The subscription really is gone; only the comp keeps the access.
+    expect(user.subscriptionPlan).toBeNull();
+    expect(user.polarSubscriptionId).toBeNull();
+  });
+
+  it("a comped user with no subscription is still comped after an unrelated event", async () => {
+    const cookie = await adminCookie();
+    await seedUser();
+    await grantComp(cookie, { plan: "hobby", reason: "Friend of the house" });
+    await postWebhook({ type: "checkout.updated", data: { id: "co_1" } });
+    expect((await getUser()).plan).toBe("hobby");
+  });
+});
+
+describe("subscription statuses (#84)", () => {
+  const updated = (over: Record<string, unknown>) => ({
+    type: "subscription.updated",
+    data: {
+      id: "sub_1",
+      product_id: POLAR_PRO_PRODUCT_ID,
+      metadata: { userId: "user-1" },
+      created_at: "2026-02-01T00:00:00Z",
+      ...over,
+    },
+  });
+
+  it("past_due keeps access and is recorded", async () => {
+    await seedUser(paying);
+    await postWebhook(updated({ status: "past_due" }));
+
+    const user = await getUser();
+    expect(user.plan).toBe("pro");
+    expect(user.subscriptionStatus).toBe("past_due");
+  });
+
+  it("unpaid takes access away", async () => {
+    await seedUser(paying);
+    await postWebhook(updated({ status: "unpaid" }));
+
+    const user = await getUser();
+    expect(user.plan).toBe("free");
+    // The subscription is still on the row: it exists, it just entitles
+    // nothing, which is what admin needs to be able to see.
+    expect(user.subscriptionPlan).toBe("pro");
+    expect(user.subscriptionStatus).toBe("unpaid");
+  });
+
+  it("a status nobody wrote a rule for grants nothing", async () => {
+    await seedUser(paying);
+    await postWebhook(updated({ status: "some_future_polar_status" }));
+    expect((await getUser()).plan).toBe("free");
+  });
+
+  it("synchronizes the product, so a downgrade through updated applies", async () => {
+    await seedUser(paying);
+    await postWebhook(updated({ status: "active", product_id: POLAR_HOBBY_PRODUCT_ID }));
+
+    const user = await getUser();
+    expect(user.plan).toBe("hobby");
+    expect(user.subscriptionPlan).toBe("hobby");
+  });
+
+  it("synchronizes cancellation state and period end (#84)", async () => {
+    await seedUser(paying);
+    await postWebhook(
+      updated({
+        status: "active",
+        cancel_at_period_end: true,
+        current_period_end: "2026-03-01T00:00:00Z",
+      }),
+    );
+
+    const user = await getUser();
+    expect(user.plan).toBe("pro");
+    expect(user.polarSubscriptionCancelAtPeriodEnd).toBe(true);
+    expect(user.polarSubscriptionCurrentPeriodEnd?.toISOString()).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("records the price as charged, not the list price (#82)", async () => {
+    await seedUser();
+    await postWebhook({
+      type: "subscription.active",
+      data: {
+        id: "sub_1",
+        product_id: POLAR_PRO_PRODUCT_ID,
+        metadata: { userId: "user-1" },
+        amount: 450,
+        currency: "eur",
+        recurring_interval: "month",
+        created_at: "2026-02-01T00:00:00Z",
+      },
+    });
+
+    const user = await getUser();
+    expect(user.subscriptionAmount).toBe(450);
+    expect(user.subscriptionCurrency).toBe("eur");
+    expect(user.subscriptionInterval).toBe("month");
+  });
+
+  it("keeps the most recently changed subscription when a user has two", async () => {
+    // One row holds one subscription: the later change wins, and the earlier
+    // subscription cannot write back over it.
+    await seedUser();
+    await postWebhook({
+      type: "subscription.active",
+      data: {
+        id: "sub_new",
+        product_id: POLAR_PRO_PRODUCT_ID,
+        metadata: { userId: "user-1" },
+        created_at: "2026-02-02T00:00:00Z",
+      },
+    });
+    await postWebhook({
+      type: "subscription.active",
+      data: {
+        id: "sub_old",
+        product_id: POLAR_HOBBY_PRODUCT_ID,
+        metadata: { userId: "user-1" },
+        created_at: "2026-02-01T00:00:00Z",
+      },
+    });
+
+    const user = await getUser();
+    expect(user.polarSubscriptionId).toBe("sub_new");
+    expect(user.plan).toBe("pro");
+  });
+});

--- a/tests/worker/entitlement.worker.ts
+++ b/tests/worker/entitlement.worker.ts
@@ -335,4 +335,31 @@ describe("subscription statuses (#84)", () => {
     expect(user.polarSubscriptionId).toBe("sub_new");
     expect(user.plan).toBe("pro");
   });
+
+  it("an updated event moves the subscription id along with the facts", async () => {
+    // Otherwise the row would describe a subscription that does not exist:
+    // one subscription's plan, status and price under another one's id.
+    await seedUser();
+    await postWebhook({
+      type: "subscription.active",
+      data: {
+        id: "sub_new",
+        product_id: POLAR_PRO_PRODUCT_ID,
+        metadata: { userId: "user-1" },
+        created_at: "2026-02-01T00:00:00Z",
+      },
+    });
+    await postWebhook(
+      updated({
+        id: "sub_other",
+        product_id: POLAR_HOBBY_PRODUCT_ID,
+        status: "active",
+        modified_at: "2026-02-03T00:00:00Z",
+      }),
+    );
+
+    const user = await getUser();
+    expect(user.subscriptionPlan).toBe("hobby");
+    expect(user.polarSubscriptionId).toBe("sub_other");
+  });
 });


### PR DESCRIPTION
Closes #81. Closes #82. Closes #84.

`user.plan` carried two facts at once: what a user may do, and what a user
pays. A comp an admin wrote by hand was byte-identical to a plan a Polar
webhook wrote, so `subscription.revoked` could strip access an admin granted,
and every revenue figure counted comps as money. The three issues are three
views of that, and they share one migration, so they land together.

## #81 The split

Migration 0017 adds what Polar says (`subscription_plan`,
`subscription_status`, and the pricing below) and what an admin granted
(`comp_plan`, with grantor, reason and timestamp). `plan` stays, as a derived
column: `coalesce(comp, entitling subscription, 'free')`, written only by
`effectivePlanSql` in `entitlement.ts` and never by hand. Every read path is
unchanged and still costs one column read.

The backfill changes nobody's access: a paid row with a subscription behind it
becomes a subscription, and a paid row without one can only have come from the
admin control this replaces, so it becomes a comp.

A webhook writes `subscription_*` and never `comp_*`; the comp routes do the
reverse. That is what makes the two facts stay apart, and there is a test for
each direction. `PATCH /admin/users/:id` now refuses a `plan` field outright:
comps have their own routes, and granting one requires a reason, recorded with
the grantor's id and shown in the user list.

## #84 The statuses

`subscription.updated` is the full subscription, not a plan signal. It used to
apply only `plan`, and only while `status === "active"`, so every transition
out of active, every cancellation state and every period end arriving that way
was discarded. It now writes the whole snapshot.

Which statuses keep access is one table in `entitlement.ts`, and it fails
closed for anything not in it. `past_due` keeps access on purpose: Polar
retries a failed payment for days and revokes when it gives up, so cutting
access at the first failure punishes an expired card rather than a non-payer.
Admin shows the state instead. Multi-subscription behaviour is now stated
where `subjectOf` lives: one row holds one subscription, the most recently
changed one, resolved by the existing freshness guard.

The README lists all five events the Worker handles, and what each one does.

## #82 The money

`mrr` was `hobby * 4 + pro * 9` over the plan column. It counted comps as
revenue, read every discount at list price, counted a yearly subscription as
monthly, and rewrote history whenever prices changed.

The webhook now stores amount, currency and interval as Polar reports them,
and MRR is monthly-normalized from those. Admin reports plan counts (access,
comps included), paying subscribers (real subscriptions only), comped users,
MRR, committed MRR (dropping subscriptions scheduled to cancel) and pending
cancellations as separate figures. Mixed currencies are called out rather than
silently added up.

## Testing

`bun run verify` green, including the e2e scenario the repo asks for. It comps
a user through the admin UI and holds the line the whole branch is about:
access goes up, MRR does not move.

The local seed now produces both kinds of paid user, and a yearly subscription
in ten, so the admin views have something to tell apart.

## Merge after #89

#89 fixes the other half of the comped-user problem: the billing page offered
a subscription portal to users who have no Polar customer, and the button
always failed with "No billing account yet". That is the same user this branch
creates on purpose, so #89 should land first and this branch rebase onto it.

## One thing to check before trusting the revenue figures

`subscription.amount` is read as the amount Polar actually charges, discount
included. If Polar reports list price there instead, `computeRevenue` needs the
discount subtracted and the discount test is asserting the wrong field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can grant, update, and revoke complimentary Hobby or Pro access with a required reason.
  * Billing views now distinguish subscribers, complimentary users, unpaid or past-due accounts, and cancellations.
  * Revenue reporting includes committed MRR, subscriber counts, comped users, cancellation details, and currency warnings.
  * Subscription access now reflects billing status, with complimentary access taking precedence.

* **Documentation**
  * Expanded deployment guidance for required webhook events, subscription access rules, and administrator-granted access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->