### PR TITLE
Give every plan QR codes, and charge for the look instead

### DIFF
--- a/src/app/components/link-editor.tsx
+++ b/src/app/components/link-editor.tsx
@@ -163,22 +163,12 @@ function UtmFields({
 function QrPreviewSidebar({
   form,
   orgQr,
-  qrEnabled,
   previewUrl,
 }: {
   form: LinkInput;
   orgQr: OrgQr;
-  qrEnabled: boolean;
   previewUrl: string;
 }) {
-  if (!qrEnabled) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border p-4 text-center sm:w-60">
-        <Lock size={20} className="text-muted" />
-        <p className="text-xs text-muted">QR codes are a paid feature: upgrade in Billing.</p>
-      </div>
-    );
-  }
   const look = resolveQrLook(form, orgQr);
   return (
     <div className="flex flex-col gap-2 sm:w-60">
@@ -307,6 +297,32 @@ function QrLogoField({ form, setForm }: { form: LinkInput; setForm: (f: LinkInpu
         onLoad={(url) => setForm({ ...form, qrLogo: url })}
         onClear={() => setForm({ ...form, qrLogo: "" })}
       />
+    </div>
+  );
+}
+
+/** Stands where the customization controls would be on a paid plan. The QR
+ * itself is already on screen beside it, so this asks for the upgrade the
+ * visitor can see the point of, rather than blocking the feature. */
+function QrCustomizationUpsell({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-border p-3",
+        className,
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <Lock size={14} className="mt-0.5 shrink-0 text-muted" />
+        <p className="text-xs text-muted">
+          Add your logo, colors, and dot shapes to this QR on a paid plan.
+        </p>
+      </div>
+      <RouterLink to="/billing" className="shrink-0">
+        <Button variant="outline" size="sm">
+          See plans
+        </Button>
+      </RouterLink>
     </div>
   );
 }
@@ -505,7 +521,7 @@ export function LinkEditor({
   activeDomains,
   defaultDomainId,
   domainsAllowed,
-  qrEnabled,
+  qrCustomEnabled,
   orgQr,
   shakeKey,
 }: {
@@ -521,7 +537,7 @@ export function LinkEditor({
   /** Whether the org's plan allows a custom domain at all (regardless of
    * whether one is connected yet): governs the shared-domain slug hint. */
   domainsAllowed: boolean;
-  qrEnabled: boolean;
+  qrCustomEnabled: boolean;
   orgQr: OrgQr;
   shakeKey: number;
 }) {
@@ -604,18 +620,15 @@ export function LinkEditor({
             after QR customization (the controls it's actually previewing) than
             wedged above UTM parameters, so it's last in source order there. */}
         <div className="order-last sm:order-none">
-          <QrPreviewSidebar
-            form={form}
-            orgQr={orgQr}
-            qrEnabled={qrEnabled}
-            previewUrl={previewUrl}
-          />
+          <QrPreviewSidebar form={form} orgQr={orgQr} previewUrl={previewUrl} />
         </div>
 
         <UtmFields form={form} setForm={setForm} className="sm:col-span-2" />
 
-        {qrEnabled && (
+        {qrCustomEnabled ? (
           <QrCustomization form={form} setForm={setForm} orgQr={orgQr} className="sm:col-span-2" />
+        ) : (
+          <QrCustomizationUpsell className="sm:col-span-2" />
         )}
       </form>
 

--- a/src/app/components/link-editor.tsx
+++ b/src/app/components/link-editor.tsx
@@ -50,6 +50,37 @@ const defaultForm: LinkInput = {
 
 type UtmKey = "utmSource" | "utmMedium" | "utmCampaign" | "utmTerm" | "utmContent";
 
+/** The link's own QR look, as opposed to the organization's defaults. The
+ * server refuses these outright on a plan without qrCustom. */
+const QR_OVERRIDE_FIELDS = [
+  "qrStyle",
+  "qrColor",
+  "qrCorner",
+  "qrEyeColor",
+  "qrBg",
+  "qrLogo",
+  "qrLogoSize",
+] as const;
+
+/**
+ * Clears a link's QR overrides when the plan no longer allows them.
+ *
+ * An organization that downgrades keeps whatever its links already had, and
+ * the editor loads those values whether or not it draws the controls for
+ * them. Submitted, the server answers 402 and the whole save fails: somebody
+ * on Free could not fix a typo in a title, and the message they got talked
+ * about QR codes. Sending the fields back as empty is also what the hidden
+ * controls imply, so the save does what the dialog looks like it will do.
+ */
+function withoutQrOverrides(data: LinkInput): LinkInput {
+  const cleared = { ...data };
+  for (const field of QR_OVERRIDE_FIELDS) {
+    if (field === "qrLogoSize") cleared.qrLogoSize = null;
+    else cleared[field] = "";
+  }
+  return cleared;
+}
+
 const UTM_FIELDS: { key: UtmKey; label: string; placeholder: string }[] = [
   { key: "utmSource", label: "Source", placeholder: "newsletter" },
   { key: "utmMedium", label: "Medium", placeholder: "email" },
@@ -542,6 +573,7 @@ export function LinkEditor({
   shakeKey: number;
 }) {
   const editing = editingLink != null;
+  const save = (data: LinkInput) => onSave(qrCustomEnabled ? data : withoutQrOverrides(data));
   const toast = useToast();
   const shake = useShake();
   const destinationRef = useRef<HTMLInputElement>(null);
@@ -603,10 +635,7 @@ export function LinkEditor({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange} title={editing ? "Edit link" : "New link"} wide>
-      <form
-        onSubmit={handleSubmit(onSave, onInvalid)}
-        className="grid gap-6 sm:grid-cols-[1fr_auto]"
-      >
+      <form onSubmit={handleSubmit(save, onInvalid)} className="grid gap-6 sm:grid-cols-[1fr_auto]">
         <LinkFormFields
           form={form}
           setForm={setForm}
@@ -640,7 +669,7 @@ export function LinkEditor({
           variant="primary"
           type="submit"
           disabled={busy}
-          onClick={handleSubmit(onSave, onInvalid)}
+          onClick={handleSubmit(save, onInvalid)}
           className={shake.className}
           onAnimationEnd={shake.end}
         >

--- a/src/app/components/link-preview-dialog.tsx
+++ b/src/app/components/link-preview-dialog.tsx
@@ -7,22 +7,12 @@ import { resolveQrLook, type OrgQr } from "../lib/org-qr";
 import { QRPreview } from "./qr";
 import type { LinkDTO } from "@/shared/types";
 
-function LinkPreviewContent({
-  link,
-  qrEnabled,
-  orgQr,
-}: {
-  link: LinkDTO;
-  qrEnabled: boolean;
-  orgQr: OrgQr;
-}) {
+function LinkPreviewContent({ link, orgQr }: { link: LinkDTO; orgQr: OrgQr }) {
   const toast = useToast();
   const url = shortUrl(link.slug, link.domain);
   return (
     <div className="flex flex-col items-center gap-3">
-      {qrEnabled && (
-        <QRPreview url={url} {...resolveQrLook(link, orgQr)} downloadName={`qr-${link.slug}`} />
-      )}
+      <QRPreview url={url} {...resolveQrLook(link, orgQr)} downloadName={`qr-${link.slug}`} />
       <div className="flex min-w-0 max-w-full items-center gap-2">
         <p className="min-w-0 truncate font-mono text-sm font-bold">{url}</p>
         <CopyButton
@@ -35,25 +25,27 @@ function LinkPreviewContent({
   );
 }
 
-/** The short URL (and its QR code, on paid plans) for one link, in a dialog:
- * shared by "link just created" (dashboard quick-create) and "show QR"
- * (links table row action) — same content, different title. */
+/** The short URL and its QR code for one link, in a dialog: shared by "link
+ * just created" (dashboard quick-create) and "show QR" (links table row
+ * action). Same content, different title.
+ *
+ * The QR is here on every plan. Only its look (logo, colors, shapes) is
+ * paid, and `orgQr` already resolves to the built-in defaults for a free
+ * org, which cannot have set any. */
 export function LinkPreviewDialog({
   title,
   link,
-  qrEnabled,
   orgQr,
   onClose,
 }: {
   title: string;
   link: LinkDTO | null;
-  qrEnabled: boolean;
   orgQr: OrgQr;
   onClose: () => void;
 }) {
   return (
     <Dialog open={!!link} onOpenChange={(o) => !o && onClose()} title={title}>
-      {link && <LinkPreviewContent link={link} qrEnabled={qrEnabled} orgQr={orgQr} />}
+      {link && <LinkPreviewContent link={link} orgQr={orgQr} />}
     </Dialog>
   );
 }

--- a/src/app/components/links-table.tsx
+++ b/src/app/components/links-table.tsx
@@ -5,7 +5,6 @@ import {
   Ellipsis,
   ExternalLink,
   Link,
-  Lock,
   Pencil,
   QrCode,
   Trash2,
@@ -34,12 +33,10 @@ function linkDetailPath(link: LinkDTO): string {
 /** What a row can do to its link. The table threads these straight through. */
 interface RowActions {
   navigate: (to: string) => void;
-  limits: { qr: boolean };
   onQrClick: (link: LinkDTO) => void;
   onEdit: (link: LinkDTO) => void;
   onDelete: (link: LinkDTO) => void;
   onCreateAlias: (link: LinkDTO) => void;
-  noQrToast: () => void;
 }
 
 /** The short link itself: expander, domain badge, slug, copy button. */
@@ -98,7 +95,7 @@ function LinkCell({
 }
 
 function RowMenu({ link, actions }: { link: LinkDTO; actions: RowActions }) {
-  const { navigate, limits, onQrClick, onEdit, onDelete, onCreateAlias, noQrToast } = actions;
+  const { navigate, onQrClick, onEdit, onDelete, onCreateAlias } = actions;
   return (
     <Menu
       align="end"
@@ -114,8 +111,8 @@ function RowMenu({ link, actions }: { link: LinkDTO; actions: RowActions }) {
       <MenuItem onClick={() => navigate(linkDetailPath(link))}>
         <ChartColumn size={14} /> View analytics
       </MenuItem>
-      <MenuItem onClick={() => (limits.qr ? onQrClick(link) : noQrToast())}>
-        {limits.qr ? <QrCode size={14} /> : <Lock size={14} />} QR code
+      <MenuItem onClick={() => onQrClick(link)}>
+        <QrCode size={14} /> QR code
       </MenuItem>
       <MenuItem onClick={() => onEdit(link)}>
         <Pencil size={14} /> Edit

--- a/src/app/components/qr-defaults-card.tsx
+++ b/src/app/components/qr-defaults-card.tsx
@@ -274,7 +274,7 @@ export function QrDefaultsCard() {
   const orgId = org?.id ?? "";
   const me = useCurrentUser();
   const isAdmin = canManageQrDefaults(me.data?.user.isAdmin, org?.role);
-  const hasQr = org ? PLAN_LIMITS[org.plan].qr : false;
+  const hasQrCustom = org ? PLAN_LIMITS[org.plan].qrCustom : false;
 
   const { values, setField, savingQr, save } = useQrDefaultsForm(orgId, org!);
 
@@ -287,7 +287,7 @@ export function QrDefaultsCard() {
             Applied to every link's QR code unless the link overrides them.
           </p>
         </div>
-        {!hasQr ? (
+        {!hasQrCustom ? (
           <UpgradeQrPrompt />
         ) : (
           <div className="grid gap-6 sm:grid-cols-[1fr_auto]">

--- a/src/app/routes/billing.tsx
+++ b/src/app/routes/billing.tsx
@@ -71,7 +71,8 @@ const PLAN_FEATURES = [
     `${PLAN_LIMITS.hobby.orgs}`,
     `${PLAN_LIMITS.pro.orgs}`,
   ],
-  ["QR codes", "No", "Yes", "Yes"],
+  ["QR codes", "Yes", "Yes", "Yes"],
+  ["QR logo & colors", "No", "Yes", "Yes"],
   [
     "Analytics",
     `${PLAN_LIMITS.free.analyticsDays}d`,

--- a/src/app/routes/dashboard.tsx
+++ b/src/app/routes/dashboard.tsx
@@ -136,7 +136,6 @@ export function Dashboard() {
         title="Link created"
         link={created}
         onClose={() => setCreated(null)}
-        qrEnabled={limits.qr}
         orgQr={orgQr}
       />
 

--- a/src/app/routes/landing.tsx
+++ b/src/app/routes/landing.tsx
@@ -70,9 +70,8 @@ const featureGroups = [
       },
       {
         icon: QrCode,
-        title: "Branded QR codes",
-        body: "One click turns any link into a QR code with your logo, colors, and dot styles baked in. Set org-wide defaults, override per link, and print it anywhere.",
-        plan: "Paid",
+        title: "QR codes, branded on paid plans",
+        body: "One click turns any link into a QR code you can download and print, on every plan. Paid plans bake in your logo, colors, and dot styles: set org-wide defaults and override them per link.",
       },
       {
         icon: Globe,
@@ -146,7 +145,7 @@ const faqs = [
   },
   {
     q: "What's the difference between Hobby and Pro?",
-    a: `Hobby (${PLAN_PRICES.hobby}/mo) unlocks branded QR codes, a custom domain with your own slugs, ${PLAN_LIMITS.hobby.links} links, ${PLAN_LIMITS.hobby.members} team members, and ${PLAN_LIMITS.hobby.analyticsDays}-day analytics for one organization. Pro (${PLAN_PRICES.pro}/mo) raises everything: ${PLAN_LIMITS.pro.orgs} organizations, ${PLAN_LIMITS.pro.links.toLocaleString()} links, ${PLAN_LIMITS.pro.members} team members, ${PLAN_LIMITS.pro.domains} custom domains each, ${PLAN_LIMITS.pro.analyticsDays}-day analytics, and direct email support. Only the organization owner needs a paid plan: one subscription covers every organization they own.`,
+    a: `Hobby (${PLAN_PRICES.hobby}/mo) puts your logo and colors on QR codes (plain ones are free), and adds a custom domain with your own slugs, ${PLAN_LIMITS.hobby.links} links, ${PLAN_LIMITS.hobby.members} team members, and ${PLAN_LIMITS.hobby.analyticsDays}-day analytics for one organization. Pro (${PLAN_PRICES.pro}/mo) raises everything: ${PLAN_LIMITS.pro.orgs} organizations, ${PLAN_LIMITS.pro.links.toLocaleString()} links, ${PLAN_LIMITS.pro.members} team members, ${PLAN_LIMITS.pro.domains} custom domains each, ${PLAN_LIMITS.pro.analyticsDays}-day analytics, and direct email support. Only the organization owner needs a paid plan: one subscription covers every organization they own.`,
   },
   {
     q: "How is rdyrct privacy-friendly?",
@@ -265,6 +264,7 @@ function MobilePlans({ paidTo }: { paidTo: (p: "hobby" | "pro") => string }) {
         `${PLAN_LIMITS.free.links} links`,
         `${PLAN_LIMITS.free.members} team members`,
         `${PLAN_LIMITS.free.analyticsDays}-day click analytics`,
+        "QR codes",
         "Random slugs on the shared domain",
       ],
       cta: (
@@ -283,7 +283,7 @@ function MobilePlans({ paidTo }: { paidTo: (p: "hobby" | "pro") => string }) {
         `${PLAN_LIMITS.hobby.links} links`,
         `${PLAN_LIMITS.hobby.members} team members`,
         `${PLAN_LIMITS.hobby.domains} custom domain with your own slugs`,
-        "QR codes",
+        "QR codes with your logo and colors",
         `${PLAN_LIMITS.hobby.analyticsDays}-day click analytics`,
       ],
       cta: (
@@ -457,6 +457,12 @@ function PricingSection() {
             </tr>
             <tr>
               <Td className="font-bold">QR codes</Td>
+              <YesCell />
+              <YesCell />
+              <YesCell tier="pro" />
+            </tr>
+            <tr>
+              <Td className="font-bold">QR logo, colors, and shapes</Td>
               <NoCell />
               <YesCell />
               <YesCell tier="pro" />

--- a/src/app/routes/links.tsx
+++ b/src/app/routes/links.tsx
@@ -223,8 +223,6 @@ export function LinksPage() {
     setPage,
   } = useLinkFilter(links);
 
-  const noQrToast = () => toast("QR codes are a paid feature: upgrade in Billing", "error");
-
   /**
    * Answer the duplicate-destination prompt (#45).
    *
@@ -307,7 +305,6 @@ export function LinksPage() {
           orgId={orgId}
           paged={paged}
           navigate={navigate}
-          limits={limits}
           onQrClick={dialogs.setQrLink}
           onEdit={dialogs.openEdit}
           onDelete={dialogs.setDeleting}
@@ -317,7 +314,6 @@ export function LinksPage() {
           totalPages={totalPages}
           currentPage={safePage}
           onPageChange={setPage}
-          noQrToast={noQrToast}
         />
       </LinksListArea>
 
@@ -506,20 +502,17 @@ function LinkDialogStack({
         activeDomains={activeDomains}
         defaultDomainId={defaultDomainId}
         domainsAllowed={limits.domains > 0}
-        qrEnabled={limits.qr}
+        qrCustomEnabled={limits.qrCustom}
         orgQr={orgQr}
         shakeKey={dialogs.shakeKey}
       />
 
-      {limits.qr && (
-        <LinkPreviewDialog
-          title={dialogs.qrLink ? `QR · /${dialogs.qrLink.slug}` : "QR"}
-          link={dialogs.qrLink}
-          onClose={() => dialogs.setQrLink(null)}
-          qrEnabled
-          orgQr={orgQr}
-        />
-      )}
+      <LinkPreviewDialog
+        title={dialogs.qrLink ? `QR · /${dialogs.qrLink.slug}` : "QR"}
+        link={dialogs.qrLink}
+        onClose={() => dialogs.setQrLink(null)}
+        orgQr={orgQr}
+      />
 
       <CreateAliasDialog
         orgId={orgId}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,7 +6,10 @@ export interface PlanLimits {
   links: number;
   members: number; // total members incl. owner
   domains: number;
-  qr: boolean;
+  /** Whether the plan may style a QR: logo, colors, dot and corner shapes,
+   * and the org-wide defaults. Generating a plain QR and downloading it is
+   * free on every plan, so this gates the look, never the code itself. */
+  qrCustom: boolean;
   analyticsDays: number; // how far back click analytics look
 }
 
@@ -16,7 +19,7 @@ export const PLAN_LIMITS: Record<OrgPlan, PlanLimits> = {
     links: 30,
     members: 3 /* owner + 2 */,
     domains: 0,
-    qr: false,
+    qrCustom: false,
     analyticsDays: 7,
   },
   hobby: {
@@ -24,7 +27,7 @@ export const PLAN_LIMITS: Record<OrgPlan, PlanLimits> = {
     links: 500,
     members: 5,
     domains: 1,
-    qr: true,
+    qrCustom: true,
     analyticsDays: 30,
   },
   pro: {
@@ -32,7 +35,7 @@ export const PLAN_LIMITS: Record<OrgPlan, PlanLimits> = {
     links: 3000,
     members: 25,
     domains: 5,
-    qr: true,
+    qrCustom: true,
     analyticsDays: 365,
   },
 };

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -445,7 +445,7 @@ function assertLinkQuota(count: number, plan: OrgPlan, limits: PlanLimits): void
 }
 
 function assertQrAllowed(body: LinkInput, limits: PlanLimits): void {
-  if (hasQrOverride(body) && !limits.qr)
+  if (hasQrOverride(body) && !limits.qrCustom)
     throw new HTTPException(402, {
       message: "QR customization is a paid feature: upgrade to use it",
     });

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -129,7 +129,7 @@ async function applyQrPatch(
   validateQrFields(body, orgId);
   // QR customization is a paid feature, so are the org-level defaults.
   const { limits } = await orgPlan(db, orgId);
-  if (!limits.qr)
+  if (!limits.qrCustom)
     throw new HTTPException(402, {
       message: "QR customization is a paid feature: upgrade to use it",
     });

--- a/src/worker/routes/qr-logos.ts
+++ b/src/worker/routes/qr-logos.ts
@@ -62,7 +62,7 @@ function validateQrLogoBody(type: string, body: ArrayBuffer): string {
 qrLogoRoutes.post("/", requireOrgRole("member"), async (c) => {
   // A logo is QR customization: a paid feature.
   const { limits } = await orgPlan(c.var.db, c.req.param("orgId")!);
-  if (!limits.qr)
+  if (!limits.qrCustom)
     throw new HTTPException(402, {
       message: "QR customization is a paid feature: upgrade to use it",
     });

--- a/tests/e2e/qr-download.pw.ts
+++ b/tests/e2e/qr-download.pw.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { expect, test } from "@playwright/test";
 import { signUpAndVerify } from "./resend";
-import { setPlan } from "./db";
+import { rawSql, setPlan } from "./db";
 import { createOrg } from "./orgs";
 
 const password = "test-password-123";
@@ -81,4 +81,50 @@ test("styling a QR is paid, generating one is not", async ({ page }) => {
   const paidEditor = page.getByRole("dialog", { name: "New link" });
   await expect(paidEditor.getByRole("group", { name: "QR customization" })).toBeVisible();
   await expect(paidEditor.getByText(/Add your logo, colors, and dot shapes/)).toBeHidden();
+});
+
+test("a downgraded org can still edit a link that has a QR look", async ({ page }) => {
+  // The trap: an org that had a paid plan keeps its links' QR overrides. The
+  // editor loads them whether or not it draws the controls, so a Free plan
+  // submitted values the server refuses outright, and the 402 blocked the
+  // save entirely. Somebody could not fix a typo in a title, and the message
+  // they got talked about QR codes.
+  //
+  // The override goes in through the database rather than the paid UI: what
+  // is under test is the free plan's save, and driving the paid editor first
+  // only adds ways for this to fail for another reason.
+  const email = `qr-downgrade-${Date.now()}@gmail.com`;
+
+  await signUpAndVerify(page, email, password);
+  await createOrg(page, "Downgrade Org");
+
+  await page.goto("/links");
+  await page.getByRole("button", { name: "New link" }).first().click();
+  const editor = page.getByRole("dialog", { name: "New link" });
+  await editor.getByLabel("Destination").fill("example.com/downgrade");
+  await page.getByRole("button", { name: "Create link" }).click();
+  await expect(editor).toBeHidden();
+
+  // The state a downgrade leaves behind: the link keeps the look it was
+  // given while the plan allowed one.
+  await rawSql(page, "UPDATE links SET qr_style = 'dots' WHERE destination LIKE ?", [
+    "%downgrade%",
+  ]);
+  await page.reload();
+
+  await page
+    .getByRole("button", { name: /Actions for/ })
+    .first()
+    .click();
+  await page.getByRole("menuitem", { name: "Edit" }).click();
+  const reopened = page.getByRole("dialog", { name: "Edit link" });
+  await expect(reopened.getByRole("group", { name: "QR customization" })).toBeHidden();
+
+  await reopened.getByLabel("Title").fill("Renamed on the free plan");
+  await page.getByRole("button", { name: "Save" }).click();
+
+  // Saved, rather than refused with a message about a feature the dialog
+  // did not even offer.
+  await expect(reopened).toBeHidden();
+  await expect(page.getByText("Renamed on the free plan")).toBeVisible();
 });

--- a/tests/e2e/qr-download.pw.ts
+++ b/tests/e2e/qr-download.pw.ts
@@ -25,10 +25,8 @@ test("a downloaded QR PNG is big enough to print, not preview-sized (#88)", asyn
 
   await signUpAndVerify(page, email, password);
   await createOrg(page, "QR Org");
-  // QR is a paid feature (PLAN_LIMITS.free.qr === false), so the dialog shows
-  // no code at all until the plan allows it.
-  await setPlan(page, email);
-  await page.reload();
+  // No setPlan: generating and downloading a QR is free on every plan. Only
+  // its look is paid, which the next test covers.
 
   const destination = page.getByPlaceholder("https://example.com/launch").first();
   await expect(destination).toBeVisible();
@@ -50,4 +48,37 @@ test("a downloaded QR PNG is big enough to print, not preview-sized (#88)", asyn
   const { width, height } = await pngSize(path!);
   expect(width).toBe(1024);
   expect(height).toBe(1024);
+});
+
+/**
+ * The paid line is drawn around the QR's *look*, not the QR. A free plan
+ * gets a working code and an upgrade prompt where the styling controls sit;
+ * a paid plan gets the controls. Both halves are asserted here, because
+ * checking only the free side would pass just as well if the controls had
+ * disappeared for everyone.
+ */
+test("styling a QR is paid, generating one is not", async ({ page }) => {
+  const email = `qr-look-${Date.now()}@gmail.com`;
+
+  await signUpAndVerify(page, email, password);
+  await createOrg(page, "QR Look Org");
+
+  await page.goto("/links");
+  await page.getByRole("button", { name: "New link" }).first().click();
+  const editor = page.getByRole("dialog", { name: "New link" });
+  await expect(editor).toBeVisible();
+
+  // The code itself renders for a free plan: no lock, no empty placeholder.
+  await expect(editor.getByText("QR code", { exact: true })).toBeVisible();
+  await expect(editor.getByText(/Add your logo, colors, and dot shapes/)).toBeVisible();
+  await expect(editor.getByRole("group", { name: "QR customization" })).toBeHidden();
+
+  await page.keyboard.press("Escape");
+  await setPlan(page, email);
+  await page.reload();
+
+  await page.getByRole("button", { name: "New link" }).first().click();
+  const paidEditor = page.getByRole("dialog", { name: "New link" });
+  await expect(paidEditor.getByRole("group", { name: "QR customization" })).toBeVisible();
+  await expect(paidEditor.getByText(/Add your logo, colors, and dot shapes/)).toBeHidden();
 });


### PR DESCRIPTION
QR codes were gated behind a paid plan wholesale. Generating one is now free on
every plan, and the paid part is the look: your logo, your colors, your dot and
corner styles.

A code with no branding costs us nothing to make and is the thing people arrive
wanting. Charging for it turns a working tool into a demo, and the branding is
what an organization actually pays for.

Part of splitting #105 up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - QR codes are now available for all plans, including Free.
  - Paid plans can customize QR colors and logos.
  - QR actions and previews are always available.
  - Free-plan users see upgrade guidance when accessing customization.

- **Billing**
  - Pricing comparisons now clearly distinguish QR generation from branded QR customization.

- **Bug Fixes**
  - Updated QR access controls consistently across link creation, previews, downloads, and customization.

- **Tests**
  - Added coverage confirming Free-plan QR generation and paid-plan customization access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->