### PR TITLE
Write each public page's title into the HTML the Worker serves

### DIFF
--- a/src/app/lib/seo.ts
+++ b/src/app/lib/seo.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { PUBLIC_PAGE_META } from "@/shared/page-meta";
+import { DEFAULT_PAGE_META, PUBLIC_PAGE_META } from "@/shared/page-meta";
 
 /**
  * Keeps the head honest after a client-side navigation.
@@ -13,14 +13,9 @@ import { PUBLIC_PAGE_META } from "@/shared/page-meta";
  *
  * Both read the same strings, so the two cannot drift.
  */
-/** Sets one attribute and hands back the undo, so leaving a page restores
- * whatever the document arrived with. */
-function setAttribute(selector: string, attribute: string, value: string): () => void {
-  const element = document.head.querySelector(selector);
-  if (!element) return () => {};
-  const before = element.getAttribute(attribute) ?? "";
-  element.setAttribute(attribute, value);
-  return () => element.setAttribute(attribute, before);
+/** Sets one attribute, if the document has that tag at all. */
+function setAttribute(selector: string, attribute: string, value: string): void {
+  document.head.querySelector(selector)?.setAttribute(attribute, value);
 }
 
 /** Every tag a page owns, with the value it should carry. */
@@ -39,18 +34,20 @@ function pageTags(path: string, title: string, description: string) {
 
 export function useSeo(path: string) {
   useEffect(() => {
-    const meta = PUBLIC_PAGE_META[path];
-    if (!meta) return;
-
-    const previousTitle = document.title;
-    document.title = meta.title;
-    const undo = pageTags(path, meta.title, meta.description).map(([selector, attribute, value]) =>
-      setAttribute(selector, attribute, value),
-    );
-
-    return () => {
-      document.title = previousTitle;
-      for (const restore of undo) restore();
-    };
+    const meta = PUBLIC_PAGE_META[path] ?? DEFAULT_PAGE_META;
+    apply(path, meta);
+    // Back to what index.html ships, not to what this document arrived
+    // carrying. Those are the same thing only for somebody who walked here
+    // from elsewhere in the app: arrive on /privacy directly and the Worker
+    // has already written the privacy head into the document, so restoring
+    // "what we arrived with" left the privacy title sitting on the dashboard
+    // they navigated to.
+    return () => apply("/", DEFAULT_PAGE_META);
   }, [path]);
+}
+
+function apply(path: string, meta: { title: string; description: string }): void {
+  document.title = meta.title;
+  for (const [selector, attribute, value] of pageTags(path, meta.title, meta.description))
+    setAttribute(selector, attribute, value);
 }

--- a/src/app/lib/seo.ts
+++ b/src/app/lib/seo.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { PUBLIC_PAGE_META } from "@/shared/page-meta";
+
+/**
+ * Keeps the head honest after a client-side navigation.
+ *
+ * The Worker already writes each public page's title, description and
+ * canonical into the HTML it serves (src/worker/page-meta.ts), which is what
+ * a crawler or a link preview reads. This is for the case that has no new
+ * document at all: somebody on the landing page clicking through to the QR
+ * generator keeps the head they arrived with, so a share from that tab would
+ * describe the wrong page.
+ *
+ * Both read the same strings, so the two cannot drift.
+ */
+/** Sets one attribute and hands back the undo, so leaving a page restores
+ * whatever the document arrived with. */
+function setAttribute(selector: string, attribute: string, value: string): () => void {
+  const element = document.head.querySelector(selector);
+  if (!element) return () => {};
+  const before = element.getAttribute(attribute) ?? "";
+  element.setAttribute(attribute, value);
+  return () => element.setAttribute(attribute, before);
+}
+
+/** Every tag a page owns, with the value it should carry. */
+function pageTags(path: string, title: string, description: string) {
+  const canonical = new URL(path, window.location.origin).toString();
+  return [
+    ['meta[name="description"]', "content", description],
+    ['meta[property="og:title"]', "content", title],
+    ['meta[property="og:description"]', "content", description],
+    ['meta[property="og:url"]', "content", canonical],
+    ['meta[name="twitter:title"]', "content", title],
+    ['meta[name="twitter:description"]', "content", description],
+    ['link[rel="canonical"]', "href", canonical],
+  ] satisfies [string, string, string][];
+}
+
+export function useSeo(path: string) {
+  useEffect(() => {
+    const meta = PUBLIC_PAGE_META[path];
+    if (!meta) return;
+
+    const previousTitle = document.title;
+    document.title = meta.title;
+    const undo = pageTags(path, meta.title, meta.description).map(([selector, attribute, value]) =>
+      setAttribute(selector, attribute, value),
+    );
+
+    return () => {
+      document.title = previousTitle;
+      for (const restore of undo) restore();
+    };
+  }, [path]);
+}

--- a/src/app/routes/privacy.tsx
+++ b/src/app/routes/privacy.tsx
@@ -1,8 +1,10 @@
 // fallow-ignore-file code-duplication -- legal sections share structural patterns
 import { SUPPORT_EMAIL } from "../ui/footer";
 import { LegalPageLayout } from "../ui/misc";
+import { useSeo } from "../lib/seo";
 
 export function PrivacyPage() {
+  useSeo("/privacy");
   return (
     <LegalPageLayout>
       <div>

--- a/src/app/routes/terms.tsx
+++ b/src/app/routes/terms.tsx
@@ -1,8 +1,10 @@
 // fallow-ignore-file code-duplication -- legal sections share structural patterns
 import { SUPPORT_EMAIL, GITHUB_URL } from "../ui/footer";
 import { LegalPageLayout } from "../ui/misc";
+import { useSeo } from "../lib/seo";
 
 export function TermsPage() {
+  useSeo("/terms");
   return (
     <LegalPageLayout>
       <div>

--- a/src/shared/page-meta.ts
+++ b/src/shared/page-meta.ts
@@ -1,0 +1,44 @@
+/**
+ * What each public page calls itself in a search result and a link preview.
+ *
+ * Shared because two places need the same strings and must not drift: the
+ * Worker writes them into the HTML it serves (src/worker/page-meta.ts), and
+ * the SPA re-applies them on client-side navigation, where no new document is
+ * fetched and the head would otherwise still describe the page somebody
+ * arrived on.
+ *
+ * The wording leads with what people type. "URL shortener" and "QR code
+ * generator" are the searches; the brand is not, and a title that opens with
+ * it spends the most valuable words in the result on a name nobody is looking
+ * for yet.
+ */
+export interface PageMeta {
+  title: string;
+  description: string;
+}
+
+export const PUBLIC_PAGE_META: Record<string, PageMeta> = {
+  "/": {
+    title: "rdyrct - URL shortener and QR code generator with click analytics",
+    description:
+      "Free URL shortener and QR code generator for teams. Branded short links on your own domain, custom QR codes with your logo, and privacy-friendly click analytics with UTM tracking.",
+  },
+  "/signup": {
+    title: "Sign up - rdyrct URL shortener and QR codes",
+    description:
+      "Create a free rdyrct account: short links with click analytics, QR codes, and UTM tracking for your team. No card required.",
+  },
+  "/login": {
+    title: "Log in - rdyrct",
+    description: "Log in to your rdyrct account to manage short links, QR codes and analytics.",
+  },
+  "/privacy": {
+    title: "Privacy policy - rdyrct",
+    description:
+      "What rdyrct stores and what it does not: click analytics keep country, referrer, device and time, never an IP address or a precise location.",
+  },
+  "/terms": {
+    title: "Terms of service - rdyrct",
+    description: "The terms covering rdyrct short links, QR codes and analytics.",
+  },
+};

--- a/src/shared/page-meta.ts
+++ b/src/shared/page-meta.ts
@@ -17,6 +17,19 @@ export interface PageMeta {
   description: string;
 }
 
+/**
+ * What index.html ships, and therefore what every page that has no entry of
+ * its own should read. Kept here rather than left implicit in the HTML: the
+ * client hook has to put this back when it leaves a public page, and
+ * "restore whatever the document arrived with" is wrong for exactly the
+ * visitor who arrived on the public page itself.
+ */
+export const DEFAULT_PAGE_META: PageMeta = {
+  title: "rdyrct - short links that carry your team's brand",
+  description:
+    "Short links that carry your brand. Branded short links, QR codes, and custom domains with privacy-friendly analytics.",
+};
+
 export const PUBLIC_PAGE_META: Record<string, PageMeta> = {
   "/": {
     title: "rdyrct - URL shortener and QR code generator with click analytics",

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -17,6 +17,7 @@ import { capRoutes } from "./routes/cap";
 import { sweepLinkRisk } from "./risk";
 import { resolveSlug, resolveDomain, type KVLink } from "./kv";
 import { RESERVED_SLUGS } from "./util";
+import { withPageMeta } from "./page-meta";
 import { enforcePublicAuthRateLimit, enforceSignedApiRateLimit } from "./rate-limit";
 import { applySecurityHeaders, isBlogPath } from "./security-headers";
 import { drizzle } from "drizzle-orm/d1";
@@ -196,7 +197,15 @@ app.get("/:slug", async (c, next) => {
 
 /* ---------------- SPA fallback ---------------- */
 
-app.all("*", (c) => c.env.ASSETS.fetch(c.req.raw));
+app.all("*", async (c) => {
+  const response = await c.env.ASSETS.fetch(c.req.raw);
+  // The SPA is one document for every route, so the head it ships describes
+  // the landing page. Public pages get their own title, description and
+  // canonical written in before the bytes leave (#96): a crawler or a link
+  // preview reads those, and most of them never run the JavaScript that
+  // would otherwise set them.
+  return withPageMeta(response, new URL(c.req.url));
+});
 
 /* ---------------- Queue consumer: KV/R2 follow-up work + click ingestion ---------------- */
 

--- a/src/worker/page-meta.ts
+++ b/src/worker/page-meta.ts
@@ -1,0 +1,72 @@
+/**
+ * Per-page title, description and canonical, written into the HTML before it
+ * leaves the Worker.
+ *
+ * The SPA ships one index.html for every route, so the QR generator went out
+ * under the landing page's title, the landing page's description and the
+ * landing page's canonical: two pages competing for one search result, and
+ * a link preview that described the wrong thing.
+ *
+ * Doing it here rather than in the browser is the point. A crawler that
+ * renders JavaScript would eventually see a title set on mount, but the ones
+ * that matter for a link preview (Slack, WhatsApp, iMessage, Discord) read
+ * the bytes and never run a line of it, and Bing's renderer is a queue with
+ * no promised turnaround. HTMLRewriter costs one pass over a document this
+ * Worker is already serving.
+ *
+ * Only the public routes are listed. Everything behind the login can keep the
+ * default: it wants no traffic from a search engine.
+ */
+import { PUBLIC_PAGE_META, type PageMeta } from "@/shared/page-meta";
+
+/** The absolute URL a page should call canonical, on whichever host is
+ * serving it. */
+function canonicalFor(url: URL, path: string): string {
+  return new URL(path, url.origin).toString();
+}
+
+class MetaContent {
+  constructor(private readonly value: string) {}
+  element(element: Element) {
+    element.setAttribute("content", this.value);
+  }
+}
+
+class Href {
+  constructor(private readonly value: string) {}
+  element(element: Element) {
+    element.setAttribute("href", this.value);
+  }
+}
+
+class Text {
+  constructor(private readonly value: string) {}
+  element(element: Element) {
+    element.setInnerContent(this.value);
+  }
+}
+
+/**
+ * Rewrites the head of an HTML response for `path`, or returns it untouched
+ * when the path is not a page we describe.
+ *
+ * The response is passed through unread when nothing matches, so the asset
+ * path stays a straight pipe for everything else.
+ */
+export function withPageMeta(response: Response, url: URL): Response {
+  const meta: PageMeta | undefined = PUBLIC_PAGE_META[url.pathname];
+  if (!meta) return response;
+  if (!response.headers.get("content-type")?.includes("text/html")) return response;
+
+  const canonical = canonicalFor(url, url.pathname);
+  return new HTMLRewriter()
+    .on("title", new Text(meta.title))
+    .on('meta[name="description"]', new MetaContent(meta.description))
+    .on('meta[property="og:title"]', new MetaContent(meta.title))
+    .on('meta[property="og:description"]', new MetaContent(meta.description))
+    .on('meta[property="og:url"]', new MetaContent(canonical))
+    .on('meta[name="twitter:title"]', new MetaContent(meta.title))
+    .on('meta[name="twitter:description"]', new MetaContent(meta.description))
+    .on('link[rel="canonical"]', new Href(canonical))
+    .transform(response);
+}

--- a/tests/e2e/production/seo.pw.ts
+++ b/tests/e2e/production/seo.pw.ts
@@ -61,12 +61,12 @@ test("walking off a public page does not take its title along", async ({ page })
   await page.getByRole("link", { name: "Terms" }).click();
   await expect(page).toHaveTitle(/Terms of service/);
 
-  // And off a public page entirely: back to what index.html ships, rather
-  // than the privacy title following along. The landing page claims its own
-  // head once there is a hook call on it; until then the default is exactly
-  // what leaving should restore.
+  // And off a public page entirely. Asserted as "not the page we left",
+  // because what the landing page ends up titled depends on whether it
+  // claims a head of its own, while "the privacy title came along" is the
+  // bug in either case.
   await page.goto("/privacy");
   await page.getByRole("link", { name: "rdyrct" }).first().click();
   await expect(page).toHaveURL(/\/$/);
-  await expect(page).toHaveTitle("rdyrct - short links that carry your team's brand");
+  await expect(page).not.toHaveTitle(/Privacy policy/);
 });

--- a/tests/e2e/production/seo.pw.ts
+++ b/tests/e2e/production/seo.pw.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The head a crawler actually receives, from the built Worker and the real
+ * asset bundle.
+ *
+ * Fetched rather than rendered: the clients this is for (Slack, WhatsApp,
+ * iMessage, Discord, and Bing's first pass) read the bytes and never run a
+ * line of the page's JavaScript. A title set on mount would pass a rendered
+ * check and still be wrong for every one of them.
+ */
+
+const PAGES = [
+  { path: "/", title: /URL shortener and QR code generator/ },
+  { path: "/signup", title: /Sign up/ },
+  { path: "/privacy", title: /Privacy policy/ },
+];
+
+test("each public page arrives with its own title", async ({ request }) => {
+  for (const { path, title } of PAGES) {
+    const html = await (await request.get(path)).text();
+    const found = /<title>([^<]*)<\/title>/.exec(html)?.[1] ?? "";
+    expect(found, `title of ${path}`).toMatch(title);
+  }
+});
+
+test("each public page points its canonical at itself", async ({ request }) => {
+  for (const { path } of PAGES) {
+    const html = await (await request.get(path)).text();
+    const canonical = /rel="canonical" href="([^"]*)"/.exec(html)?.[1] ?? "";
+    expect(new URL(canonical).pathname, `canonical of ${path}`).toBe(path);
+  }
+});
+
+test("a public page describes itself in the share tags, not the landing page", async ({
+  request,
+}) => {
+  const html = await (await request.get("/privacy")).text();
+
+  expect(html).toMatch(/"og:title" content="Privacy policy/);
+  expect(html).toMatch(/"og:description" content="What rdyrct stores/);
+  expect(html).toMatch(/"og:url" content="[^"]*\/privacy"/);
+});
+
+test("the signed-in app keeps the default head", async ({ request }) => {
+  // Nothing behind the login wants search traffic.
+  const html = await (await request.get("/dashboard")).text();
+
+  expect(html).toContain("<title>rdyrct - short links that carry your team's brand");
+});

--- a/tests/e2e/production/seo.pw.ts
+++ b/tests/e2e/production/seo.pw.ts
@@ -48,3 +48,25 @@ test("the signed-in app keeps the default head", async ({ request }) => {
 
   expect(html).toContain("<title>rdyrct - short links that carry your team's brand");
 });
+
+test("walking off a public page does not take its title along", async ({ page }) => {
+  // The head the Worker wrote is right for the document it served, and wrong
+  // for wherever a client-side navigation goes next. Restoring "what the
+  // document arrived with" looked correct and was exactly backwards for the
+  // visitor who arrived on the public page itself: they carried the privacy
+  // title onto the page they clicked through to.
+  await page.goto("/privacy");
+  await expect(page).toHaveTitle(/Privacy policy/);
+
+  await page.getByRole("link", { name: "Terms" }).click();
+  await expect(page).toHaveTitle(/Terms of service/);
+
+  // And off a public page entirely: back to what index.html ships, rather
+  // than the privacy title following along. The landing page claims its own
+  // head once there is a hook call on it; until then the default is exactly
+  // what leaving should restore.
+  await page.goto("/privacy");
+  await page.getByRole("link", { name: "rdyrct" }).first().click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page).toHaveTitle("rdyrct - short links that carry your team's brand");
+});

--- a/tests/worker/page-meta.worker.ts
+++ b/tests/worker/page-meta.worker.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { withPageMeta } from "../../src/worker/page-meta";
+
+/**
+ * The head each public page goes out with (#96).
+ *
+ * The SPA is one index.html for every route, so without this the QR
+ * generator claimed the landing page's title, description and canonical:
+ * two pages competing for one search result, and a link preview describing
+ * the wrong thing. Setting them in the browser on mount is not enough,
+ * because the clients behind a link preview (Slack, WhatsApp, iMessage) read
+ * the bytes and never run the JavaScript.
+ *
+ * The rewrite is asserted here rather than through a request, because the
+ * worker test environment has no built asset bundle and so serves no HTML.
+ * The whole path is covered against the real bundle in
+ * tests/e2e/production/seo.pw.ts.
+ */
+
+const SHELL = `<!doctype html><html><head>
+<title>rdyrct - short links that carry your team's brand</title>
+<meta name="description" content="Short links that carry your brand." />
+<link rel="canonical" href="https://rdyrct.com" />
+<meta property="og:title" content="rdyrct" />
+<meta property="og:description" content="Short links that carry your brand." />
+<meta property="og:url" content="https://rdyrct.com" />
+<meta name="twitter:title" content="rdyrct" />
+<meta name="twitter:description" content="Short links that carry your brand." />
+</head><body></body></html>`;
+
+function shell(): Response {
+  return new Response(SHELL, { headers: { "content-type": "text/html; charset=utf-8" } });
+}
+
+async function rewrite(path: string): Promise<string> {
+  const url = new URL(`https://rdyrct.com${path}`);
+  return withPageMeta(shell(), url).text();
+}
+
+describe("the head a public page ships", () => {
+  it("gives a public page its own title, description and canonical", async () => {
+    const html = await rewrite("/privacy");
+
+    expect(html).toContain("<title>Privacy policy - rdyrct");
+    expect(html).toMatch(/name="description" content="What rdyrct stores/);
+    expect(html).toContain('href="https://rdyrct.com/privacy"');
+  });
+
+  it("leads the landing page with what people search for", async () => {
+    const html = await rewrite("/");
+
+    // "URL shortener" and "QR code generator" are the searches; the brand is
+    // not, and a title that opens with it spends the result's best words on a
+    // name nobody is looking for yet.
+    expect(html).toContain("URL shortener and QR code generator");
+  });
+
+  it("carries the same words into the share preview tags", async () => {
+    const html = await rewrite("/privacy");
+
+    for (const tag of ["og:title", "twitter:title"]) {
+      expect(html).toMatch(new RegExp(`"${tag}" content="Privacy policy`));
+    }
+    expect(html).toContain('"og:url" content="https://rdyrct.com/privacy"');
+  });
+
+  it("leaves the signed-in app on the default head", async () => {
+    // Nothing behind the login wants search traffic, so it keeps whatever
+    // index.html says rather than earning an entry in the table.
+    const html = await rewrite("/dashboard");
+
+    expect(html).toContain("<title>rdyrct - short links that carry your team's brand");
+  });
+
+  it("does not touch anything that is not HTML", async () => {
+    const asset = new Response("body{}", { headers: { "content-type": "text/css" } });
+    const out = withPageMeta(asset, new URL("https://rdyrct.com/"));
+
+    expect(await out.text()).toBe("body{}");
+  });
+});


### PR DESCRIPTION
The SPA shipped one `index.html` for every route, so every public page went out
under the landing page's title, description and canonical. Two pages competed
for one search result, and every link preview said the same thing.

`HTMLRewriter` writes each public page's head in the Worker. It has to be the
Worker: the clients this is for (Slack, WhatsApp, iMessage, Discord, Bing's
first pass) read the bytes and never run a line of the page's JavaScript, so a
title set on mount would pass a rendered check and still be wrong for all of
them. The client hook survives for in-app navigation, and both read the same
strings from `src/shared/page-meta.ts`.

Nothing behind the login gets an entry: it keeps the default head, because
nothing back there wants search traffic.

Part of splitting #105 up. Based on #110.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page-specific SEO metadata for the homepage, authentication pages, privacy policy, and terms.
  * Added dynamic titles, descriptions, canonical URLs, Open Graph metadata, and Twitter metadata.
  * Added default metadata for authenticated dashboard pages.
  * Metadata now updates during in-app navigation and server-rendered page requests.

* **Bug Fixes**
  * Ensured unknown routes and non-HTML responses retain their existing content and metadata.
  * Prevented outdated page titles from persisting after navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->