### PR TITLE
Score link destinations on create, edit and cron

### DIFF
--- a/migrations/0019_add_link_risk_scoring.sql
+++ b/migrations/0019_add_link_risk_scoring.sql
@@ -1,0 +1,28 @@
+-- Destination risk scoring (#68).
+--
+-- Nothing checked whether a link pointed somewhere malicious. Bad links
+-- surfaced only when somebody reported them, and by then the shared domain
+-- may already be on a blocklist.
+--
+-- Three columns, all null on existing rows, which is the correct starting
+-- state: null means unscored, not clean. The cron picks up the nulls first,
+-- so the whole table cycles without a backfill here.
+--
+-- risk_score    0 = nothing known against it, 100 = a provider refuses it.
+--               An integer rather than a boolean because a second provider
+--               will have degrees, and widening a boolean later is a
+--               migration nobody enjoys.
+-- risk_reasons  JSON array of short codes, e.g. ["dns_blocklist"].
+-- risk_checked_at  ms epoch. Also the cron's queue order: oldest first.
+-- risk_provider    which provider answered, so two of them can be compared
+--                  on real traffic before anyone pays for the second.
+--
+-- Deliberately not indexed. The cron's `order by risk_checked_at` scan is a
+-- daily job over a table measured in thousands of rows, and the admin list
+-- (#67) filters by org first. Add an index when a query is actually slow,
+-- not in anticipation.
+
+ALTER TABLE links ADD COLUMN risk_score INTEGER;
+ALTER TABLE links ADD COLUMN risk_reasons TEXT;
+ALTER TABLE links ADD COLUMN risk_checked_at INTEGER;
+ALTER TABLE links ADD COLUMN risk_provider TEXT;

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -231,6 +231,13 @@ export const links = sqliteTable(
       onDelete: "set null",
     }),
     createdAt: integer("created_at").notNull(),
+    // Destination risk (#68). Null means unscored, never clean: a provider
+    // outage and a clean answer must not look the same. Admin-only (#67),
+    // never in an org-scoped response.
+    riskScore: integer("risk_score"),
+    riskReasons: text("risk_reasons"),
+    riskCheckedAt: integer("risk_checked_at"),
+    riskProvider: text("risk_provider"),
   },
   (t) => [index("idx_links_org").on(t.orgId)],
 );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -14,6 +14,7 @@ import { adminRoutes } from "./routes/admin";
 import { billingRoutes, handlePolarWebhook } from "./routes/billing";
 import { domainRoutes } from "./routes/domains";
 import { capRoutes } from "./routes/cap";
+import { sweepLinkRisk } from "./risk";
 import { resolveSlug, resolveDomain, type KVLink } from "./kv";
 import { RESERVED_SLUGS } from "./util";
 import { enforcePublicAuthRateLimit, enforceSignedApiRateLimit } from "./rate-limit";
@@ -243,5 +244,11 @@ export default {
     // Daily: retire rename aliases past their 48h deadline (see #38). The
     // redirect path already stopped resolving them; this frees their slugs.
     await sweepExpiredAliases(env, drizzle(env.DB, { schema }));
+
+    // Daily: re-score link destinations, unscored first then oldest (#68).
+    // Bounded, because the point is that the table cycles rather than that
+    // any one run finishes it: a destination that turns bad long after it
+    // was created gets caught on some later day.
+    await sweepLinkRisk(env.DB);
   },
 };

--- a/src/worker/risk.ts
+++ b/src/worker/risk.ts
@@ -1,0 +1,146 @@
+/**
+ * Scoring a link's destination (#68).
+ *
+ * It scores, it does not block. Nobody waits on this to create a link and
+ * nobody is refused by it: false positives on a shortener are expensive, so
+ * a human stays in the loop. The columns it fills are read by admin routes
+ * only (#67), never in an org-scoped response.
+ *
+ * The provider is one function so a second one can be added without a
+ * rewrite, and every row records which one answered. Today that is
+ * Cloudflare's security resolver, which refuses to resolve domains it knows
+ * to be serving malware or phishing and answers 0.0.0.0 instead. It needs no
+ * account, no key, and no billing, and it runs inside the network we are
+ * already on.
+ *
+ * Known limits, which are the reason `provider` is stored:
+ *  - Hostname only. https://legit.example/compromised/page looks clean.
+ *  - No threat type, just blocked or not, so `reasons` is coarser than a
+ *    real threat API's categories would be.
+ *  - It is a public resolver, not a documented threat feed. The behaviour is
+ *    stable and widely relied on, but it is not a contract, so an answer we
+ *    do not recognise leaves the row unscored rather than calling it clean.
+ *    Google Web Risk is the upgrade for full-URL scoring, when there is
+ *    evidence of that specific abuse to justify the credential.
+ */
+
+/** 0 = nothing known against it, 100 = a provider refuses to resolve it. */
+export type RiskVerdict = {
+  score: number;
+  reasons: string[];
+  provider: string;
+};
+
+export const RISK_PROVIDER_DNS = "cloudflare-security-dns";
+const RESOLVER = "https://security.cloudflare-dns.com/dns-query";
+const LOOKUP_TIMEOUT_MS = 3000;
+
+/** The resolver's "I will not resolve this" answer. */
+const BLOCKED_ANSWERS = new Set(["0.0.0.0", "::"]);
+
+type DnsJson = {
+  Status?: number;
+  Answer?: { data?: string }[];
+};
+
+/**
+ * Scores one destination, or returns null to mean "still unscored".
+ *
+ * Null is not "clean": a timeout, a shape we do not recognise, and a
+ * provider outage all land here, and the row keeps a null score so the cron
+ * picks it up again later. Only a definite answer writes a score.
+ */
+export async function scoreDestination(destination: string): Promise<RiskVerdict | null> {
+  const hostname = hostnameOf(destination);
+  if (!hostname) return null;
+
+  let json: DnsJson;
+  try {
+    const res = await fetch(`${RESOLVER}?name=${encodeURIComponent(hostname)}&type=A`, {
+      headers: { accept: "application/dns-json" },
+      signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    json = (await res.json()) as DnsJson;
+  } catch {
+    return null;
+  }
+
+  // Status 3 is NXDOMAIN: the name does not exist. That is a dead link, not
+  // a dangerous one, and saying otherwise would score every typo as malware.
+  if (json.Status === 3) return { score: 0, reasons: [], provider: RISK_PROVIDER_DNS };
+  if (json.Status !== 0 || !Array.isArray(json.Answer)) return null;
+
+  const blocked = json.Answer.some((a) => a.data && BLOCKED_ANSWERS.has(a.data));
+  return {
+    score: blocked ? 100 : 0,
+    reasons: blocked ? ["dns_blocklist"] : [],
+    provider: RISK_PROVIDER_DNS,
+  };
+}
+
+/**
+ * Scores one link and writes the result, swallowing every failure.
+ *
+ * Meant for `waitUntil`, so it runs after the response and no caller ever
+ * waits on it. A provider error, a shape we do not recognise, or a row that
+ * vanished mid-flight all leave the row exactly as it was: unscored, and
+ * therefore first in the cron's queue next time.
+ */
+export async function scoreAndRecord(
+  db: D1Database,
+  linkId: string,
+  destination: string,
+): Promise<void> {
+  try {
+    const verdict = await scoreDestination(destination);
+    if (!verdict) return;
+    await db
+      .prepare(
+        `update links set risk_score = ?, risk_reasons = ?, risk_checked_at = ?, risk_provider = ?
+         where id = ?`,
+      )
+      .bind(verdict.score, JSON.stringify(verdict.reasons), Date.now(), verdict.provider, linkId)
+      .run();
+  } catch (error) {
+    console.warn("risk_score_failed", linkId, error);
+  }
+}
+
+/**
+ * Re-scores the least recently checked links, oldest first, nulls before
+ * anything else.
+ *
+ * Bounded, because the whole point is that the table cycles rather than that
+ * any one run finishes it: a destination that turns bad long after creation
+ * is caught on some later day, and one run can never blow the daily job's
+ * time budget.
+ *
+ * Sequential rather than parallel on purpose. This is a background sweep
+ * with all day to finish, and firing a batch of lookups at a public resolver
+ * at once is how you get rate limited by it.
+ */
+export async function sweepLinkRisk(db: D1Database, batchSize = 50): Promise<number> {
+  const { results } = await db
+    .prepare(
+      `select id, destination from links
+       order by risk_checked_at is not null, risk_checked_at asc
+       limit ?`,
+    )
+    .bind(batchSize)
+    .all<{ id: string; destination: string }>();
+
+  for (const row of results) await scoreAndRecord(db, row.id, row.destination);
+  return results.length;
+}
+
+/** The host a destination points at, or null if it is not a URL we can read. */
+function hostnameOf(destination: string): string | null {
+  try {
+    const url = new URL(destination);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.hostname || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/worker/risk.ts
+++ b/src/worker/risk.ts
@@ -138,8 +138,12 @@ export async function sweepLinkRisk(db: D1Database, batchSize = 50): Promise<num
   // budget retrying the same failures, while destinations that were clean a
   // year ago are never looked at again. That is the sweep quietly giving up
   // on the job it exists for, with nothing on screen to say so.
-  const unscored = await pickToScore(db, "risk_checked_at is null", batchSize);
-  const scored = await pickToScore(db, "risk_checked_at is not null", batchSize);
+  // Together: two independent reads of our own database, which is not the
+  // resolver the loop below is careful with.
+  const [unscored, scored] = await Promise.all([
+    pickToScore(db, "risk_checked_at is null", batchSize),
+    pickToScore(db, "risk_checked_at is not null", batchSize),
+  ]);
   // The cap gives way when the other side cannot fill the batch: it exists to
   // stop the unscored crowding out rescans, not to leave the budget unspent.
   const room = Math.max(Math.ceil(batchSize / 2), batchSize - scored.length);

--- a/src/worker/risk.ts
+++ b/src/worker/risk.ts
@@ -95,12 +95,24 @@ export async function scoreAndRecord(
   try {
     const verdict = await scoreDestination(destination);
     if (!verdict) return;
+    // Only if the row still points where the lookup went. A destination edit
+    // clears the verdict and starts its own scan, and the lookup it replaced
+    // can still be in flight: without this, the older answer lands afterwards
+    // and labels the new destination with the old one's verdict. Two edits in
+    // quick succession are the same race with both scans in flight.
     await db
       .prepare(
         `update links set risk_score = ?, risk_reasons = ?, risk_checked_at = ?, risk_provider = ?
-         where id = ?`,
+         where id = ? and destination = ?`,
       )
-      .bind(verdict.score, JSON.stringify(verdict.reasons), Date.now(), verdict.provider, linkId)
+      .bind(
+        verdict.score,
+        JSON.stringify(verdict.reasons),
+        Date.now(),
+        verdict.provider,
+        linkId,
+        destination,
+      )
       .run();
   } catch (error) {
     console.warn("risk_score_failed", linkId, error);
@@ -108,8 +120,7 @@ export async function scoreAndRecord(
 }
 
 /**
- * Re-scores the least recently checked links, oldest first, nulls before
- * anything else.
+ * Re-scores links, oldest first, with never-scored ones taking priority.
  *
  * Bounded, because the whole point is that the table cycles rather than that
  * any one run finishes it: a destination that turns bad long after creation
@@ -121,18 +132,42 @@ export async function scoreAndRecord(
  * at once is how you get rate limited by it.
  */
 export async function sweepLinkRisk(db: D1Database, batchSize = 50): Promise<number> {
-  const { results } = await db
-    .prepare(
-      `select id, destination from links
-       order by risk_checked_at is not null, risk_checked_at asc
-       limit ?`,
-    )
-    .bind(batchSize)
-    .all<{ id: string; destination: string }>();
+  // Half the batch at most for the never-scored, so they cannot crowd out the
+  // rescans. A destination the resolver keeps timing out on stays unscored,
+  // and unscored sorts first: enough of those and every run spends its whole
+  // budget retrying the same failures, while destinations that were clean a
+  // year ago are never looked at again. That is the sweep quietly giving up
+  // on the job it exists for, with nothing on screen to say so.
+  const unscored = await pickToScore(db, "risk_checked_at is null", batchSize);
+  const scored = await pickToScore(db, "risk_checked_at is not null", batchSize);
+  // The cap gives way when the other side cannot fill the batch: it exists to
+  // stop the unscored crowding out rescans, not to leave the budget unspent.
+  const room = Math.max(Math.ceil(batchSize / 2), batchSize - scored.length);
+  const take = unscored.slice(0, room);
+  const results = [...take, ...scored.slice(0, batchSize - take.length)];
 
   // react-doctor-disable-next-line react-doctor/async-await-in-loop
   for (const row of results) await scoreAndRecord(db, row.id, row.destination);
   return results.length;
+}
+
+/** One side of the sweep's batch: the oldest rows in the given state. */
+async function pickToScore(
+  db: D1Database,
+  state: string,
+  limit: number,
+): Promise<{ id: string; destination: string }[]> {
+  if (limit <= 0) return [];
+  const { results } = await db
+    .prepare(
+      `select id, destination from links
+       where ${state}
+       order by risk_checked_at asc
+       limit ?`,
+    )
+    .bind(limit)
+    .all<{ id: string; destination: string }>();
+  return results;
 }
 
 /** The host a destination points at, or null if it is not a URL we can read. */

--- a/src/worker/risk.ts
+++ b/src/worker/risk.ts
@@ -130,6 +130,7 @@ export async function sweepLinkRisk(db: D1Database, batchSize = 50): Promise<num
     .bind(batchSize)
     .all<{ id: string; destination: string }>();
 
+  // react-doctor-disable-next-line react-doctor/async-await-in-loop
   for (const row of results) await scoreAndRecord(db, row.id, row.destination);
   return results.length;
 }

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -25,6 +25,7 @@ import {
   ALIAS_TTL_MS,
 } from "../util";
 import { jsonBodyLimit } from "../body-limit";
+import { scoreAndRecord } from "../risk";
 import type { AddressDTO, LinkDTO, LinkInput, OrgPlan, PlanLimits, TopEntry } from "@/shared/types";
 
 const RECENT_CLICKS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -555,6 +556,13 @@ function newLinkRow(
     qrLogoSize: body.qrLogoSize ?? null,
     createdBy,
     createdAt: Date.now(),
+    // Unscored until the waitUntil after this response lands (#68). Null is
+    // not "clean": it is "nobody has looked yet", which is also what puts
+    // this row first in the cron's queue if the lookup fails.
+    riskScore: null,
+    riskReasons: null,
+    riskCheckedAt: null,
+    riskProvider: null,
   };
 }
 
@@ -665,6 +673,9 @@ linkRoutes.post("/", requireOrgRole("member"), async (c) => {
     });
   }
   await enqueueStorage(c.env, [syncLinkMsg(link.slug, hostname)]);
+  // Score the destination after the response (#68), the way clicks are
+  // recorded: it scores, it never blocks, and nobody waits on it.
+  c.executionCtx.waitUntil(scoreAndRecord(c.env.DB, link.id, link.destination));
   return c.json(toDTO(link, 0, hostname, 1), 201);
 });
 
@@ -698,7 +709,25 @@ function mergedLinkUpdate(
     qrBg: body.qrBg ?? existing.qrBg,
     qrEyeColor: body.qrEyeColor ?? existing.qrEyeColor,
     qrLogoSize: body.qrLogoSize ?? existing.qrLogoSize,
+    ...riskAfterDestinationChange(existing, fields.destination),
   };
+}
+
+/**
+ * Clears the risk verdict when a destination changes (#68), in the same write
+ * that changes it.
+ *
+ * Leaving the previous score in place until the re-scan lands would let a
+ * link swapped to a bad destination keep reading clean, which is exactly the
+ * attack the re-score exists to catch. An unchanged destination keeps its
+ * verdict, so editing a title does not send the row back through the queue.
+ */
+function riskAfterDestinationChange(
+  existing: typeof schema.links.$inferSelect,
+  destination: string,
+) {
+  if (destination === existing.destination) return {};
+  return { riskScore: null, riskReasons: null, riskCheckedAt: null, riskProvider: null };
 }
 
 /** A moved link leaves a stale key behind: syncing that old key finds no row
@@ -831,6 +860,16 @@ linkRoutes.patch("/:linkId", requireOrgRole("member"), async (c) => {
   ];
   await db.batch(writes as [(typeof writes)[number], ...(typeof writes)[number][]]);
   await enqueueStorage(c.env, messages);
+
+  // Re-score a changed destination (#68). This is the trigger that matters:
+  // the standard move is to register a clean destination, pass the check,
+  // then swap it, and scoring only at creation buys false confidence.
+  //
+  // mergedLinkUpdate already cleared the old verdict in the same write, so
+  // the link reads as unscored from the moment it changed rather than
+  // carrying the previous destination's clean bill until this finishes.
+  if (updated.destination !== existing.destination)
+    c.executionCtx.waitUntil(scoreAndRecord(c.env.DB, existing.id, updated.destination));
 
   return c.json(await linkToDTO(db, orgId, updated));
 });

--- a/tests/e2e/link-risk.pw.ts
+++ b/tests/e2e/link-risk.pw.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
+import { queryRows } from "./db";
+import { createOrg } from "./orgs";
+
+/**
+ * Destination scoring, through the app the way a person uses it (#68).
+ *
+ * The worker tests stub the resolver and assert the pipeline. This one runs
+ * against the real resolver and asserts the two things only a browser can
+ * show: that creating a link is not delayed or blocked by the scoring, and
+ * that the verdict lands on the row afterwards.
+ *
+ * It scores a genuinely bad destination using the addresses Cloudflare
+ * publishes for exactly this purpose, so the assertion does not depend on
+ * some real site's reputation staying bad.
+ */
+
+const password = "test-password-123";
+const BLOCKED_DESTINATION = "https://malware.testcategory.com/";
+
+type RiskRow = { risk_score: number | null; risk_reasons: string | null };
+
+test("a new link is created immediately and scored afterwards (#68)", async ({ page }) => {
+  const email = `risk-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, email, password);
+  await createOrg(page, "Scoring Org");
+
+  const destination = page.getByPlaceholder("https://example.com/launch").first();
+  await expect(destination).toBeVisible();
+  await destination.fill(BLOCKED_DESTINATION);
+
+  const started = Date.now();
+  await page.getByRole("button", { name: "Create link" }).click();
+
+  // The link exists straight away: scoring never sits in the request path.
+  await expect(page.getByRole("dialog", { name: "Link created" })).toBeVisible();
+  expect(Date.now() - started).toBeLessThan(10_000);
+
+  // Nothing about the score is shown to the person who made it: this is
+  // admin-only signal (#67), and telling a creator which destinations pass
+  // is a map for working around the check. The API-shape version of this
+  // assertion, which is the one with teeth, is in link-risk.worker.ts.
+  await expect(page.getByText(/dns_blocklist|risk score/i)).toHaveCount(0);
+
+  // The verdict lands on the row shortly after, from the real resolver.
+  await expect
+    .poll(
+      async () => {
+        const rows = await queryRows<RiskRow>(
+          page,
+          "select risk_score, risk_reasons from links where destination = ?",
+          [BLOCKED_DESTINATION],
+        );
+        return rows[0]?.risk_score ?? null;
+      },
+      { timeout: 20_000, message: "destination was never scored" },
+    )
+    .toBe(100);
+
+  const rows = await queryRows<RiskRow>(
+    page,
+    "select risk_score, risk_reasons from links where destination = ?",
+    [BLOCKED_DESTINATION],
+  );
+  expect(JSON.parse(rows[0].risk_reasons ?? "[]")).toEqual(["dns_blocklist"]);
+});

--- a/tests/risk.test.ts
+++ b/tests/risk.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { RISK_PROVIDER_DNS, scoreDestination } from "../src/worker/risk";
+
+/**
+ * Reading the resolver's answers (#68).
+ *
+ * The distinction every test here turns on is unscored (null) versus clean
+ * (score 0). They are not the same thing, and conflating them is the way
+ * this feature fails quietly: a provider outage would mark the whole table
+ * clean and nobody would notice, because a clean table is what you expect to
+ * see. So a shape we do not recognise stays null and gets looked at again.
+ */
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Answers every lookup with one canned DNS-over-HTTPS body. */
+function resolverReturns(body: unknown, ok = true) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), { status: ok ? 200 : 502 })) as typeof fetch;
+}
+
+describe("reading the resolver", () => {
+  test("scores a domain the resolver refuses to resolve", async () => {
+    // 0.0.0.0 is how Cloudflare's security resolver says "not this one".
+    resolverReturns({ Status: 0, Answer: [{ data: "0.0.0.0" }] });
+    expect(await scoreDestination("https://malware.example/page")).toEqual({
+      score: 100,
+      reasons: ["dns_blocklist"],
+      provider: RISK_PROVIDER_DNS,
+    });
+  });
+
+  test("scores an ordinary answer clean", async () => {
+    resolverReturns({ Status: 0, Answer: [{ data: "140.82.121.3" }] });
+    expect(await scoreDestination("https://github.com/x")).toEqual({
+      score: 0,
+      reasons: [],
+      provider: RISK_PROVIDER_DNS,
+    });
+  });
+
+  test("treats a name that does not exist as clean, not dangerous", async () => {
+    // NXDOMAIN. A dead link is a dead link; scoring every typo as malware
+    // would bury the real findings.
+    resolverReturns({ Status: 3 });
+    expect((await scoreDestination("https://nothing.invalid"))?.score).toBe(0);
+  });
+});
+
+describe("staying unscored rather than guessing", () => {
+  test("leaves a failed lookup unscored", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+    expect(await scoreDestination("https://example.com")).toBeNull();
+  });
+
+  test("leaves a non-200 unscored", async () => {
+    resolverReturns({ Status: 0, Answer: [] }, false);
+    expect(await scoreDestination("https://example.com")).toBeNull();
+  });
+
+  test("leaves an unrecognised answer shape unscored", async () => {
+    // The resolver is a public service, not a documented threat feed. If it
+    // ever answers something new, that must read as "we do not know", never
+    // as "clean".
+    resolverReturns({ something: "else" });
+    expect(await scoreDestination("https://example.com")).toBeNull();
+  });
+
+  test("leaves a SERVFAIL unscored", async () => {
+    resolverReturns({ Status: 2 });
+    expect(await scoreDestination("https://example.com")).toBeNull();
+  });
+});
+
+describe("destinations it will not look up", () => {
+  test("skips anything that is not a URL", async () => {
+    expect(await scoreDestination("not a url")).toBeNull();
+  });
+
+  test("skips a non-http scheme", async () => {
+    for (const url of ["javascript:alert(1)", "data:text/html,x", "ftp://files.example"]) {
+      expect(await scoreDestination(url)).toBeNull();
+    }
+  });
+});

--- a/tests/worker/link-risk.worker.ts
+++ b/tests/worker/link-risk.worker.ts
@@ -3,7 +3,7 @@ import { env } from "cloudflare:workers";
 import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
 import worker from "../../src/worker";
 import { applyTestMigrations, authEnv, freeOwnerCookie } from "./support";
-import { sweepLinkRisk } from "../../src/worker/risk";
+import { scoreAndRecord, sweepLinkRisk } from "../../src/worker/risk";
 
 /**
  * Destination risk scoring end to end (#68).
@@ -20,13 +20,17 @@ const CLEAN = "https://example.com/x";
 const realFetch = globalThis.fetch;
 
 /** A resolver that refuses BLOCKED's host and resolves everything else. */
-function stubResolver(options: { fail?: boolean } = {}) {
+function stubResolver(options: { fail?: boolean; failHost?: string } = {}) {
   const calls: string[] = [];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
     if (!url.startsWith("https://security.cloudflare-dns.com")) return realFetch(input);
     calls.push(url);
-    if (options.fail) throw new Error("resolver unreachable");
+    // failHost, because the resolver is asked about a host: the query carries
+    // no path, so a test that needs some links to keep failing and others to
+    // succeed has to separate them by hostname.
+    if (options.fail || (options.failHost && url.includes(options.failHost)))
+      throw new Error("resolver unreachable");
     const blocked = url.includes("malware.example");
     return new Response(
       JSON.stringify({ Status: 0, Answer: [{ data: blocked ? "0.0.0.0" : "93.184.216.34" }] }),
@@ -164,6 +168,26 @@ describe("re-scoring on a destination edit", () => {
     expect(row?.risk_checked_at).toBeNull();
   });
 
+  it("throws away a verdict for a destination the link no longer has", async () => {
+    // The lookup is slow and the edit is not. A scan of the old destination
+    // can still be in flight when the link is pointed somewhere else, and it
+    // used to land afterwards and label the new destination with the old
+    // one's verdict: swap a blocked link to something clean and the clean one
+    // inherits 100, or the reverse, which is the direction that matters.
+    //
+    // Called directly with a destination the row no longer has, which is
+    // exactly the state a late scan finishes in.
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const linkId = await createLink(cookie, CLEAN);
+
+    await scoreAndRecord(env.DB, linkId, BLOCKED);
+
+    const row = await riskRow(linkId);
+    expect(row?.risk_score).toBe(0);
+    expect(row?.risk_provider).not.toBeNull();
+  });
+
   it("leaves the verdict alone when only the title changes", async () => {
     stubResolver();
     const cookie = await freeOwnerCookie();
@@ -189,6 +213,36 @@ describe("the cron sweep", () => {
 
     expect((await riskRow(a))?.risk_score).toBe(100);
     expect((await riskRow(b))?.risk_score).toBe(0);
+  });
+
+  it("keeps rescanning even when the unscored never come good", async () => {
+    // A destination the resolver keeps failing on stays unscored, and
+    // unscored is picked first. Enough of those and every run spent its whole
+    // budget retrying the same failures, so a link scored a year ago was
+    // never looked at again: the sweep still returned a number and still did
+    // nothing useful.
+    const cookie = await freeOwnerCookie();
+
+    // Four that can never be scored, on their own host so they can keep
+    // failing while the fifth succeeds.
+    stubResolver({ fail: true });
+    for (let i = 0; i < 4; i++)
+      await postLink(cookie, { destination: `https://stuck.example/${i}` });
+
+    globalThis.fetch = realFetch;
+    stubResolver();
+    const old = await createLink(cookie, CLEAN);
+    const scoredAt = (await riskRow(old))?.risk_checked_at as number;
+    expect(scoredAt).not.toBeNull();
+
+    globalThis.fetch = realFetch;
+    stubResolver({ failHost: "stuck.example" });
+    await new Promise((done) => setTimeout(done, 5));
+    await sweepLinkRisk(env.DB, 4);
+
+    // Half the batch went to the never-scored, so the rescan still got its
+    // turn: the timestamp moved.
+    expect((await riskRow(old))?.risk_checked_at).toBeGreaterThan(scoredAt);
   });
 
   it("stops at the batch size, so one run cannot blow the daily budget", async () => {

--- a/tests/worker/link-risk.worker.ts
+++ b/tests/worker/link-risk.worker.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../../src/worker";
+import { applyTestMigrations, authEnv, freeOwnerCookie } from "./support";
+import { sweepLinkRisk } from "../../src/worker/risk";
+
+/**
+ * Destination risk scoring end to end (#68).
+ *
+ * The resolver is stubbed here, so what these assert is the pipeline: that
+ * scoring happens on the right triggers, writes the right columns, never
+ * blocks or fails a write, and never reaches an org-scoped response. How the
+ * resolver's answers are read is tests/risk.test.ts.
+ */
+
+const BLOCKED = "https://malware.example/x";
+const CLEAN = "https://example.com/x";
+
+const realFetch = globalThis.fetch;
+
+/** A resolver that refuses BLOCKED's host and resolves everything else. */
+function stubResolver(options: { fail?: boolean } = {}) {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (!url.startsWith("https://security.cloudflare-dns.com")) return realFetch(input);
+    calls.push(url);
+    if (options.fail) throw new Error("resolver unreachable");
+    const blocked = url.includes("malware.example");
+    return new Response(
+      JSON.stringify({ Status: 0, Answer: [{ data: blocked ? "0.0.0.0" : "93.184.216.34" }] }),
+      { status: 200 },
+    );
+  }) as typeof fetch;
+  return calls;
+}
+
+async function call(path: string, init: RequestInit): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(`http://localhost${path}`, init), authEnv(), ctx);
+  // waitOnExecutionContext settles the waitUntil the scoring runs in, so the
+  // assertions below are not racing it.
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+const postLink = (cookie: string, body: Record<string, unknown>) =>
+  call("/api/orgs/org-1/links", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+/** Creates a link through the API and returns its id: every test here starts
+ * this way, and only cares about what scoring did to the row afterwards. */
+async function createLink(cookie: string, destination: string): Promise<string> {
+  const res = await postLink(cookie, { destination });
+  const { id } = (await res.json()) as { id: string };
+  return id;
+}
+
+const patchLink = (cookie: string, id: string, body: Record<string, unknown>) =>
+  call(`/api/orgs/org-1/links/${id}`, {
+    method: "PATCH",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+async function riskRow(linkId: string) {
+  return env.DB.prepare(
+    "select risk_score, risk_reasons, risk_checked_at, risk_provider from links where id = ?",
+  )
+    .bind(linkId)
+    .first<{
+      risk_score: number | null;
+      risk_reasons: string | null;
+      risk_checked_at: number | null;
+      risk_provider: string | null;
+    }>();
+}
+
+beforeEach(async () => {
+  reset();
+  await applyTestMigrations();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("scoring on create", () => {
+  it("records a verdict for a destination the resolver refuses", async () => {
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const linkId = await createLink(cookie, BLOCKED);
+
+    const row = await riskRow(linkId);
+    expect(row?.risk_score).toBe(100);
+    expect(JSON.parse(row?.risk_reasons ?? "[]")).toEqual(["dns_blocklist"]);
+    expect(row?.risk_provider).toBe("cloudflare-security-dns");
+    expect(row?.risk_checked_at).toBeGreaterThan(0);
+  });
+
+  it("records a clean verdict for an ordinary destination", async () => {
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const linkId = await createLink(cookie, CLEAN);
+    expect((await riskRow(linkId))?.risk_score).toBe(0);
+  });
+
+  it("creates the link anyway when the resolver is down, and leaves it unscored", async () => {
+    // It scores, it does not block. A provider outage must never cost a user
+    // their link, and must not look like a clean bill of health either.
+    stubResolver({ fail: true });
+    const cookie = await freeOwnerCookie();
+    const res = await postLink(cookie, { destination: BLOCKED });
+    expect(res.status).toBe(201);
+
+    const { id } = (await res.json()) as { id: string };
+    expect((await riskRow(id))?.risk_score).toBeNull();
+  });
+
+  it("never puts a score in the org-scoped response", async () => {
+    // Scores are admin-only (#67). Handing one back here would tell whoever
+    // created the link exactly which destinations pass.
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const body = await (await postLink(cookie, { destination: BLOCKED })).text();
+    expect(body).not.toContain("risk");
+
+    const list = await (await call("/api/orgs/org-1/links", { headers: { cookie } })).text();
+    expect(list).not.toContain("risk");
+  });
+});
+
+describe("re-scoring on a destination edit", () => {
+  it("re-scores when the destination changes", async () => {
+    // The attack this exists for: register something clean, pass the check,
+    // then swap it.
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const linkId = await createLink(cookie, CLEAN);
+    expect((await riskRow(linkId))?.risk_score).toBe(0);
+
+    await patchLink(cookie, linkId, { destination: BLOCKED });
+    expect((await riskRow(linkId))?.risk_score).toBe(100);
+  });
+
+  it("drops the old verdict in the same write, not after the re-scan", async () => {
+    // With the resolver down there is no new verdict to write, so this shows
+    // the clearing is done by the edit itself: a swapped link must not keep
+    // reading clean while the re-scan is pending or failing.
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const linkId = await createLink(cookie, CLEAN);
+
+    globalThis.fetch = realFetch;
+    stubResolver({ fail: true });
+    await patchLink(cookie, linkId, { destination: BLOCKED });
+
+    const row = await riskRow(linkId);
+    expect(row?.risk_score).toBeNull();
+    expect(row?.risk_checked_at).toBeNull();
+  });
+
+  it("leaves the verdict alone when only the title changes", async () => {
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const linkId = await createLink(cookie, BLOCKED);
+    const before = await riskRow(linkId);
+
+    await patchLink(cookie, linkId, { title: "Renamed" });
+    expect(await riskRow(linkId)).toEqual(before);
+  });
+});
+
+describe("the cron sweep", () => {
+  it("picks up unscored links first, then the oldest", async () => {
+    stubResolver({ fail: true });
+    const cookie = await freeOwnerCookie();
+    const a = await createLink(cookie, BLOCKED);
+    const b = await createLink(cookie, CLEAN);
+    expect((await riskRow(a))?.risk_score).toBeNull();
+
+    globalThis.fetch = realFetch;
+    stubResolver();
+    expect(await sweepLinkRisk(env.DB)).toBe(2);
+
+    expect((await riskRow(a))?.risk_score).toBe(100);
+    expect((await riskRow(b))?.risk_score).toBe(0);
+  });
+
+  it("stops at the batch size, so one run cannot blow the daily budget", async () => {
+    stubResolver({ fail: true });
+    const cookie = await freeOwnerCookie();
+    for (let i = 0; i < 4; i++) await postLink(cookie, { destination: `${CLEAN}/${i}` });
+
+    globalThis.fetch = realFetch;
+    const calls = stubResolver();
+    expect(await sweepLinkRisk(env.DB, 2)).toBe(2);
+    expect(calls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Part of #68.

A shortener is phishing infrastructure by default, and how quickly we notice a
bad destination is what keeps rdyrct.com off blocklists. Destinations are
scored on create and on edit, plus a cron sweep, rather than waiting for a
report.

Scoring only. What an admin does with a score comes later in the stack.

Part of splitting #105 up. Based on #109.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated risk scoring for link destinations.
  * New links are scored asynchronously, with results refreshed when destinations change.
  * Risk checks run during scheduled maintenance and prioritize links needing assessment.
  * Risk verdicts are kept out of creator-facing link responses.

* **Bug Fixes**
  * Previous risk results are cleared when a link destination is updated.
  * Resolver failures and unsupported destinations are handled without preventing link creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->