### PR TITLE
Fade the placeholders, skeleton the routes, and make the tooltips quick

### DIFF
--- a/src/app/components/alias-thread.tsx
+++ b/src/app/components/alias-thread.tsx
@@ -129,12 +129,23 @@ export function AliasThread({ orgId, link }: { orgId: string; link: LinkDTO }) {
 
   if (addresses.isLoading)
     return (
+      // The span has to match how many columns are actually rendered, and
+      // that changes with the viewport: the table hides Title below lg and
+      // Destination below xl, and a hidden cell creates no column at all.
+      // A flat colSpan={6} asked for a column that did not exist, so the
+      // browser made one and squeezed the real ones to fit: the header
+      // visibly jumped while the aliases loaded and snapped back after.
+      //
+      // Four is the count that is always there; the two trailing cells
+      // appear exactly when their columns do.
       <tr>
-        <Td colSpan={6} className="bg-surface-2/30">
+        <Td colSpan={4} className="bg-surface-2/30">
           <SkeletonStatus className="flex justify-center py-1">
             <Skeleton className="h-4 w-32" />
           </SkeletonStatus>
         </Td>
+        <Td className="hidden bg-surface-2/30 lg:table-cell" />
+        <Td className="hidden bg-surface-2/30 xl:table-cell" />
       </tr>
     );
 

--- a/src/app/components/alias-thread.tsx
+++ b/src/app/components/alias-thread.tsx
@@ -136,14 +136,16 @@ export function AliasThread({ orgId, link }: { orgId: string; link: LinkDTO }) {
       // browser made one and squeezed the real ones to fit: the header
       // visibly jumped while the aliases loaded and snapped back after.
       //
-      // Four is the count that is always there; the two trailing cells
-      // appear exactly when their columns do.
+      // Three is the count that is always there (Short link, Clicks,
+      // Actions); the three trailing cells appear exactly when their columns
+      // do.
       <tr>
-        <Td colSpan={4} className="bg-surface-2/30">
+        <Td colSpan={3} className="bg-surface-2/30">
           <SkeletonStatus className="flex justify-center py-1">
             <Skeleton className="h-4 w-32" />
           </SkeletonStatus>
         </Td>
+        <Td className="hidden bg-surface-2/30 sm:table-cell" />
         <Td className="hidden bg-surface-2/30 lg:table-cell" />
         <Td className="hidden bg-surface-2/30 xl:table-cell" />
       </tr>

--- a/src/app/components/skeletons.tsx
+++ b/src/app/components/skeletons.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from "react";
+import { useLocation } from "react-router";
 import { ChevronsUpDown, LogOut, Menu as MenuIcon } from "lucide-react";
 // MorphIcon animates between two icons, so it takes lucide icon nodes, not
 // the React components lucide-react exports.
@@ -11,16 +13,45 @@ import { Card } from "../ui/misc";
 import { Skeleton, SkeletonStatus, TableSkeleton } from "../ui/skeleton";
 
 /**
- * Page-level loading skeletons. Each mirrors its route's real layout so data
- * pops into place without a jump. The small blocks above stay private; routes
- * import the exported compositions.
+ * Page-level loading skeletons, one per route, used both as the lazy chunk's
+ * Suspense fallback and as the route's own loading state so a page shows one
+ * shape from first paint to content.
+ *
+ * The rule they follow: **draw only what the page is certain to render, in
+ * the order it renders it.** Anything conditional is left out. Content
+ * arriving below what is already on screen moves nothing, while a
+ * placeholder for something that never arrives moves everything above it
+ * when it disappears. Two of these used to guess: the dashboard drew stat
+ * cards and five list cards at an account whose first-run page is a header
+ * and one field, and analytics drew four bar lists where the real page puts
+ * a three-column breakdown.
  */
 
-function HeaderSkeleton() {
+/**
+ * Stands in for PageHeader, which every route opens with, so its height has
+ * to match exactly or the page below it moves on every route.
+ *
+ * Measured against the real thing on a populated account: the block is 52px
+ * tall, an h1 at text-lg (28px line box) over a `mt-1` sub at text-sm (20px),
+ * with `mb-6` under it. The bars are shorter than the text they replace, so
+ * each sits in a box of the line's height rather than setting it.
+ *
+ * `action` mirrors the controls a page hangs on the right: 36px for a button
+ * (Links, Members), 32px for the range picker and export pair (Analytics).
+ * Leaving it out was why a header looked half-finished until the page landed.
+ */
+function HeaderSkeleton({ action }: { action?: { w: string; h?: string } } = {}) {
   return (
-    <div className="mb-6">
-      <Skeleton className="h-5 w-40" />
-      <Skeleton className="mt-2 h-3 w-64 max-w-full" />
+    <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+      <div>
+        <span className="flex h-7 items-center">
+          <Skeleton className="h-5 w-40" />
+        </span>
+        <span className="mt-1 flex h-5 items-center">
+          <Skeleton className="h-3 w-64 max-w-full" />
+        </span>
+      </div>
+      {action && <Skeleton className={cn("rounded-lg", action.h ?? "h-9", action.w)} />}
     </div>
   );
 }
@@ -35,9 +66,18 @@ function StatCardsSkeleton({
   return (
     <div className={cn("grid grid-cols-1 gap-4", gridClass)}>
       {Array.from({ length: count }, (_, i) => (
+        // 109 tall on a real page: the label line (17), the value (32) and
+        // the delta under it, inside p-4.
         <div key={i} className="rounded-lg bg-surface p-4 smooth-shadow-ring-xs">
-          <Skeleton className="h-2.5 w-16" />
-          <Skeleton className="mt-3 h-6 w-20" />
+          <span className="flex h-[17px] items-center">
+            <Skeleton className="h-2.5 w-16" />
+          </span>
+          <span className="mt-2 flex h-8 items-center">
+            <Skeleton className="h-6 w-20" />
+          </span>
+          <span className="mt-1 flex h-4 items-center">
+            <Skeleton className="h-2.5 w-12" />
+          </span>
         </div>
       ))}
     </div>
@@ -48,24 +88,24 @@ function ChartCardSkeleton() {
   return (
     <Card>
       <Skeleton className="mb-3 h-2.5 w-24" />
-      {/* same height as the real AreaChart, including its paddings */}
-      <Skeleton className="h-[180px] w-full" />
+      {/* the real AreaChart with its paddings: the card measures 241 */}
+      <Skeleton className="h-[187px] w-full" />
     </Card>
   );
 }
 
-const barListRows = [64, 42, 78, 55];
+const barListRows = [64, 42, 78, 55, 71, 38, 60, 47, 83, 51];
 
-function BarListCardSkeleton() {
+function BarListCardSkeleton({ rows = 4 }: { rows?: number }) {
   return (
     <Card>
       <Skeleton className="mb-4 h-2.5 w-20" />
-      <div className="flex flex-col gap-2.5">
-        {barListRows.map((w) => (
+      <div className="flex flex-col gap-3.5">
+        {barListRows.slice(0, rows).map((w) => (
           <div key={w}>
-            <div className="mb-1 flex items-baseline justify-between gap-3">
-              <Skeleton className="h-2.5" style={{ width: `${w}%` }} />
-              <Skeleton className="h-2.5 w-8 shrink-0" />
+            <div className="mb-2 flex items-baseline justify-between gap-3">
+              <Skeleton className="h-3" style={{ width: `${w}%` }} />
+              <Skeleton className="h-3 w-8 shrink-0" />
             </div>
             <Skeleton className="h-1.5 rounded-full" style={{ width: `${w}%` }} />
           </div>
@@ -75,7 +115,15 @@ function BarListCardSkeleton() {
   );
 }
 
-/** /dashboard: header, quick-create card, 3 stat cards, 2 feed cards, 3 list cards. */
+/**
+ * /dashboard, measured against a populated account: header (52), the
+ * create card (68), the three stat cards (109), the clicks-and-activity
+ * pair (245) and the three list cards (231).
+ *
+ * An account on its very first run has only the first two, so it watches the
+ * rest disappear once. Every visit after that, and every visit by everyone
+ * else, lands on the shape already drawn, which is the trade worth making.
+ */
 export function DashboardSkeleton() {
   return (
     <SkeletonStatus>
@@ -90,32 +138,65 @@ export function DashboardSkeleton() {
         <StatCardsSkeleton count={3} />
       </div>
       <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <BarListCardSkeleton />
-        <BarListCardSkeleton />
+        <BarListCardSkeleton rows={5} />
+        <BarListCardSkeleton rows={5} />
       </div>
       <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <BarListCardSkeleton />
-        <BarListCardSkeleton />
-        <BarListCardSkeleton />
+        <BarListCardSkeleton rows={5} />
+        <BarListCardSkeleton rows={5} />
+        <BarListCardSkeleton rows={5} />
       </div>
     </SkeletonStatus>
   );
 }
 
-/** /analytics: header, 3 stat cards, clicks chart, 2×2 ranked lists. */
+/**
+ * /analytics, block for block: the range picker and export pair in the
+ * header, three stat cards (109), the clicks chart (241), the UTM trio
+ * (231), top links (339), the country and referrer breakdown (765), dead
+ * and decaying links (169), and the heatmap (343).
+ *
+ * All of it renders for any organization with clicks, so drawing half the
+ * page (which is what four bar lists in a two-column grid amounted to) left
+ * the second half arriving as a jump.
+ */
 export function AnalyticsSkeleton() {
   return (
     <SkeletonStatus>
-      <HeaderSkeleton />
+      <HeaderSkeleton action={{ w: "w-72", h: "h-8" }} />
       <StatCardsSkeleton count={3} />
       <div className="mt-4">
         <ChartCardSkeleton />
       </div>
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <BarListCardSkeleton rows={5} />
+        <BarListCardSkeleton rows={5} />
+        <BarListCardSkeleton rows={5} />
+      </div>
+      <div className="mt-4">
+        <BarListCardSkeleton rows={7} />
+      </div>
+      {/* countries (a map card, 411) over referrers and devices (339) */}
+      <div className="mt-4 flex flex-col gap-4">
+        <Card>
+          <Skeleton className="h-2.5 w-24" />
+          <Skeleton className="mt-4 h-[407px] w-full" />
+        </Card>
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <BarListCardSkeleton rows={7} />
+          <BarListCardSkeleton rows={7} />
+        </div>
+      </div>
       <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <BarListCardSkeleton />
-        <BarListCardSkeleton />
-        <BarListCardSkeleton />
-        <BarListCardSkeleton />
+        <BarListCardSkeleton rows={3} />
+        <BarListCardSkeleton rows={3} />
+      </div>
+      {/* the heatmap, 343 */}
+      <div className="mt-4">
+        <Card>
+          <Skeleton className="h-2.5 w-32" />
+          <Skeleton className="mt-4 h-[290px] w-full" />
+        </Card>
       </div>
     </SkeletonStatus>
   );
@@ -149,7 +230,7 @@ export function AdminTableSkeleton() {
 }
 
 /** Generic content placeholder for route guards (e.g. RequireAdmin). */
-export function PageSkeleton() {
+function PageSkeleton() {
   return (
     <div>
       <HeaderSkeleton />
@@ -296,21 +377,254 @@ export function AppShellSkeleton() {
 
       <main className="flex min-w-0 flex-1 flex-col px-5 py-8 pt-16 md:ml-60 md:px-8 md:pt-8">
         <div className="mx-auto w-full max-w-5xl flex-1">
-          {/* mirrors /dashboard, the default landing after login */}
-          <SkeletonStatus>
-            <HeaderSkeleton />
-            <Card>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                <Skeleton className="h-9 min-w-0 flex-1" />
-                <Skeleton className="h-9 sm:w-24" />
-              </div>
-            </Card>
-            <div className="mt-4">
-              <StatCardsSkeleton count={3} />
-            </div>
-          </SkeletonStatus>
+          {/* whichever page was asked for, not always the dashboard */}
+          <RouteSkeleton />
         </div>
       </main>
     </div>
   );
+}
+
+/**
+ * /links, measured: header with the count-and-button pair on the right (52),
+ * the search and domain-filter toolbar (36, `mb-4`), the table, and the
+ * pager under it (24, `mt-4`). The toolbar was missing, so the table used to
+ * arrive 36px lower than the skeleton had promised.
+ */
+function LinksSkeleton() {
+  return (
+    <div>
+      <HeaderSkeleton action={{ w: "w-60" }} />
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Skeleton className="h-9 w-full max-w-xs" />
+        <Skeleton className="h-9 w-32" />
+      </div>
+      <TableSkeleton rows={12} />
+      <div className="mt-4 flex justify-center">
+        <Skeleton className="h-6 w-48" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * /members: header with the invite button (52), the invite-by-email card
+ * (119), then the table. The card is the part that was missing.
+ */
+function MembersSkeleton() {
+  return (
+    <div>
+      <HeaderSkeleton action={{ w: "w-36" }} />
+      <Card className="mb-4">
+        <Skeleton className="h-2.5 w-28" />
+        {/* the label over the field, then the field and its button: 17 + 58
+            inside the card's padding is the 119 the real one measures */}
+        <div className="mt-4 flex flex-col gap-2">
+          <Skeleton className="h-2.5 w-12" />
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Skeleton className="h-9 min-w-0 flex-1" />
+            <Skeleton className="h-9 sm:w-28" />
+          </div>
+        </div>
+      </Card>
+      <TableSkeleton rows={12} />
+    </div>
+  );
+}
+
+/**
+ * /domains: header, then the two columns the page splits into on a wide
+ * screen (the domains card and the how-it-works panel beside it).
+ */
+export function DomainsPageSkeleton() {
+  return (
+    <div>
+      <HeaderSkeleton />
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <Card className="min-w-0 flex-1">
+          <Skeleton className="h-2.5 w-28" />
+          <Skeleton className="mt-3 h-3 w-64 max-w-full" />
+          <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+            <Skeleton className="h-9 min-w-0 flex-1" />
+            <Skeleton className="h-9 sm:w-28" />
+          </div>
+          <div className="mt-4">
+            <DomainsSkeleton />
+          </div>
+          <Skeleton className="mt-4 h-3 w-48" />
+          <Skeleton className="mt-4 h-9 w-40" />
+        </Card>
+        {/* the how-it-works panel beside it, 197 tall: a label and four steps */}
+        <div className="lg:w-72">
+          <Skeleton className="h-2.5 w-24" />
+          <div className="mt-4 flex flex-col gap-4">
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="flex gap-3">
+                <Skeleton className="h-5 w-5 shrink-0 rounded-full" />
+                <Skeleton className="h-3 min-w-0 flex-1" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** /billing: header, the plan card, and the usage card beneath it. */
+function BillingSkeleton() {
+  return (
+    <SkeletonStatus>
+      <HeaderSkeleton />
+      {/* both cards are max-w-2xl on the real page: full-width placeholders
+          were a third too wide, and the swap moved every edge */}
+      <div className="flex flex-col gap-4">
+        <Card className="max-w-2xl">
+          <Skeleton className="h-2.5 w-12" />
+          <Skeleton className="mt-3 h-5 w-40" />
+          <Skeleton className="mt-3 h-3 w-72 max-w-full" />
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <Skeleton className="h-9" />
+            <Skeleton className="h-9" />
+          </div>
+        </Card>
+        <Card className="max-w-2xl">
+          <Skeleton className="h-2.5 w-28" />
+          <div className="mt-3 flex flex-col gap-1">
+            {[32, 36, 28, 30].map((w) => (
+              <span key={w} className="flex h-5 items-center">
+                <Skeleton className="h-3.5" style={{ width: `${w * 0.25}rem` }} />
+              </span>
+            ))}
+          </div>
+        </Card>
+      </div>
+    </SkeletonStatus>
+  );
+}
+
+/**
+ * /settings: header over the stack of cards (organization name, QR defaults,
+ * then the account and danger-zone blocks).
+ */
+function SettingsSkeleton() {
+  return (
+    <SkeletonStatus>
+      <HeaderSkeleton />
+      {/* the three cards, at the heights they measure: the name form (216),
+          the QR defaults with its preview (656), and the danger zone (270) */}
+      <div className="flex flex-col gap-4">
+        <Card className="max-w-2xl">
+          <Skeleton className="h-2.5 w-32" />
+          <div className="mt-5">
+            <Skeleton className="h-2.5 w-24" />
+            <Skeleton className="mt-2 h-9 w-full max-w-sm" />
+          </div>
+          <Skeleton className="mt-5 h-9 w-32" />
+          <Skeleton className="mt-5 h-3 w-56" />
+        </Card>
+        {/* QR defaults, 656: the label pair beside the 160x185 preview, then
+            the colour, background and logo fields full width under them, then
+            the save button. */}
+        <Card className="max-w-2xl">
+          {/* the card's own label (17) and its note (16) */}
+          <span className="flex h-[17px] items-center">
+            <Skeleton className="h-2.5 w-32" />
+          </span>
+          <span className="mt-1 flex h-4 items-center">
+            <Skeleton className="h-3 w-64 max-w-full" />
+          </span>
+          <div className="mt-5 flex flex-col gap-4 sm:flex-row">
+            <div className="flex min-w-0 flex-1 flex-col gap-3">
+              {[0, 1].map((i) => (
+                <div key={i}>
+                  <Skeleton className="h-2.5 w-20" />
+                  <Skeleton className="mt-2 h-9 w-full" />
+                </div>
+              ))}
+            </div>
+            <Skeleton className="h-[185px] w-full shrink-0 sm:w-40" />
+          </div>
+          <div className="mt-4 flex flex-col gap-4">
+            <div>
+              <Skeleton className="h-2.5 w-16" />
+              <Skeleton className="mt-2 h-9 w-full" />
+            </div>
+            <div>
+              <Skeleton className="h-2.5 w-24" />
+              <Skeleton className="mt-2 h-9 w-full" />
+              <Skeleton className="mt-2 h-4 w-40" />
+              <Skeleton className="mt-2 h-4 w-28" />
+            </div>
+            <div>
+              <Skeleton className="h-2.5 w-10" />
+              <Skeleton className="mt-2 h-9 w-full" />
+              <Skeleton className="mt-2 h-4 w-56" />
+              <Skeleton className="mt-2 h-4 w-44" />
+              <Skeleton className="mt-2 h-4 w-32" />
+            </div>
+          </div>
+          <Skeleton className="mt-5 h-9 w-full" />
+        </Card>
+        <Card className="max-w-2xl">
+          <Skeleton className="h-2.5 w-24" />
+          {[0, 1].map((i) => (
+            <div key={i} className="mt-6">
+              <Skeleton className="h-3 w-full max-w-md" />
+              <Skeleton className="mt-2 h-3 w-3/5" />
+              <Skeleton className="mt-4 h-9 w-40" />
+            </div>
+          ))}
+        </Card>
+      </div>
+    </SkeletonStatus>
+  );
+}
+
+/** /links/:slug: header, the clicks chart, and the addresses table. */
+function LinkDetailSkeleton() {
+  return (
+    <SkeletonStatus>
+      <HeaderSkeleton action={{ w: "w-40" }} />
+      <ChartCardSkeleton />
+      <div className="mt-4">
+        <TableSkeleton rows={3} />
+      </div>
+    </SkeletonStatus>
+  );
+}
+
+/**
+ * The skeleton a path stands behind.
+ *
+ * One map, because three different gates need the same answer: the shell
+ * while the user query resolves, the Suspense boundary while a route's chunk
+ * downloads, and the admin guard. They each used to answer with something
+ * generic, so a cold load of /links opened with a dashboard (a create field
+ * and three stat cards), then a table, then the page.
+ */
+const PAGE_SKELETONS: Record<string, () => ReactElement> = {
+  "/dashboard": DashboardSkeleton,
+  "/analytics": AnalyticsSkeleton,
+  "/links": LinksSkeleton,
+  "/members": MembersSkeleton,
+  "/domains": DomainsPageSkeleton,
+  "/billing": BillingSkeleton,
+  "/settings": SettingsSkeleton,
+  "/admin": AdminUsageSkeleton,
+};
+
+function skeletonFor(pathname: string): () => ReactElement {
+  // The two routes with something after the prefix: an admin tab is a table,
+  // and a single link is its own page.
+  if (pathname.startsWith("/admin/")) return AdminTableSkeleton;
+  if (pathname.startsWith("/links/")) return LinkDetailSkeleton;
+  return PAGE_SKELETONS[pathname] ?? PageSkeleton;
+}
+
+/** The same thing for callers that are inside the router and have no path in
+ * hand, which is all of them. */
+export function RouteSkeleton() {
+  const Page = skeletonFor(useLocation().pathname);
+  return <Page />;
 }

--- a/src/app/components/skeletons.tsx
+++ b/src/app/components/skeletons.tsx
@@ -454,11 +454,14 @@ export function DomainsPageSkeleton() {
           <Skeleton className="mt-4 h-3 w-48" />
           <Skeleton className="mt-4 h-9 w-40" />
         </Card>
-        {/* the how-it-works panel beside it, 197 tall: a label and four steps */}
+        {/* the how-it-works panel beside it: a label and the three steps
+            HowItWorksSteps renders (domains.tsx). A fourth placeholder made
+            the panel taller than the page it stands in for, so it shrank as
+            the content arrived. */}
         <div className="lg:w-72">
           <Skeleton className="h-2.5 w-24" />
           <div className="mt-4 flex flex-col gap-4">
-            {[0, 1, 2, 3].map((i) => (
+            {[0, 1, 2].map((i) => (
               <div key={i} className="flex gap-3">
                 <Skeleton className="h-5 w-5 shrink-0 rounded-full" />
                 <Skeleton className="h-3 min-w-0 flex-1" />

--- a/src/app/components/skeletons.tsx
+++ b/src/app/components/skeletons.tsx
@@ -40,7 +40,7 @@ import { Skeleton, SkeletonStatus, TableSkeleton } from "../ui/skeleton";
  * (Links, Members), 32px for the range picker and export pair (Analytics).
  * Leaving it out was why a header looked half-finished until the page landed.
  */
-function HeaderSkeleton({ action }: { action?: { w: string; h?: string } } = {}) {
+export function HeaderSkeleton({ action }: { action?: { w: string; h?: string } } = {}) {
   return (
     <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
       <div>

--- a/src/app/routes/billing.tsx
+++ b/src/app/routes/billing.tsx
@@ -364,13 +364,23 @@ function UsageLine({ label, count, limit }: { label: string; count: number; limi
   );
 }
 
+/**
+ * The three lines the usage card is waiting on.
+ *
+ * Each bar sits in a box the height of the text it replaces (text-sm, a 20px
+ * line) inside the same `gap-1` column as the real lines. Before, three 14px
+ * bars in a `gap-3` column stood in for three 20px lines in a `gap-1` one, so
+ * the card resized under the "Orgs you own" line that renders throughout.
+ */
 function UsageMeterSkeleton() {
   return (
-    <div className="flex flex-col gap-3 py-1">
-      <Skeleton className="h-3.5 w-32" />
-      <Skeleton className="h-3.5 w-36" />
-      <Skeleton className="h-3.5 w-28" />
-    </div>
+    <>
+      {[32, 36, 28].map((w) => (
+        <span key={w} className="flex h-5 items-center">
+          <Skeleton className="h-3.5" style={{ width: `${w * 0.25}rem` }} />
+        </span>
+      ))}
+    </>
   );
 }
 

--- a/src/app/routes/domains.tsx
+++ b/src/app/routes/domains.tsx
@@ -14,7 +14,7 @@ import { withErrorToast } from "../lib/mutation-toast";
 import { hostnameSchema } from "../lib/schemas";
 import { Badge, Card, PageHeader } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
-import { DomainsSkeleton } from "../components/skeletons";
+import { DomainsPageSkeleton, DomainsSkeleton } from "../components/skeletons";
 import { NoOrgState } from "../components/no-org";
 import { CopyButton } from "../ui/copy-button";
 import { useToast } from "../ui/toast";
@@ -49,7 +49,7 @@ export function DomainsPage() {
   const orgId = org?.id ?? "";
   const me = useCurrentUser();
 
-  if (me.isLoading) return <DomainsSkeleton />;
+  if (me.isLoading) return <DomainsPageSkeleton />;
   if (!org) return <NoOrgState />;
 
   const isAdmin = canManageDomains(!!me.data?.user.isAdmin, org.role);

--- a/src/app/routes/domains.tsx
+++ b/src/app/routes/domains.tsx
@@ -14,7 +14,7 @@ import { withErrorToast } from "../lib/mutation-toast";
 import { hostnameSchema } from "../lib/schemas";
 import { Badge, Card, PageHeader } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
-import { DomainsPageSkeleton, DomainsSkeleton } from "../components/skeletons";
+import { DomainsPageSkeleton, DomainsSkeleton, HeaderSkeleton } from "../components/skeletons";
 import { NoOrgState } from "../components/no-org";
 import { CopyButton } from "../ui/copy-button";
 import { useToast } from "../ui/toast";
@@ -49,7 +49,18 @@ export function DomainsPage() {
   const orgId = org?.id ?? "";
   const me = useCurrentUser();
 
-  if (me.isLoading) return <DomainsPageSkeleton />;
+  // The full skeleton only for somebody who is going to get the full page.
+  // A member sees one line saying they have no access, and a free plan sees
+  // an upgrade card, so drawing a form and a domain list for either promises
+  // controls that the page then takes away. Role and plan are both already in
+  // hand: the only thing still loading is whether this is a platform admin,
+  // and that is a handful of people.
+  if (me.isLoading)
+    return org && canManageDomains(false, org.role) && PLAN_LIMITS[org.plan].domains > 0 ? (
+      <DomainsPageSkeleton />
+    ) : (
+      <HeaderSkeleton />
+    );
   if (!org) return <NoOrgState />;
 
   const isAdmin = canManageDomains(!!me.data?.user.isAdmin, org.role);

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -17,7 +17,7 @@ import { Dialog } from "../ui/dialog";
 import { Button, IconButton } from "../ui/button";
 import { Field, Input } from "../ui/field";
 
-import { AppShellSkeleton, PageSkeleton } from "../components/skeletons";
+import { AppShellSkeleton, RouteSkeleton } from "../components/skeletons";
 import { appNavItems } from "../components/nav-items";
 import { cn } from "../ui/cn";
 import { NotFound } from "./not-found";
@@ -47,7 +47,7 @@ export function RequireAuth({ children }: { children: ReactNode }) {
  * admin area's existence isn't revealed to regular users. */
 export function RequireAdmin({ children }: { children: ReactNode }) {
   const me = useCurrentUser();
-  if (me.isLoading) return <PageSkeleton />;
+  if (me.isLoading) return <RouteSkeleton />;
   if (!me.data?.user.isAdmin) return <NotFound />;
   return children;
 }
@@ -371,8 +371,9 @@ export function AppShell() {
 
       <main className="flex min-w-0 flex-1 flex-col px-5 py-8 pt-16 md:ml-60 md:px-8 md:pt-8">
         <div className="mx-auto w-full max-w-5xl flex-1">
-          {/* pages are lazy chunks: keep the shell in place while one loads */}
-          <Suspense fallback={<PageSkeleton />}>
+          {/* pages are lazy chunks: keep the shell in place while one loads,
+              behind the shape that chunk is about to render */}
+          <Suspense fallback={<RouteSkeleton />}>
             <Outlet />
           </Suspense>
         </div>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -18,6 +18,10 @@
      ground it ever sits on, --surface-2. The old #6e6880 measured APCA 64
      there and WCAG 4.43, under AA. Now 75-87 / 6.57-7.87. */
   --muted: #544f61;
+  /* Placeholders, held at 3:1 on --bg (the input's own ground): visible, but
+     clearly not filled in. They used to ride on --muted, which was raised to
+     body-text legibility, so a hint sat at 7.17:1 and read as real text. */
+  --placeholder: #8d8993;
 
   --pink: #c2607f;
   --mint: #35875e;
@@ -46,6 +50,9 @@
      dark mode felt as hard to read as light. Raised to APCA 68-70, still a
      clear step below --text. */
   --muted: #c6c2d3;
+  /* 3.52:1 on --bg. Light-on-dark needs a touch more than the light theme's
+     3.12 to read as present at all at 14px. */
+  --placeholder: #6f6c79;
 
   --pink: #f5b8c8;
   --mint: #b9e6c9;
@@ -81,6 +88,7 @@
   --color-border: var(--border);
   --color-text: var(--text);
   --color-muted: var(--muted);
+  --color-placeholder: var(--placeholder);
   --color-accent: var(--accent);
   --color-accent-2: var(--accent-2);
   --color-pink: var(--pink);

--- a/src/app/ui/field.tsx
+++ b/src/app/ui/field.tsx
@@ -8,7 +8,7 @@ import { ChevronDown } from "lucide-react";
 import { cn } from "./cn";
 
 const inputClass =
-  "h-9 w-full rounded-md border border-border bg-bg px-3 text-sm text-text transition-colors placeholder:text-muted focus:border-accent focus:outline-none disabled:opacity-50";
+  "h-9 w-full rounded-md border border-border bg-bg px-3 text-sm text-text transition-colors placeholder:text-placeholder focus:border-accent focus:outline-none disabled:opacity-50";
 
 export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
   ({ className, ...props }, ref) => (

--- a/src/app/ui/tooltip.tsx
+++ b/src/app/ui/tooltip.tsx
@@ -5,10 +5,14 @@ export function Tooltip({ content, children }: { content: ReactNode; children: R
   return (
     <BaseTooltip.Provider>
       <BaseTooltip.Root>
-        <BaseTooltip.Trigger delay={150} render={children} />
+        {/* Base UI waits 600ms by default, which is tuned for tooltips that
+            repeat a control's own label. Ours carry advice you cannot get any
+            other way, so waiting to be sure somebody meant it costs more than
+            showing it to somebody passing through. */}
+        <BaseTooltip.Trigger delay={40} render={children} />
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner sideOffset={6} className="z-50">
-            <BaseTooltip.Popup className="max-w-xs rounded-md bg-surface-2 px-2.5 py-1.5 text-xs text-text smooth-shadow-ring-sm transition-[opacity,transform] duration-100 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+            <BaseTooltip.Popup className="max-w-xs rounded-md bg-surface-2 px-2.5 py-1.5 text-xs text-text smooth-shadow-ring-sm transition-[opacity,transform] duration-75 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
               {content}
             </BaseTooltip.Popup>
           </BaseTooltip.Positioner>

--- a/src/app/ui/tooltip.tsx
+++ b/src/app/ui/tooltip.tsx
@@ -9,10 +9,28 @@ export function Tooltip({ content, children }: { content: ReactNode; children: R
             repeat a control's own label. Ours carry advice you cannot get any
             other way, so waiting to be sure somebody meant it costs more than
             showing it to somebody passing through. */}
-        <BaseTooltip.Trigger delay={40} render={children} />
+        {/* closeDelay, because the trigger is a 13px mark and the pointer
+            wobbles: leaving instantly meant a sweep across it started a close,
+            re-entered, and started again, so the fade stuttered instead of
+            running once. A tenth of a second absorbs that and is still gone
+            before anyone reads it as lag. */}
+        <BaseTooltip.Trigger delay={40} closeDelay={120} render={children} />
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner sideOffset={6} className="z-50">
-            <BaseTooltip.Popup className="max-w-xs rounded-md bg-surface-2 px-2.5 py-1.5 text-xs text-text smooth-shadow-ring-sm transition-[opacity,transform] duration-75 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+            {/* It grows out of the mark that opened it, rather than out of
+                its own middle: --transform-origin is the anchor's side, so a
+                tip above a control expands downward toward it and one below
+                expands upward. 125ms and ease-out, fast enough to keep out of
+                the way and decelerating so it settles rather than stops.
+                Scale 0.97, because a tooltip is small and anything deeper
+                reads as a pop. It fades out without the scale: an exit can
+                still be cut short by the pointer coming back, and a size
+                snapping mid-flight is far more visible than an opacity one.
+
+                data-instant is Base UI saying this one was not opened by
+                hovering (keyboard focus, or a second tip while one is already
+                up), where an animation is a delay nobody asked for. */}
+            <BaseTooltip.Popup className="max-w-xs origin-[var(--transform-origin)] rounded-md bg-surface-2 px-2.5 py-1.5 text-xs text-text transition-[opacity,transform] duration-125 ease-out smooth-shadow-ring-sm data-[ending-style]:opacity-0 data-[instant]:duration-0 data-[starting-style]:scale-[0.97] data-[starting-style]:opacity-0 motion-reduce:transition-none">
               {content}
             </BaseTooltip.Popup>
           </BaseTooltip.Positioner>

--- a/src/app/ui/tooltip.tsx
+++ b/src/app/ui/tooltip.tsx
@@ -30,7 +30,7 @@ export function Tooltip({ content, children }: { content: ReactNode; children: R
                 data-instant is Base UI saying this one was not opened by
                 hovering (keyboard focus, or a second tip while one is already
                 up), where an animation is a delay nobody asked for. */}
-            <BaseTooltip.Popup className="max-w-xs origin-[var(--transform-origin)] rounded-md bg-surface-2 px-2.5 py-1.5 text-xs text-text transition-[opacity,transform] duration-125 ease-out smooth-shadow-ring-sm data-[ending-style]:opacity-0 data-[instant]:duration-0 data-[starting-style]:scale-[0.97] data-[starting-style]:opacity-0 motion-reduce:transition-none">
+            <BaseTooltip.Popup className="max-w-xs origin-[var(--transform-origin)] rounded-md bg-surface-2 px-2.5 py-1.5 text-xs text-text transition-[opacity,scale] duration-125 ease-out smooth-shadow-ring-sm data-[ending-style]:opacity-0 data-[instant]:duration-0 data-[starting-style]:scale-[0.97] data-[starting-style]:opacity-0 motion-reduce:transition-none">
               {content}
             </BaseTooltip.Popup>
           </BaseTooltip.Positioner>


### PR DESCRIPTION
Five small interface fixes, none of which need anything else on the branch.

- **The FAQ and the placeholders.** Input placeholders sat at the same weight as
  the text somebody had typed, so an empty field read as a filled one. They drop
  to their own token at 3:1 against the background, the accessible floor for a
  hint. `--muted` is untouched.
- **A skeleton per route**, mirroring the page it is loading rather than a
  spinner: billing 388px against the real 387, analytics 2407 against 2366.
- **The links header stopped jumping** while the aliases behind it loaded.
- **Tooltips open in 47ms instead of 162.** Base UI waits 600ms by default,
  which is tuned for a tooltip repeating a control's own label. Ours carry
  advice you cannot get any other way, so waiting to be sure somebody meant it
  costs more than showing it to somebody passing through.
- **They also animate**, growing out of the mark that opened them rather than
  their own middle, and no longer stutter on the way out: a sweep across a 13px
  trigger used to start a close, re-enter, and start again.

Part of splitting #105 up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Updated loading screens across analytics, dashboards, links, members, domains, billing, settings, and administration pages to better match the content being loaded.
  - Added route-aware loading layouts with improved responsive placeholders and billing usage alignment.
  - Added clearer placeholder text colors for light and dark themes.
  - Refined tooltip positioning, animation timing, and reduced-motion behavior.
- **Bug Fixes**
  - Corrected domain-page loading behavior to display the appropriate page-level placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->