### PR TITLE
Instrument the landing-to-activation funnel, and keep it honest about consent (#64)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,20 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       # Before verify, not after: verify now ends with the browser smoke
-      # test, which needs this file to start the dev server.
+      # test, which needs these files to start the dev server.
+      #
+      # Both of them. .env carries the VITE_PUBLIC_POSTHOG_* pair that
+      # src/app/lib/posthog.ts reads, and CI used to run without it: the
+      # analytics path was never exercised here, and in dev mode a missing
+      # token makes the loader throw on every capture. A developer with a
+      # .env therefore ran a different suite from CI, which is how a green
+      # local run reached a red pipeline.
+      #
+      # The token is the placeholder from .env.example, so nothing lands in
+      # a real project, and the funnel test blocks the requests anyway.
       - name: Configure browser test environment
-        run: cp .dev.vars.example .dev.vars
+        run: |
+          cp .dev.vars.example .dev.vars
+          cp .env.example .env
       - name: Static checks, unit tests, and browser smoke test
         run: bun run verify

--- a/src/app/components/no-org.tsx
+++ b/src/app/components/no-org.tsx
@@ -3,6 +3,8 @@ import { useForm } from "react-hook-form";
 import { valibotResolver } from "@hookform/resolvers/valibot";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api";
+import posthog from "../lib/posthog";
+import { FUNNEL } from "../lib/funnel";
 import { useCurrentOrg } from "../lib/current-org";
 import { Button } from "../ui/button";
 import { Field, Input } from "../ui/field";
@@ -32,6 +34,11 @@ export function NoOrgState() {
           method: "POST",
           body: { name: name.trim() },
         });
+        // This path fired nothing before: an org created from the empty
+        // state, which is the route a brand-new user actually takes, was
+        // missing from the numbers entirely.
+        posthog.capture("organization_created");
+        posthog.capture(FUNNEL.orgCreated, { from: "empty_state" });
         setOrg(created.id);
         await qc.refetchQueries({ queryKey: ["user"] });
       } catch (err) {

--- a/src/app/lib/consent-buffer.ts
+++ b/src/app/lib/consent-buffer.ts
@@ -1,0 +1,64 @@
+/**
+ * The pre-consent event queue.
+ *
+ * Split out of posthog.ts because it is not really PostHog's concern, and
+ * because in there it was untestable: the only observable was network traffic
+ * from an SDK that will not even bootstrap when a test intercepts its config
+ * request. As a module of its own it is plain data, and the rules that matter
+ * can be asserted directly.
+ *
+ * The rules:
+ *  - Only funnel steps are held. A QR download by someone who has not
+ *    answered the banner belongs to no funnel.
+ *  - Only while consent is *unanswered*. Rejected is not the same as
+ *    unanswered: queueing after a refusal would let a later Accept in the
+ *    same document replay events the visitor already said no to.
+ *  - In memory only. Nothing is written down, so a reload discards it.
+ *  - Capped, so a long session that never answers cannot grow without bound.
+ */
+import { isFunnelEvent } from "./funnel";
+
+export type BufferedEvent = {
+  event: string;
+  properties?: Record<string, unknown>;
+  /** When it actually happened, not when it was flushed. */
+  at: Date;
+};
+
+const LIMIT = 50;
+
+let pending: BufferedEvent[] = [];
+
+/**
+ * @param unanswered whether the visitor has yet to answer the banner
+ * @returns whether the event was held
+ */
+export function bufferBeforeConsent(
+  event: string,
+  properties: Record<string, unknown> | undefined,
+  unanswered: boolean,
+  now: Date = new Date(),
+): boolean {
+  if (!unanswered || !isFunnelEvent(event) || pending.length >= LIMIT) return false;
+  pending.push({ event, properties, at: now });
+  return true;
+}
+
+/** Hands over everything held and empties the queue. */
+export function drainBuffer(): BufferedEvent[] {
+  const queued = pending;
+  pending = [];
+  return queued;
+}
+
+/** Throws the queue away unsent. */
+export function discardBuffer() {
+  pending = [];
+}
+
+/** Test seam: how many events are currently held. */
+export function bufferedCount(): number {
+  return pending.length;
+}
+
+export const BUFFER_LIMIT = LIMIT;

--- a/src/app/lib/funnel.ts
+++ b/src/app/lib/funnel.ts
@@ -1,0 +1,86 @@
+/**
+ * The landing-to-activation funnel (#64).
+ *
+ * One list, in order, so the funnel is something the codebase states rather
+ * than something you reconstruct by grepping for capture() calls. PostHog's
+ * funnel builder needs these names to be stable: renaming one silently breaks
+ * the historical series, so treat them as an API.
+ *
+ * Measurement caveat, recorded here because it is easy to forget when reading
+ * a dashboard: PostHog is off until the visitor accepts the consent banner
+ * (see posthog.ts). Steps before that are buffered and flushed on Accept, and
+ * nothing at all is recorded for a visitor who rejects. So these events count
+ * *consenting* visitors. The honest denominator for the top of the funnel is
+ * Cloudflare's own request count for the landing route, which needs no
+ * consent because it is aggregate.
+ */
+export const FUNNEL = {
+  /** 1. Landing page rendered. */
+  landingViewed: "funnel_landing_viewed",
+  /** 2. A call to action was clicked. `placement` says which one. */
+  ctaClicked: "funnel_cta_clicked",
+  /** 3. The pricing section scrolled into view. */
+  pricingViewed: "funnel_pricing_viewed",
+  /** 4. Signup form submitted and accepted. Already covered by
+   *  `user_signed_up`; this is the funnel-shaped name for the same moment. */
+  signupSubmitted: "funnel_signup_submitted",
+  /** 5a. Verification code sent. */
+  verificationSent: "funnel_verification_sent",
+  /** 5b. Verification code accepted. */
+  verificationCompleted: "funnel_verification_completed",
+  /** 6. First organization created. */
+  orgCreated: "funnel_org_created",
+  /** 7. First link created. The activation event: a signed-up user with no
+   *  link is not activated, so this is the end of the headline metric. */
+  linkCreated: "funnel_link_created",
+} as const;
+
+const FUNNEL_EVENTS: ReadonlySet<string> = new Set(Object.values(FUNNEL));
+
+/** Buffer this event when it fires before the visitor has answered the
+ *  consent banner. Only funnel steps are worth holding; a QR download by an
+ *  unconsented visitor is not part of any funnel. */
+export function isFunnelEvent(event: string): boolean {
+  return FUNNEL_EVENTS.has(event);
+}
+
+/**
+ * Where a CTA lives, so the hero, the pricing table and the closing block can
+ * be told apart. #64 asks for exactly this: the hero click distinguished from
+ * the secondary and from the final-CTA-section click.
+ */
+export type CtaPlacement =
+  | "hero_primary"
+  | "hero_secondary"
+  | "header"
+  | "pricing_free"
+  | "pricing_hobby"
+  | "pricing_pro"
+  | "final_cta";
+
+/**
+ * Campaign attribution for the landing view, read from the URL and the
+ * referrer.
+ *
+ * Referrer is reduced to its hostname. The full URL can carry a search query
+ * or a private path, and storing referrer hostnames rather than URLs is
+ * already the rule for click analytics (#20); the marketing funnel does not
+ * get a weaker standard than the product does.
+ */
+export function landingContext(): Record<string, string> {
+  const out: Record<string, string> = {};
+  try {
+    const params = new URLSearchParams(window.location.search);
+    for (const key of ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"]) {
+      const value = params.get(key);
+      if (value) out[key] = value.slice(0, 200);
+    }
+    if (document.referrer) {
+      const host = new URL(document.referrer).hostname;
+      if (host && host !== window.location.hostname) out.referrer_host = host;
+    }
+  } catch {
+    /* a malformed referrer or search string is not worth failing a pageview */
+  }
+  return out;
+}

--- a/src/app/lib/funnel.ts
+++ b/src/app/lib/funnel.ts
@@ -28,10 +28,16 @@ export const FUNNEL = {
   verificationSent: "funnel_verification_sent",
   /** 5b. Verification code accepted. */
   verificationCompleted: "funnel_verification_completed",
-  /** 6. First organization created. */
+  /** 6. An organization was created. */
   orgCreated: "funnel_org_created",
-  /** 7. First link created. The activation event: a signed-up user with no
-   *  link is not activated, so this is the end of the headline metric. */
+  /** 7. A link was created. The activation event: a signed-up user with no
+   *  link is not activated, so this is the end of the headline metric.
+   *
+   *  Both of these fire on every creation, not only the first. A funnel step
+   *  counts a person once, at their first occurrence, so gating client-side
+   *  would mean keeping "has this user created one before?" state in the
+   *  browser to arrive at the same number. Only genuinely new links reach
+   *  this: merging into an existing link goes through useAddressMutations. */
   linkCreated: "funnel_link_created",
 } as const;
 
@@ -59,6 +65,24 @@ export type CtaPlacement =
   | "final_cta";
 
 /**
+ * A campaign tag is supposed to name a campaign, but the query string is
+ * attacker- and mistake-controlled, and a link built by hand can easily carry
+ * `utm_campaign=alice@example.com`. Anything outside a conservative shape is
+ * dropped rather than truncated: a length cap does not make an email address
+ * stop being one.
+ */
+const CAMPAIGN_SHAPE = /^[a-zA-Z0-9._\-+ ]{1,64}$/;
+
+function safeCampaignValue(value: string): string | null {
+  const trimmed = value.trim();
+  if (!CAMPAIGN_SHAPE.test(trimmed)) return null;
+  // "+" and "." are legal in campaign names and in the local part of an
+  // address, so shape alone is not enough.
+  if (trimmed.includes("@")) return null;
+  return trimmed;
+}
+
+/**
  * Campaign attribution for the landing view, read from the URL and the
  * referrer.
  *
@@ -73,7 +97,8 @@ export function landingContext(): Record<string, string> {
     const params = new URLSearchParams(window.location.search);
     for (const key of ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"]) {
       const value = params.get(key);
-      if (value) out[key] = value.slice(0, 200);
+      const safe = value && safeCampaignValue(value);
+      if (safe) out[key] = safe;
     }
     if (document.referrer) {
       const host = new URL(document.referrer).hostname;

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -3,6 +3,7 @@ import { api, ApiError } from "./api";
 import { authClient } from "./auth-client";
 import { writeAuthHint } from "./auth-hint";
 import posthog from "./posthog";
+import { FUNNEL } from "./funnel";
 import type {
   CurrentUser,
   AppConfig,
@@ -105,7 +106,13 @@ export function useLinkMutations(orgId: string) {
   };
   const create = useMutation({
     mutationFn: (body: LinkInput) => api<LinkDTO>(`/orgs/${orgId}/links`, { method: "POST", body }),
-    onSuccess: invalidate,
+    onSuccess: (link) => {
+      invalidate();
+      // Funnel step 7, the activation event (#64). On the hook rather than
+      // the call sites, so the dashboard's quick-create and the links page
+      // both count and neither can be forgotten.
+      posthog.capture(FUNNEL.linkCreated, { on_custom_domain: Boolean(link.domainId) });
+    },
   });
   const update = useMutation({
     mutationFn: ({ id, ...body }: LinkInput & { id: string }) =>

--- a/src/app/lib/posthog.ts
+++ b/src/app/lib/posthog.ts
@@ -1,4 +1,5 @@
 import type { default as PosthogClient } from "posthog-js";
+import { isFunnelEvent } from "./funnel";
 
 // Nothing here loads posthog-js or contacts PostHog until the user accepts
 // analytics in the consent banner (see consent-banner.tsx): before that,
@@ -68,16 +69,47 @@ export function resumeAnalyticsIfConsented() {
   void loadClient();
 }
 
+/**
+ * Events that happened before the visitor answered the banner.
+ *
+ * The banner renders after the page does, so the landing view and any CTA
+ * click that beats it would otherwise be lost, and those are the first two
+ * steps of the funnel (#64). Held in memory only: nothing is written down and
+ * nothing leaves the browser unless the visitor later picks Accept, at which
+ * point the queue is sent with its original timestamps so the session reads
+ * as one path instead of starting halfway through.
+ *
+ * Rejecting drops the queue on the floor. The cap is there so a long session
+ * that never answers cannot grow without bound.
+ */
+const PENDING_LIMIT = 50;
+let pending: { event: string; properties?: Record<string, unknown>; at: string }[] = [];
+
+function queueBeforeConsent(event: string, properties?: Record<string, unknown>) {
+  if (pending.length >= PENDING_LIMIT) return;
+  pending.push({ event, properties, at: new Date().toISOString() });
+}
+
+function flushPending(posthog: typeof PosthogClient | null) {
+  if (!posthog) return;
+  const queued = pending;
+  pending = [];
+  for (const { event, properties, at } of queued) {
+    posthog.capture(event, { ...properties, $capture_before_consent: true, timestamp: at });
+  }
+}
+
 export function grantAnalyticsConsent() {
   try {
     localStorage.setItem(CONSENT_KEY, "accepted");
   } catch {
     /* ignore */
   }
-  void loadClient();
+  void loadClient()?.then(flushPending);
 }
 
 export function revokeAnalyticsConsent() {
+  pending = [];
   try {
     localStorage.setItem(CONSENT_KEY, "rejected");
   } catch {
@@ -90,7 +122,14 @@ export function revokeAnalyticsConsent() {
 
 const posthog = {
   capture(event: string, properties?: Record<string, unknown>) {
-    void loadClient()?.then((p) => p?.capture(event, properties));
+    const client = loadClient();
+    // Null means no consent yet. Hold funnel steps so the path survives a
+    // later Accept; everything else is dropped, as before.
+    if (!client) {
+      if (isFunnelEvent(event)) queueBeforeConsent(event, properties);
+      return;
+    }
+    void client.then((p) => p?.capture(event, properties));
   },
   identify(id: string, properties?: Record<string, unknown>) {
     if (identifiedId === id) return;

--- a/src/app/lib/posthog.ts
+++ b/src/app/lib/posthog.ts
@@ -1,5 +1,5 @@
 import type { default as PosthogClient } from "posthog-js";
-import { isFunnelEvent } from "./funnel";
+import { bufferBeforeConsent, discardBuffer, drainBuffer } from "./consent-buffer";
 
 // Nothing here loads posthog-js or contacts PostHog until the user accepts
 // analytics in the consent banner (see consent-banner.tsx): before that,
@@ -70,32 +70,26 @@ export function resumeAnalyticsIfConsented() {
 }
 
 /**
- * Events that happened before the visitor answered the banner.
- *
  * The banner renders after the page does, so the landing view and any CTA
  * click that beats it would otherwise be lost, and those are the first two
- * steps of the funnel (#64). Held in memory only: nothing is written down and
- * nothing leaves the browser unless the visitor later picks Accept, at which
- * point the queue is sent with its original timestamps so the session reads
- * as one path instead of starting halfway through.
- *
- * Rejecting drops the queue on the floor. The cap is there so a long session
- * that never answers cannot grow without bound.
+ * steps of the funnel (#64). See consent-buffer.ts for the rules; this file
+ * only decides when to ask it and how to replay it.
  */
-const PENDING_LIMIT = 50;
-let pending: { event: string; properties?: Record<string, unknown>; at: string }[] = [];
-
-function queueBeforeConsent(event: string, properties?: Record<string, unknown>) {
-  if (pending.length >= PENDING_LIMIT) return;
-  pending.push({ event, properties, at: new Date().toISOString() });
+function consentUnanswered(): boolean {
+  try {
+    return localStorage.getItem(CONSENT_KEY) === null;
+  } catch {
+    return false;
+  }
 }
 
 function flushPending(posthog: typeof PosthogClient | null) {
   if (!posthog) return;
-  const queued = pending;
-  pending = [];
-  for (const { event, properties, at } of queued) {
-    posthog.capture(event, { ...properties, $capture_before_consent: true, timestamp: at });
+  for (const { event, properties, at } of drainBuffer()) {
+    // `timestamp` belongs in the third argument. Passing it as a property
+    // leaves the SDK stamping the flush time, which would collapse the whole
+    // pre-consent path onto the moment the banner was answered.
+    posthog.capture(event, { ...properties, $capture_before_consent: true }, { timestamp: at });
   }
 }
 
@@ -109,7 +103,7 @@ export function grantAnalyticsConsent() {
 }
 
 export function revokeAnalyticsConsent() {
-  pending = [];
+  discardBuffer();
   try {
     localStorage.setItem(CONSENT_KEY, "rejected");
   } catch {
@@ -126,7 +120,7 @@ const posthog = {
     // Null means no consent yet. Hold funnel steps so the path survives a
     // later Accept; everything else is dropped, as before.
     if (!client) {
-      if (isFunnelEvent(event)) queueBeforeConsent(event, properties);
+      bufferBeforeConsent(event, properties, consentUnanswered());
       return;
     }
     void client.then((p) => p?.capture(event, properties));

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -14,6 +14,7 @@ import { AuthCard, PasswordMeter } from "../components/auth-form";
 import { authClient } from "../lib/auth-client";
 import { friendlyAuthError } from "../lib/auth-errors";
 import posthog from "../lib/posthog";
+import { FUNNEL } from "../lib/funnel";
 import { useShake } from "../lib/use-shake";
 import { useCurrentUser } from "../lib/hooks";
 import { firstFormError } from "../lib/form-errors";
@@ -469,6 +470,11 @@ function useAuthFlow(mode: "login" | "signup") {
       failSubmit(error.message ?? "Could not send the verification code");
       return;
     }
+    // Funnel steps 4 and 5a (#64): the form was accepted and a code is on
+    // its way. `resend` distinguishes this from the resend path below, which
+    // is a repeat rather than a new person reaching the step.
+    posthog.capture(FUNNEL.signupSubmitted);
+    posthog.capture(FUNNEL.verificationSent, { resend: false });
     setAuthEmail(email);
     writePending({ email, next });
     setView("verify-otp");
@@ -526,7 +532,12 @@ function useAuthFlow(mode: "login" | "signup") {
       await new Promise((resolve) => setTimeout(resolve, 900));
       clearPending();
       await qc.refetchQueries({ queryKey: ["user"] });
-      if (mode === "signup") posthog.capture("user_signed_up");
+      if (mode === "signup") {
+        posthog.capture("user_signed_up");
+        // Funnel step 5b (#64). Only on signup: a sign-in that happens to
+        // re-verify is not someone crossing this step for the first time.
+        posthog.capture(FUNNEL.verificationCompleted);
+      }
       const isAdmin = qc.getQueryData<CurrentUser | null>(["user"])?.user.isAdmin ?? false;
       setVerifyPhase("leaving");
       await new Promise((resolve) => setTimeout(resolve, 300));
@@ -547,6 +558,7 @@ function useAuthFlow(mode: "login" | "signup") {
       toast(resendError.message ?? "Could not resend the code", "error");
       return;
     }
+    posthog.capture(FUNNEL.verificationSent, { resend: true });
     setResent(true);
   };
 

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -372,6 +372,10 @@ async function trySignUp(
   if (signUpError) {
     deps.failSubmit(friendlyAuthError(signUpError));
   } else {
+    // Funnel step 4 (#64), at the boundary that actually means "an account
+    // was accepted". Before goVerify, so a failure to send the code cannot
+    // lose the signup that already happened.
+    posthog.capture(FUNNEL.signupSubmitted);
     await deps.goVerify(email);
   }
 }
@@ -470,10 +474,10 @@ function useAuthFlow(mode: "login" | "signup") {
       failSubmit(error.message ?? "Could not send the verification code");
       return;
     }
-    // Funnel steps 4 and 5a (#64): the form was accepted and a code is on
-    // its way. `resend` distinguishes this from the resend path below, which
-    // is a repeat rather than a new person reaching the step.
-    posthog.capture(FUNNEL.signupSubmitted);
+    // Funnel step 5a (#64). This one belongs here because both callers do
+    // genuinely send a code. Step 4 does not: goVerify is also reached from
+    // trySignIn's EMAIL_NOT_VERIFIED branch, so counting a signup here would
+    // count every returning unverified user as a new one.
     posthog.capture(FUNNEL.verificationSent, { resend: false });
     setAuthEmail(email);
     writePending({ email, next });

--- a/src/app/routes/landing.tsx
+++ b/src/app/routes/landing.tsx
@@ -30,10 +30,12 @@ import {
 // the lucide-react components used elsewhere on this page.
 import { Moon, Sun } from "lucide";
 import { MorphIcon } from "morphicons/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useCurrentUser } from "../lib/hooks";
 import { readAuthHint } from "../lib/auth-hint";
 import { useTheme } from "../lib/theme";
+import posthog from "../lib/posthog";
+import { FUNNEL, landingContext, type CtaPlacement } from "../lib/funnel";
 import { PLAN_LIMITS, PLAN_PRICES } from "@/shared/types";
 import { Button, IconButton } from "../ui/button";
 import { Table, Th, Td } from "../ui/misc";
@@ -164,20 +166,31 @@ const faqs = [
   },
 ];
 
+/** Every call to action on this page reports through here, so the funnel
+ *  sees one event with a placement rather than eight differently-named ones. */
+function trackCta(placement: CtaPlacement) {
+  posthog.capture(FUNNEL.ctaClicked, { placement });
+}
+
 function Section({
   children,
   className = "py-16",
   id,
+  onEnter,
 }: {
   children: ReactNode;
   className?: string;
   id?: string;
+  /** Fires once when the section scrolls into view. Used for the funnel's
+   *  "pricing viewed" step, which is a scroll, not a click. */
+  onEnter?: () => void;
 }) {
   return (
     <m.section
       id={id}
       initial={{ opacity: 0, y: 16 }}
       whileInView={{ opacity: 1, y: 0 }}
+      onViewportEnter={onEnter}
       viewport={{ once: true, margin: "-80px" }}
       transition={{ duration: 0.5, ease: "easeOut" }}
       className={className}
@@ -255,7 +268,7 @@ function MobilePlans({ paidTo }: { paidTo: (p: "hobby" | "pro") => string }) {
         "Random slugs on the shared domain",
       ],
       cta: (
-        <Link to="/signup">
+        <Link to="/signup" onClick={() => trackCta("pricing_free")}>
           <Button variant="outline" size="sm" className="w-full">
             Sign up free
           </Button>
@@ -274,7 +287,7 @@ function MobilePlans({ paidTo }: { paidTo: (p: "hobby" | "pro") => string }) {
         `${PLAN_LIMITS.hobby.analyticsDays}-day click analytics`,
       ],
       cta: (
-        <Link to={paidTo("hobby")}>
+        <Link to={paidTo("hobby")} onClick={() => trackCta("pricing_hobby")}>
           <Button variant="outline" size="sm" className="w-full">
             Start Hobby
           </Button>
@@ -295,7 +308,7 @@ function MobilePlans({ paidTo }: { paidTo: (p: "hobby" | "pro") => string }) {
         "Direct email support",
       ],
       cta: (
-        <Link to={paidTo("pro")}>
+        <Link to={paidTo("pro")} onClick={() => trackCta("pricing_pro")}>
           <Button variant="primary" size="sm" className="w-full">
             Start Pro
           </Button>
@@ -359,7 +372,11 @@ function MobilePlans({ paidTo }: { paidTo: (p: "hobby" | "pro") => string }) {
 function PricingSection() {
   const paidTo = usePaidPlanTo();
   return (
-    <Section id="pricing" className="scroll-mt-16 py-16">
+    <Section
+      id="pricing"
+      className="scroll-mt-16 py-16"
+      onEnter={() => posthog.capture(FUNNEL.pricingViewed)}
+    >
       <div className="mb-8 text-center">
         <h2 className="text-xl font-bold">Simple pricing</h2>
         <p className="mx-auto mt-2 max-w-xl text-sm text-muted">
@@ -465,21 +482,21 @@ function PricingSection() {
             <tr>
               <Td />
               <Td>
-                <Link to="/signup">
+                <Link to="/signup" onClick={() => trackCta("pricing_free")}>
                   <Button variant="outline" size="sm" className="w-full">
                     Sign up free
                   </Button>
                 </Link>
               </Td>
               <Td>
-                <Link to={paidTo("hobby")}>
+                <Link to={paidTo("hobby")} onClick={() => trackCta("pricing_hobby")}>
                   <Button variant="outline" size="sm" className="w-full">
                     Start Hobby
                   </Button>
                 </Link>
               </Td>
               <Cell tier="pro">
-                <Link to={paidTo("pro")}>
+                <Link to={paidTo("pro")} onClick={() => trackCta("pricing_pro")}>
                   <Button variant="primary" size="sm" className="w-full">
                     Start Pro
                   </Button>
@@ -746,7 +763,7 @@ function LandingHeader({ authed }: { authed: boolean }) {
           <MorphIcon icon={theme === "dark" ? Sun : Moon} size={15} spring="snappy" />
         </IconButton>
         {authed ? (
-          <Link to="/dashboard">
+          <Link to="/dashboard" onClick={() => trackCta("header")}>
             <Button variant="primary">Dashboard</Button>
           </Link>
         ) : (
@@ -754,7 +771,7 @@ function LandingHeader({ authed }: { authed: boolean }) {
             <Link to="/login" className="text-muted hover:text-accent">
               Log in
             </Link>
-            <Link to="/signup">
+            <Link to="/signup" onClick={() => trackCta("header")}>
               <Button variant="primary">Sign up</Button>
             </Link>
           </>
@@ -786,12 +803,12 @@ function HeroSection({ ctaTo, ctaLabel }: { ctaTo: string; ctaLabel: string }) {
             the site sending people to a repository; it now lives in its own
             band under the pricing table. */}
         <div className="flex flex-wrap items-center justify-center gap-3">
-          <Link to={ctaTo}>
+          <Link to={ctaTo} onClick={() => trackCta("hero_primary")}>
             <Button variant="primary" size="md" className="h-11 px-6 text-base">
               {ctaLabel}
             </Button>
           </Link>
-          <a href="#analytics">
+          <a href="#analytics" onClick={() => trackCta("hero_secondary")}>
             <Button variant="outline" size="md" className="h-11 px-6 text-base">
               <BarChart3 size={16} /> See the analytics
             </Button>
@@ -954,7 +971,7 @@ function FinalCtaSection({ ctaTo, ctaLabel }: { ctaTo: string; ctaLabel: string 
           Create your first short link on the free plan. No credit card, no visitor tracking, no
           servers to run.
         </p>
-        <Link to={ctaTo}>
+        <Link to={ctaTo} onClick={() => trackCta("final_cta")}>
           <Button variant="primary" size="md" className="h-11 px-6 text-base">
             {ctaLabel}
           </Button>
@@ -973,6 +990,13 @@ export function LandingPage() {
   const authed = me.isPending ? authHint : !!me.data;
   const ctaTo = authed ? "/dashboard" : "/signup";
   const ctaLabel = authed ? "Open dashboard" : "Get started free";
+
+  // Step 1 of the funnel (#64). Once per mount, not per render, and not
+  // gated on `me` settling: a landing view is a view whether or not the
+  // session query has come back.
+  useEffect(() => {
+    posthog.capture(FUNNEL.landingViewed, landingContext());
+  }, []);
 
   return (
     <MotionConfig reducedMotion="user">

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -23,6 +23,7 @@ import { cn } from "../ui/cn";
 import { NotFound } from "./not-found";
 import { PLAN_LIMITS, type User, type UserOrg } from "@/shared/types";
 import posthog from "../lib/posthog";
+import { FUNNEL } from "../lib/funnel";
 
 const ORG_LIMIT_MESSAGE = "Upgrade to Pro to create more organizations";
 
@@ -313,6 +314,7 @@ export function AppShell() {
       });
       await qc.invalidateQueries({ queryKey: ["user"] });
       posthog.capture("organization_created");
+      posthog.capture(FUNNEL.orgCreated, { from: "switcher" });
       setNewOrgOpen(false);
       setNewOrgName("");
       setOrg(created.id);

--- a/tests/consent-buffer.test.ts
+++ b/tests/consent-buffer.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  BUFFER_LIMIT,
+  bufferBeforeConsent,
+  bufferedCount,
+  discardBuffer,
+  drainBuffer,
+} from "../src/app/lib/consent-buffer";
+import { FUNNEL } from "../src/app/lib/funnel";
+
+const UNANSWERED = true;
+const ANSWERED = false;
+
+afterEach(discardBuffer);
+
+describe("what gets held", () => {
+  test("holds a funnel step while the banner is unanswered", () => {
+    expect(bufferBeforeConsent(FUNNEL.landingViewed, undefined, UNANSWERED)).toBe(true);
+    expect(bufferedCount()).toBe(1);
+  });
+
+  test("holds nothing once the banner has been answered", () => {
+    // The case that matters: after a rejection, a later Accept in the same
+    // document must not replay events the visitor already refused.
+    expect(bufferBeforeConsent(FUNNEL.ctaClicked, { placement: "hero_primary" }, ANSWERED)).toBe(
+      false,
+    );
+    expect(bufferedCount()).toBe(0);
+  });
+
+  test("holds nothing that is not a funnel step", () => {
+    expect(bufferBeforeConsent("qr_code_downloaded", undefined, UNANSWERED)).toBe(false);
+    expect(bufferedCount()).toBe(0);
+  });
+
+  test("stops at the cap instead of growing without bound", () => {
+    for (let i = 0; i < BUFFER_LIMIT + 25; i++) {
+      bufferBeforeConsent(FUNNEL.ctaClicked, { i }, UNANSWERED);
+    }
+    expect(bufferedCount()).toBe(BUFFER_LIMIT);
+  });
+});
+
+describe("draining", () => {
+  test("returns the time each event happened, not the time it was drained", () => {
+    const earlier = new Date("2026-08-09T10:00:00.000Z");
+    const later = new Date("2026-08-09T10:00:30.000Z");
+    bufferBeforeConsent(FUNNEL.landingViewed, undefined, UNANSWERED, earlier);
+    bufferBeforeConsent(FUNNEL.ctaClicked, { placement: "hero_primary" }, UNANSWERED, later);
+
+    const drained = drainBuffer();
+    expect(drained.map((e) => e.at.toISOString())).toEqual([
+      earlier.toISOString(),
+      later.toISOString(),
+    ]);
+    expect(drained[1].properties).toEqual({ placement: "hero_primary" });
+  });
+
+  test("keeps the order the steps happened in", () => {
+    bufferBeforeConsent(FUNNEL.landingViewed, undefined, UNANSWERED);
+    bufferBeforeConsent(FUNNEL.pricingViewed, undefined, UNANSWERED);
+    bufferBeforeConsent(FUNNEL.ctaClicked, undefined, UNANSWERED);
+    expect(drainBuffer().map((e) => e.event)).toEqual([
+      FUNNEL.landingViewed,
+      FUNNEL.pricingViewed,
+      FUNNEL.ctaClicked,
+    ]);
+  });
+
+  test("empties, so a second flush cannot send the same events twice", () => {
+    bufferBeforeConsent(FUNNEL.landingViewed, undefined, UNANSWERED);
+    expect(drainBuffer()).toHaveLength(1);
+    expect(drainBuffer()).toHaveLength(0);
+  });
+});
+
+describe("discarding", () => {
+  test("throws everything away, and nothing can be drained afterwards", () => {
+    bufferBeforeConsent(FUNNEL.landingViewed, undefined, UNANSWERED);
+    bufferBeforeConsent(FUNNEL.ctaClicked, undefined, UNANSWERED);
+    discardBuffer();
+    expect(bufferedCount()).toBe(0);
+    expect(drainBuffer()).toEqual([]);
+  });
+});

--- a/tests/e2e/funnel.pw.ts
+++ b/tests/e2e/funnel.pw.ts
@@ -82,6 +82,24 @@ test("accepting flushes the steps that happened before the banner was answered",
   expect(await page.evaluate((k) => localStorage.getItem(k), CONSENT_KEY)).toBe("accepted");
 });
 
+// Rejected is not the same as unanswered: browsing on after a refusal must
+// stay silent, not merely unsent-for-now.
+//
+// That the rejected period is never even *queued* is asserted directly in
+// tests/consent-buffer.test.ts. It cannot be asserted here, because a capture
+// batch never leaves the browser while the test intercepts PostHog's config
+// request, so "no request" would look identical either way.
+test("browsing on after a rejection stays silent", async ({ page }) => {
+  const attempts = await openLanding(page);
+
+  await page.getByRole("button", { name: "Reject" }).click();
+  await page.getByRole("link", { name: /see the analytics/i }).click();
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(800);
+
+  expect(attempts).toEqual([]);
+});
+
 // The buffer holds events in memory. It must not survive a reload, or a
 // visitor who reloads and then rejects would have their earlier steps sent.
 test("the pre-consent buffer does not survive a reload", async ({ page }) => {

--- a/tests/e2e/funnel.pw.ts
+++ b/tests/e2e/funnel.pw.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+
+// The funnel (#64) is only worth anything if the consent gate holds, so these
+// assert the privacy behaviour first and the instrumentation second.
+//
+// Nothing here talks to PostHog. Every test blocks its hosts outright and
+// watches what the app *tries* to send, which is the thing that matters: a
+// request that leaves the browser has already leaked, whether or not the far
+// end is reachable.
+
+const POSTHOG_GLOB = "**/*.i.posthog.com/**";
+const CONSENT_KEY = "rdyrct:consent:v2";
+
+/** Records every request the page attempts toward PostHog, and blocks them. */
+async function trapPostHog(page: import("@playwright/test").Page) {
+  const attempts: string[] = [];
+  await page.route(POSTHOG_GLOB, (route) => {
+    attempts.push(route.request().url());
+    return route.abort();
+  });
+  // posthog-js also pulls its bundle from the assets host.
+  await page.route("**/us-assets.i.posthog.com/**", (route) => {
+    attempts.push(route.request().url());
+    return route.abort();
+  });
+  return attempts;
+}
+
+/** Trap PostHog, open the landing page, wait for it to render. Every test
+ *  here starts this way. */
+async function openLanding(page: import("@playwright/test").Page) {
+  const attempts = await trapPostHog(page);
+  await page.goto("/");
+  await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+  return attempts;
+}
+
+test("a visitor who has not answered the banner sends nothing to PostHog", async ({ page }) => {
+  const attempts = await openLanding(page);
+
+  // Scroll the whole page: this fires the landing view and the pricing-viewed
+  // step, the two that happen before anyone could plausibly have consented.
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(600);
+
+  expect(attempts).toEqual([]);
+});
+
+test("rejecting keeps PostHog off and discards what was buffered", async ({ page }) => {
+  const attempts = await openLanding(page);
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.evaluate(() => window.scrollTo(0, 0));
+
+  await page.getByRole("button", { name: "Reject" }).click();
+  await page.waitForTimeout(600);
+
+  expect(attempts).toEqual([]);
+
+  // And it stays off across a reload, rather than re-prompting and re-arming.
+  await page.reload();
+  await page.waitForTimeout(600);
+  expect(attempts).toEqual([]);
+  expect(await page.evaluate((k) => localStorage.getItem(k), CONSENT_KEY)).toBe("rejected");
+});
+
+test("accepting flushes the steps that happened before the banner was answered", async ({
+  page,
+}) => {
+  const attempts = await openLanding(page);
+
+  // A CTA click before answering the banner. It must not be sent yet, and it
+  // must not be lost either: this is the buffer's whole reason to exist.
+  await page.getByRole("link", { name: /see the analytics/i }).click();
+  await page.waitForTimeout(300);
+  expect(attempts).toEqual([]);
+
+  await page.getByRole("button", { name: "Accept" }).click();
+
+  // Now it should try to reach PostHog. The requests are blocked, so this
+  // asserts intent, not delivery.
+  await expect.poll(() => attempts.length, { timeout: 10_000 }).toBeGreaterThan(0);
+  expect(await page.evaluate((k) => localStorage.getItem(k), CONSENT_KEY)).toBe("accepted");
+});
+
+// The buffer holds events in memory. It must not survive a reload, or a
+// visitor who reloads and then rejects would have their earlier steps sent.
+test("the pre-consent buffer does not survive a reload", async ({ page }) => {
+  const attempts = await openLanding(page);
+  await page.getByRole("link", { name: /see the analytics/i }).click();
+  await page.reload();
+  await page.getByRole("button", { name: "Reject" }).click();
+  await page.waitForTimeout(600);
+
+  expect(attempts).toEqual([]);
+  // Nothing about the queue should have been written down anywhere.
+  const stored = await page.evaluate(() => JSON.stringify(Object.entries(localStorage)));
+  expect(stored).not.toContain("funnel_");
+});

--- a/tests/funnel.test.ts
+++ b/tests/funnel.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { FUNNEL, isFunnelEvent, landingContext } from "../src/app/lib/funnel";
+
+/** Minimal stand-ins for the two globals landingContext() reads. */
+function browser({ search = "", referrer = "", host = "rdyrct.com" } = {}) {
+  (globalThis as { window?: unknown }).window = {
+    location: { search, hostname: host },
+  };
+  (globalThis as { document?: unknown }).document = { referrer };
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  delete (globalThis as { document?: unknown }).document;
+});
+
+describe("isFunnelEvent", () => {
+  test("recognises every declared step, so none is dropped before consent", () => {
+    for (const event of Object.values(FUNNEL)) expect(isFunnelEvent(event)).toBe(true);
+  });
+
+  test("ignores everything else, so the buffer only ever holds funnel steps", () => {
+    expect(isFunnelEvent("qr_code_downloaded")).toBe(false);
+    expect(isFunnelEvent("user_signed_in")).toBe(false);
+    expect(isFunnelEvent("")).toBe(false);
+  });
+});
+
+describe("landingContext", () => {
+  test("reads the UTM parameters a campaign lands with", () => {
+    browser({ search: "?utm_source=newsletter&utm_medium=email&utm_campaign=spring" });
+    expect(landingContext()).toEqual({
+      utm_source: "newsletter",
+      utm_medium: "email",
+      utm_campaign: "spring",
+    });
+  });
+
+  test("keeps only the referrer's hostname, never its path or query", () => {
+    browser({ referrer: "https://news.ycombinator.com/item?id=12345&secret=abc" });
+    expect(landingContext()).toEqual({ referrer_host: "news.ycombinator.com" });
+  });
+
+  test("drops our own hostname, which is a navigation and not a referral", () => {
+    browser({ referrer: "https://rdyrct.com/pricing", host: "rdyrct.com" });
+    expect(landingContext()).toEqual({});
+  });
+
+  test("caps a long parameter rather than shipping an unbounded string", () => {
+    browser({ search: `?utm_campaign=${"x".repeat(500)}` });
+    expect(landingContext().utm_campaign).toHaveLength(200);
+  });
+
+  test("survives a malformed referrer instead of failing the pageview", () => {
+    browser({ referrer: "not a url" });
+    expect(landingContext()).toEqual({});
+  });
+});

--- a/tests/funnel.test.ts
+++ b/tests/funnel.test.ts
@@ -46,9 +46,34 @@ describe("landingContext", () => {
     expect(landingContext()).toEqual({});
   });
 
-  test("caps a long parameter rather than shipping an unbounded string", () => {
+  test("drops an over-long parameter rather than truncating it", () => {
+    // Truncation was the old rule and it was the wrong one: the first 200
+    // characters of an email address are still an email address.
     browser({ search: `?utm_campaign=${"x".repeat(500)}` });
-    expect(landingContext().utm_campaign).toHaveLength(200);
+    expect(landingContext().utm_campaign).toBeUndefined();
+  });
+
+  test("drops a campaign value carrying an email address", () => {
+    browser({ search: "?utm_campaign=alice@example.com&utm_source=newsletter" });
+    const ctx = landingContext();
+    expect(ctx.utm_campaign).toBeUndefined();
+    // The clean parameter alongside it still comes through.
+    expect(ctx.utm_source).toBe("newsletter");
+  });
+
+  test("drops values outside a plain campaign-name shape", () => {
+    for (const bad of ["<script>", "a/b", "a?b", "a%20b", "a,b", ""]) {
+      browser({ search: `?utm_campaign=${encodeURIComponent(bad)}` });
+      expect(landingContext().utm_campaign).toBeUndefined();
+    }
+  });
+
+  test("keeps the punctuation real campaign names use", () => {
+    // "+" arrives as a space: that is what URLSearchParams does with a query
+    // string, and spaces are allowed through deliberately because campaign
+    // names have them.
+    browser({ search: "?utm_campaign=spring-sale_2026.v2+eu" });
+    expect(landingContext().utm_campaign).toBe("spring-sale_2026.v2 eu");
   });
 
   test("survives a malformed referrer instead of failing the pageview", () => {


### PR DESCRIPTION
Closes #64.

All seven stages from the issue, as named events declared in one place
(`src/app/lib/funnel.ts`) rather than scattered across `capture()` calls.
PostHog's funnel builder keys on these names, so they are an API: renaming one
breaks the historical series.

| # | Stage | Event |
|---|---|---|
| 1 | Landing view (with UTM + referrer host) | `funnel_landing_viewed` |
| 2 | CTA click, with `placement` | `funnel_cta_clicked` |
| 3 | Pricing scrolled into view | `funnel_pricing_viewed` |
| 4 | Signup submitted | `funnel_signup_submitted` |
| 5 | Code sent / accepted | `funnel_verification_sent` / `_completed` |
| 6 | First organization | `funnel_org_created` |
| 7 | First link (activation) | `funnel_link_created` |

`placement` distinguishes hero primary, hero secondary, header, each pricing
tier, and the closing block, which is what #64 asks for.

## The consent problem, and what it means for the numbers

**This is the part worth reviewing.** PostHog does not load until the visitor
accepts the banner, and stages 1 and 2 are exactly where they are least likely
to have accepted yet.

That does not merely add noise, it biases the result in our favour: people who
accept a cookie banner are more engaged than people who dismiss it, and
engagement is the thing being measured. A baseline over a self-selected subset
is not a baseline, which would have broken this issue's own acceptance
criteria.

So:

- **Buffer, then flush.** Steps that fire before the banner is answered are
  held in memory and sent if the visitor later accepts, so their session reads
  as one path instead of starting halfway through. Rejecting drops the queue.
  Nothing is written to storage and nothing leaves the browser either way.
- **The top-of-funnel denominator does not come from PostHog.** Cloudflare
  already counts requests per route and `observability` is on. That count is
  aggregate, needs no consent, and is the honest denominator. PostHog measures
  the shape of the drop-off between steps.

Server-side capture of the whole funnel was rejected: sending per-visitor
events without consent is what the banner exists to prevent, and "analytics
your legal team can sign off on" is on the landing page.

## Found on the way

Creating an organization from `NoOrgState` fired **no event at all**. That is
the path a brand-new user actually takes, so the most important step in the
activation funnel was invisible. Now covered, with `from` distinguishing it
from the org switcher.

Link creation is instrumented on the mutation hook, not the call sites, so the
dashboard quick-create and the links page both count and neither can be
forgotten later.

## Tests

Four e2e scenarios assert the privacy guarantees, since those are the ones
with a real cost if wrong: nothing reaches PostHog before the banner is
answered, nothing on reject, nothing survives a reload into a reject, and
accepting does turn it on.

I tried to assert the exact flushed payload and dropped it. PostHog batches
and base64-encodes, and I measured that no capture batch flushes at all while
the requests are blocked, so the assertion would not have been deterministic.
A test that cannot reliably fail is worse than no test. The buffer's own logic
is covered by unit tests instead, including the rule that a referrer is
reduced to its hostname (#20) so the marketing funnel is held to the same
standard as click analytics.

## Not in this PR

Building the PostHog dashboard and recording the baseline. Both need the
events to be flowing in production first, and the baseline has to be read off
the live funnel joined to the Cloudflare request count.

`bun run verify` green (34 e2e). fallow clean, react-doctor 100/100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added funnel tracking across landing-page visits, CTA interactions, pricing views, sign-up, verification, organization creation, and link creation.
  - Added campaign and referral context tracking to better understand how visitors discover the product.
  - Funnel events generated before analytics consent are securely queued and sent only after consent is granted.

- **Testing**
  - Added automated coverage for consent behavior, event buffering, attribution data, and malformed referral information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->