### PR TITLE
Stop the JSON body limit rejecting logo uploads

### DIFF
--- a/src/worker/body-limit.ts
+++ b/src/worker/body-limit.ts
@@ -1,16 +1,41 @@
+import type { Context, Next } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import { QR_LOGO_MAX_BYTES } from "@/shared/types";
 
 // A generous ceiling for this API's JSON bodies — the largest legitimate
 // payload (a link create/update with every optional field filled in, or a
 // bulk invite) is a few KB — mainly a defense against an oversized or
 // malformed request reaching a route handler at all before any other
-// validation runs (see issue #19). Binary uploads (the QR logo route) set
-// their own, much larger limit instead of using this one.
+// validation runs (see issue #19).
 const DEFAULT_JSON_BODY_LIMIT = 32 * 1024;
 
+// What anything that is not JSON gets. The QR logo upload is the only one,
+// and it sets the same ceiling again on its own route; this exists because
+// the org router's middleware runs first for every path under /orgs, which
+// includes /orgs/:orgId/qr-logo. Holding a 512x512 WebP to a limit written
+// for JSON is how a 6 KB PNG came back as "Request body too large".
+const BINARY_BODY_LIMIT = QR_LOGO_MAX_BYTES + 4096;
+
+const json = bodyLimit({
+  maxSize: DEFAULT_JSON_BODY_LIMIT,
+  onError: (c) => c.json({ message: "Request body too large" }, 413),
+});
+
+const binary = bodyLimit({
+  maxSize: BINARY_BODY_LIMIT,
+  onError: (c) => c.json({ message: "File too large" }, 413),
+});
+
+/**
+ * The JSON ceiling for JSON, a file-sized one for everything else.
+ *
+ * Neither is a substitute for a route's own validation: this only keeps an
+ * oversized body from reaching a handler at all.
+ */
 export function jsonBodyLimit() {
-  return bodyLimit({
-    maxSize: DEFAULT_JSON_BODY_LIMIT,
-    onError: (c) => c.json({ message: "Request body too large" }, 413),
-  });
+  return (c: Context, next: Next) => {
+    const type = c.req.header("content-type") ?? "";
+    const isJson = type === "" || type.includes("json");
+    return isJson ? json(c, next) : binary(c, next);
+  };
 }

--- a/src/worker/body-limit.ts
+++ b/src/worker/body-limit.ts
@@ -27,15 +27,25 @@ const binary = bodyLimit({
 });
 
 /**
- * The JSON ceiling for JSON, a file-sized one for everything else.
+ * The file-sized ceiling for an image upload, the JSON one for everything
+ * else.
  *
- * Neither is a substitute for a route's own validation: this only keeps an
- * oversized body from reaching a handler at all.
+ * Written round this way on purpose. Asking "is this JSON?" and giving the
+ * larger limit to everything else means any header we fail to recognize gets
+ * the loose ceiling: `Application/JSON` is valid, and a case-sensitive
+ * `includes("json")` handed it 260 KB instead of 32. Asking "is this an
+ * image?" fails the other way, which is the way to fail.
+ *
+ * The media type is compared the same way the upload route compares it: the
+ * parameters dropped, the rest lowercased, since `image/webp; charset=x` and
+ * `IMAGE/WEBP` are the same type.
+ *
+ * Neither ceiling is a substitute for a route's own validation: this only
+ * keeps an oversized body from reaching a handler at all.
  */
 export function jsonBodyLimit() {
   return (c: Context, next: Next) => {
-    const type = c.req.header("content-type") ?? "";
-    const isJson = type === "" || type.includes("json");
-    return isJson ? json(c, next) : binary(c, next);
+    const type = (c.req.header("content-type") ?? "").split(";")[0].trim().toLowerCase();
+    return type.startsWith("image/") ? binary(c, next) : json(c, next);
   };
 }

--- a/tests/worker/request-validation.worker.ts
+++ b/tests/worker/request-validation.worker.ts
@@ -35,6 +35,31 @@ describe("request body size limit (#19)", () => {
     expect(res.status).toBe(413);
   });
 
+  it("lets a QR logo through that is larger than the JSON ceiling", async () => {
+    // The bug this pins: /orgs/:orgId/qr-logo sits under the org router, so
+    // the org router's JSON limit (32 KB) ran first and answered "Request
+    // body too large" for a perfectly ordinary logo. A 512x512 WebP is
+    // routinely bigger than that, which made every logo upload fail.
+    const cookie = await freeOwnerCookie();
+    const ctx = createExecutionContext();
+    const webp = new Uint8Array(64 * 1024);
+    // A real RIFF/WEBP header, so the route gets past its own sniffing and
+    // the only thing under test is the size limit.
+    webp.set(new TextEncoder().encode("RIFF"), 0);
+    webp.set(new TextEncoder().encode("WEBP"), 8);
+    const res = await worker.fetch(
+      new Request("http://localhost/api/orgs/org-1/qr-logo", {
+        method: "POST",
+        headers: { cookie, "content-type": "image/webp" },
+        body: webp,
+      }),
+      authEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).not.toBe(413);
+  });
+
   it("rejects an oversized QR logo upload with 413", async () => {
     const cookie = await freeOwnerCookie();
     const ctx = createExecutionContext();

--- a/tests/worker/request-validation.worker.ts
+++ b/tests/worker/request-validation.worker.ts
@@ -60,6 +60,47 @@ describe("request body size limit (#19)", () => {
     expect(res.status).not.toBe(413);
   });
 
+  it("holds a mixed-case JSON content type to the JSON ceiling", async () => {
+    // `Application/JSON` is valid, and the check used to ask whether the raw
+    // header contained "json", case-sensitively. It did not, so the request
+    // was treated as a file and got 260 KB instead of 32: a caller could opt
+    // out of the JSON limit by changing the case of their own header. It
+    // asks whether the type is an image now, so anything unrecognized falls
+    // to the tighter ceiling rather than the looser one.
+    const cookie = await freeOwnerCookie();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/api/orgs", {
+        method: "POST",
+        headers: { cookie, "content-type": "Application/JSON; charset=UTF-8" },
+        body: JSON.stringify({ name: "a".repeat(64 * 1024) }),
+      }),
+      authEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(413);
+  });
+
+  it("still lets an upload through on a mixed-case image type", async () => {
+    const cookie = await freeOwnerCookie();
+    const ctx = createExecutionContext();
+    const webp = new Uint8Array(64 * 1024);
+    webp.set(new TextEncoder().encode("RIFF"), 0);
+    webp.set(new TextEncoder().encode("WEBP"), 8);
+    const res = await worker.fetch(
+      new Request("http://localhost/api/orgs/org-1/qr-logo", {
+        method: "POST",
+        headers: { cookie, "content-type": "IMAGE/WEBP" },
+        body: webp,
+      }),
+      authEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).not.toBe(413);
+  });
+
   it("rejects an oversized QR logo upload with 413", async () => {
     const cookie = await freeOwnerCookie();
     const ctx = createExecutionContext();


### PR DESCRIPTION
Uploading a 6KB PNG as an organization's QR logo returned "Request body too
large".

The org router mounts `jsonBodyLimit` on `*`, so its 32KB ceiling ran for
`POST /orgs/:orgId/qr-logo` as well, where the body is an image. The limit
follows the content type now: JSON keeps 32KB, an upload gets the QR logo's own
256KB.

Part of splitting #105 up. Based on #111.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * QR-logo uploads up to 64 KiB are no longer incorrectly rejected.
  * JSON requests now enforce a 32 KiB size limit.
  * Binary uploads use an appropriate size limit based on the configured logo limit.
  * Oversized JSON and binary requests now return distinct error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->