### PR TITLE
Answer an abuse report without deleting an organization

### DIFF
--- a/migrations/0019_add_link_risk_scoring.sql
+++ b/migrations/0019_add_link_risk_scoring.sql
@@ -5,22 +5,25 @@
 -- may already be on a blocklist.
 --
 -- Three columns, all null on existing rows, which is the correct starting
--- state: null means unscored, not clean. The cron picks up the nulls first,
--- so the whole table cycles without a backfill here.
+-- state: null means unscored, not clean. Nothing backfills them: a link is
+-- scored when it is created, when its destination changes, and when somebody
+-- clicks it and the answer has gone stale. A link nobody ever clicks stays
+-- unscored, which is fine, because it is also a link nobody ever visits.
 --
 -- risk_score    0 = nothing known against it, 100 = a provider refuses it.
 --               An integer rather than a boolean because a second provider
 --               will have degrees, and widening a boolean later is a
 --               migration nobody enjoys.
 -- risk_reasons  JSON array of short codes, e.g. ["dns_blocklist"].
--- risk_checked_at  ms epoch. Also the cron's queue order: oldest first.
+-- risk_checked_at  ms epoch. Read on a click to decide whether the verdict
+--                  is stale enough to check again.
 -- risk_provider    which provider answered, so two of them can be compared
 --                  on real traffic before anyone pays for the second.
 --
--- Deliberately not indexed. The cron's `order by risk_checked_at` scan is a
--- daily job over a table measured in thousands of rows, and the admin list
--- (#67) filters by org first. Add an index when a query is actually slow,
--- not in anticipation.
+-- Deliberately not indexed. Nothing scans by this column: the freshness check
+-- happens per click against a hostname cache in KV, and the admin list (#67)
+-- filters by org first. Add an index when a query is actually slow, not in
+-- anticipation.
 
 ALTER TABLE links ADD COLUMN risk_score INTEGER;
 ALTER TABLE links ADD COLUMN risk_reasons TEXT;

--- a/migrations/0021_add_link_suspension_and_audit.sql
+++ b/migrations/0021_add_link_suspension_and_audit.sql
@@ -1,0 +1,52 @@
+-- Admin moderation: suspend a link, and record who did what (#67).
+--
+-- Until now the only answer to an abuse report was deleting the whole
+-- organization. That destroys a possibly-legitimate customer's other links to
+-- deal with one bad one, and it cannot be undone.
+--
+-- A shortener is phishing infrastructure by default. How fast and how
+-- precisely we can answer a report is what keeps rdyrct.com off blocklists,
+-- and rdyrct.com on Safe Browsing breaks every free-plan link at once.
+--
+-- suspended_at NULL means active. One flag on the link covers every address
+-- it answers to, so suspending does not have to chase aliases.
+--
+-- Suspension is reversible and deletion is not, which is the whole point: the
+-- row stays, its clicks stay, and an appeal is possible.
+
+ALTER TABLE links ADD COLUMN suspended_at INTEGER;
+ALTER TABLE links ADD COLUMN suspended_by TEXT REFERENCES user(id) ON DELETE SET NULL;
+ALTER TABLE links ADD COLUMN suspend_reason TEXT;
+
+-- Partial index: the admin list filters on "currently suspended", which is
+-- expected to be a tiny slice of the table, and a partial index costs nothing
+-- for the rows that are not in it.
+CREATE INDEX idx_links_suspended ON links (suspended_at) WHERE suspended_at IS NOT NULL;
+
+-- Every privileged mutation, appended and never updated.
+--
+-- Deliberately small. #22 covers the larger admin identity work (immutable
+-- root id, roles, MFA) and should build on this table rather than adding a
+-- second one.
+--
+-- actor_user_id has no foreign key on purpose: an admin account can be
+-- deleted, and the record of what they did must outlive them. Same reasoning
+-- for target_id, which points at rows this table exists to remember the
+-- deletion of.
+CREATE TABLE admin_actions (
+  id TEXT PRIMARY KEY,
+  actor_user_id TEXT NOT NULL,
+  -- e.g. 'link.suspend', 'link.unsuspend', 'org.suspend_links', 'user.ban'
+  action TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  -- Free-form JSON: the reason, counts, whatever the action needs to be
+  -- understood later without joining to rows that may be gone.
+  detail TEXT,
+  created_at INTEGER NOT NULL
+);
+
+-- The log is read newest-first, and filtered by target when investigating one
+-- link or org.
+CREATE INDEX idx_admin_actions_created ON admin_actions (created_at DESC);
+CREATE INDEX idx_admin_actions_target ON admin_actions (target_type, target_id);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
   // tests that pass in CI time out locally, and the whole suite runs slower
   // (1.6m at 4 workers, 1.3m at 2). Pinned so both match.
   workers: 2,
+  // Playwright's default is 30s, which was set for tests that click around a
+  // page. Nearly every test here starts by creating a real account: a Cap
+  // proof-of-work solve, an account write, a mail send and a six-digit code
+  // read back out of the emulator. That is most of 30s before the test has
+  // begun, and it is why failures kept landing on the first assertion after
+  // sign-up rather than on anything the test was written to check.
+  timeout: 60_000,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -20,6 +20,10 @@ import type {
   AdminOrgRow,
   AdminOrgDetail,
   AdminUserRow,
+  AdminLinkRow,
+  AdminLinkSort,
+  AdminAnonLinkRow,
+  AdminActionRow,
 } from "@/shared/types";
 
 export function useCurrentUser() {
@@ -309,6 +313,31 @@ export const useAdminOrgDetail = (orgId: string | null) =>
     queryKey: ["admin", "org", orgId],
     queryFn: () => api(`/admin/orgs/${orgId}`),
     enabled: !!orgId,
+  });
+
+/** The cross-org link list (#67). `q` and `sort` go to the server, because
+ * the table can hold far more links than a browser should filter. */
+export const useAdminLinks = (params: { q: string; sort: AdminLinkSort; suspended: boolean }) =>
+  useQuery<AdminLinkRow[]>({
+    queryKey: ["admin", "links", params],
+    queryFn: () =>
+      api(
+        `/admin/links?q=${encodeURIComponent(params.q)}&sort=${params.sort}${
+          params.suspended ? "&suspended=1" : ""
+        }`,
+      ),
+  });
+
+export const useAdminAnonLinks = () =>
+  useQuery<AdminAnonLinkRow[]>({
+    queryKey: ["admin", "anon-links"],
+    queryFn: () => api("/admin/links/anonymous"),
+  });
+
+export const useAdminAudit = () =>
+  useQuery<AdminActionRow[]>({
+    queryKey: ["admin", "audit"],
+    queryFn: () => api("/admin/links/audit"),
   });
 
 export const useAdminUsers = () =>

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -320,12 +320,13 @@ export const useAdminOrgDetail = (orgId: string | null) =>
  * than a browser should filter. Ordering does not: the response is capped, so
  * sorting it is a client concern and the column headers can drive it the way
  * every other table here works. */
-export const useAdminLinks = (params: { q: string; suspended: boolean }) =>
+export const useAdminLinks = (params: { q: string; suspended: boolean; org?: string }) =>
   useQuery<AdminLinkRow[]>({
     queryKey: ["admin", "links", params],
     queryFn: () =>
       api(
-        `/admin/links?q=${encodeURIComponent(params.q)}${params.suspended ? "&suspended=1" : ""}`,
+        `/admin/links?q=${encodeURIComponent(params.q)}${params.suspended ? "&suspended=1" : ""}` +
+          (params.org ? `&org=${encodeURIComponent(params.org)}` : ""),
       ),
     // The search term is part of the key, so without this every pause in
     // typing replaced the table with a skeleton and put it back. That flashes,

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { api, ApiError } from "./api";
 import { authClient } from "./auth-client";
 import { writeAuthHint } from "./auth-hint";
@@ -327,6 +327,11 @@ export const useAdminLinks = (params: { q: string; suspended: boolean }) =>
       api(
         `/admin/links?q=${encodeURIComponent(params.q)}${params.suspended ? "&suspended=1" : ""}`,
       ),
+    // The search term is part of the key, so without this every pause in
+    // typing replaced the table with a skeleton and put it back. That flashes,
+    // and it also tears out whatever the admin had open: a row's actions menu
+    // is unmounted mid-click when the new page of results lands.
+    placeholderData: keepPreviousData,
   });
 
 export const useAdminAnonLinks = () =>

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -21,7 +21,6 @@ import type {
   AdminOrgDetail,
   AdminUserRow,
   AdminLinkRow,
-  AdminLinkSort,
   AdminAnonLinkRow,
   AdminActionRow,
 } from "@/shared/types";
@@ -315,16 +314,18 @@ export const useAdminOrgDetail = (orgId: string | null) =>
     enabled: !!orgId,
   });
 
-/** The cross-org link list (#67). `q` and `sort` go to the server, because
- * the table can hold far more links than a browser should filter. */
-export const useAdminLinks = (params: { q: string; sort: AdminLinkSort; suspended: boolean }) =>
+/** The cross-org link list (#67).
+ *
+ * The search goes to the server, because the table can hold far more links
+ * than a browser should filter. Ordering does not: the response is capped, so
+ * sorting it is a client concern and the column headers can drive it the way
+ * every other table here works. */
+export const useAdminLinks = (params: { q: string; suspended: boolean }) =>
   useQuery<AdminLinkRow[]>({
     queryKey: ["admin", "links", params],
     queryFn: () =>
       api(
-        `/admin/links?q=${encodeURIComponent(params.q)}&sort=${params.sort}${
-          params.suspended ? "&suspended=1" : ""
-        }`,
+        `/admin/links?q=${encodeURIComponent(params.q)}${params.suspended ? "&suspended=1" : ""}`,
       ),
   });
 

--- a/src/app/lib/use-debounced.ts
+++ b/src/app/lib/use-debounced.ts
@@ -1,0 +1,26 @@
+/**
+ * A value that lags behind, for search boxes whose term reaches the server.
+ *
+ * The admin link search has to run server-side: the endpoint caps its
+ * response, so filtering in the browser would only ever search the newest
+ * rows and miss the link an abuse report actually names. That means the term
+ * is part of a query key, and without this every keystroke was its own
+ * request: typing "testing" fired eight.
+ *
+ * The other admin tables need none of this because they hold their whole
+ * table already and filter in place.
+ */
+import { useEffect, useState } from "react";
+
+export function useDebounced<T>(value: T, delayMs = 300): T {
+  const [settled, setSettled] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(value), delayMs);
+    // Clearing on every change is what makes this a debounce rather than a
+    // delay: only a pause longer than delayMs lets a value through.
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return settled;
+}

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -61,6 +61,9 @@ const AdminUsagePage = lazy(() =>
     default: m.AdminUsagePage,
   })),
 );
+const AdminLinksPage = lazy(() =>
+  import("./routes/admin/links").then((m) => ({ default: m.AdminLinksPage })),
+);
 const AdminOrgsPage = lazy(() =>
   import("./routes/admin/orgs").then((m) => ({ default: m.AdminOrgsPage })),
 );
@@ -120,6 +123,14 @@ createRoot(document.getElementById("root")!).render(
                     element={
                       <RequireAdmin>
                         <AdminUsagePage />
+                      </RequireAdmin>
+                    }
+                  />
+                  <Route
+                    path="/admin/links"
+                    element={
+                      <RequireAdmin>
+                        <AdminLinksPage />
                       </RequireAdmin>
                     }
                   />

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -61,6 +61,12 @@ const AdminUsagePage = lazy(() =>
     default: m.AdminUsagePage,
   })),
 );
+const AdminLayout = lazy(() =>
+  import("./routes/admin/layout").then((m) => ({ default: m.AdminLayout })),
+);
+const AdminAuditPage = lazy(() =>
+  import("./routes/admin/audit").then((m) => ({ default: m.AdminAuditPage })),
+);
 const AdminLinksPage = lazy(() =>
   import("./routes/admin/links").then((m) => ({ default: m.AdminLinksPage })),
 );
@@ -118,38 +124,29 @@ createRoot(document.getElementById("root")!).render(
                   <Route path="/billing" element={<BillingPage />} />
                   <Route path="/domains" element={<DomainsPage />} />
                   <Route path="/settings" element={<SettingsPage />} />
+                  {/* One guard for the whole section, and one place for its
+                      sub-navigation. Four separate RequireAdmin routes was
+                      four chances to forget one, and one of them already had
+                      been (#67). */}
                   <Route
                     path="/admin"
                     element={
                       <RequireAdmin>
-                        <AdminUsagePage />
+                        <AdminLayout />
                       </RequireAdmin>
                     }
-                  />
-                  <Route
-                    path="/admin/links"
-                    element={
-                      <RequireAdmin>
-                        <AdminLinksPage />
-                      </RequireAdmin>
-                    }
-                  />
-                  <Route
-                    path="/admin/orgs"
-                    element={
-                      <RequireAdmin>
-                        <AdminOrgsPage />
-                      </RequireAdmin>
-                    }
-                  />
-                  <Route
-                    path="/admin/users"
-                    element={
-                      <RequireAdmin>
-                        <AdminUsersPage />
-                      </RequireAdmin>
-                    }
-                  />
+                  >
+                    {/* Absolute, not relative. React Router accepts either
+                        for a child whose path starts with its parent's, and
+                        the reserved-slug drift guard reads these strings: a
+                        bare "orgs" reads to it as a top-level route and it
+                        rightly asks why "orgs" is not a reserved slug. */}
+                    <Route index element={<AdminUsagePage />} />
+                    <Route path="/admin/links" element={<AdminLinksPage />} />
+                    <Route path="/admin/orgs" element={<AdminOrgsPage />} />
+                    <Route path="/admin/users" element={<AdminUsersPage />} />
+                    <Route path="/admin/audit" element={<AdminAuditPage />} />
+                  </Route>
                 </Route>
 
                 <Route path="*" element={<NotFound />} />

--- a/src/app/routes/admin/audit.tsx
+++ b/src/app/routes/admin/audit.tsx
@@ -71,23 +71,23 @@ export function AdminAuditPage() {
                 sortKey="createdAt"
                 sort={sort}
                 onSort={setSort}
-                className="w-[30%] sm:w-[16%]"
+                className="w-[34%] sm:w-[24%] md:w-[16%]"
               />
               <SortTh
                 label="Who"
                 sortKey="actorEmail"
                 sort={sort}
                 onSort={setSort}
-                className="hidden sm:table-cell sm:w-[22%]"
+                className="hidden sm:table-cell sm:w-[30%] md:w-[22%]"
               />
               <SortTh
                 label="Action"
                 sortKey="action"
                 sort={sort}
                 onSort={setSort}
-                className="w-[70%] sm:w-[18%]"
+                className="w-[66%] sm:w-[46%] md:w-[18%]"
               />
-              <Th className="hidden sm:table-cell sm:w-[44%]">Detail</Th>
+              <Th className="hidden md:table-cell md:w-[44%]">Detail</Th>
             </tr>
           </thead>
           <tbody>
@@ -100,7 +100,7 @@ export function AdminAuditPage() {
                 </Td>
                 <Td className="truncate font-mono text-xs">{entry.action}</Td>
                 <Td
-                  className="hidden truncate text-muted sm:table-cell"
+                  className="hidden truncate text-muted md:table-cell"
                   title={entry.detail ?? entry.targetId}
                 >
                   {entry.detail ?? entry.targetId}

--- a/src/app/routes/admin/audit.tsx
+++ b/src/app/routes/admin/audit.tsx
@@ -66,7 +66,7 @@ export function AdminAuditPage() {
       ) : rows.length === 0 ? (
         <p className="py-6 text-center text-sm text-muted">Nothing recorded yet.</p>
       ) : (
-        <Table fixed>
+        <Table fixed minWidth="min-w-[56rem]">
           <thead>
             <tr>
               <SortTh
@@ -74,23 +74,23 @@ export function AdminAuditPage() {
                 sortKey="createdAt"
                 sort={sort}
                 onSort={setSort}
-                className="w-[34%] sm:w-[24%] md:w-[16%]"
+                className="w-[16%]"
               />
               <SortTh
                 label="Who"
                 sortKey="actorEmail"
                 sort={sort}
                 onSort={setSort}
-                className="hidden sm:table-cell sm:w-[30%] md:w-[22%]"
+                className="w-[22%]"
               />
               <SortTh
                 label="Action"
                 sortKey="action"
                 sort={sort}
                 onSort={setSort}
-                className="w-[66%] sm:w-[46%] md:w-[18%]"
+                className="w-[18%]"
               />
-              <Th className="hidden md:table-cell md:w-[44%]">Detail</Th>
+              <Th className="w-[44%]">Detail</Th>
             </tr>
           </thead>
           <tbody>
@@ -98,14 +98,11 @@ export function AdminAuditPage() {
               <tr key={entry.id}>
                 <Td className="whitespace-nowrap text-muted">{shortDate(entry.createdAt)}</Td>
                 {/* The address may be gone: the log outlives the account. */}
-                <Td className="hidden truncate sm:table-cell">
+                <Td className="truncate">
                   {entry.actorEmail ?? <span className="text-muted">deleted account</span>}
                 </Td>
                 <Td className="truncate font-mono text-xs">{entry.action}</Td>
-                <Td
-                  className="hidden truncate text-muted md:table-cell"
-                  title={entry.detail ?? entry.targetId}
-                >
+                <Td className="truncate text-muted" title={entry.detail ?? entry.targetId}>
                   {entry.detail ?? entry.targetId}
                 </Td>
               </tr>

--- a/src/app/routes/admin/audit.tsx
+++ b/src/app/routes/admin/audit.tsx
@@ -1,0 +1,58 @@
+/**
+ * The admin audit log (#67), on a tab of its own.
+ *
+ * It answers "who did this, and why" about the whole platform, not only about
+ * links, so it does not belong inside the Links screen: bans, comps and org
+ * deletions are recorded here too.
+ */
+import { useAdminAudit } from "../../lib/hooks";
+import { Card, PageHeader, Table, Td, Th } from "../../ui/misc";
+import { AdminTableSkeleton } from "../../components/skeletons";
+import { shortDate } from "../../lib/dates";
+
+export function AdminAuditPage() {
+  const { data, isPending } = useAdminAudit();
+  const rows = data ?? [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Audit log"
+        sub="Every privileged action, newest first. Append-only: entries are never edited or removed."
+      />
+      <Card>
+        {isPending ? (
+          <AdminTableSkeleton />
+        ) : rows.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted">Nothing recorded yet.</p>
+        ) : (
+          <Table fixed>
+            <thead>
+              <tr>
+                <Th className="w-36">When</Th>
+                <Th className="w-56">Who</Th>
+                <Th className="w-44">Action</Th>
+                <Th>Detail</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((entry) => (
+                <tr key={entry.id}>
+                  <Td className="whitespace-nowrap text-muted">{shortDate(entry.createdAt)}</Td>
+                  {/* The address may be gone: the log outlives the account. */}
+                  <Td className="truncate">
+                    {entry.actorEmail ?? <span className="text-muted">deleted account</span>}
+                  </Td>
+                  <Td className="font-mono text-xs whitespace-nowrap">{entry.action}</Td>
+                  <Td className="truncate text-muted" title={entry.detail ?? entry.targetId}>
+                    {entry.detail ?? entry.targetId}
+                  </Td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/app/routes/admin/audit.tsx
+++ b/src/app/routes/admin/audit.tsx
@@ -53,7 +53,10 @@ export function AdminAuditPage() {
 
       <SearchInput
         value={query}
-        onChange={setQuery}
+        onChange={(value) => {
+          setQuery(value);
+          setPage(0);
+        }}
         placeholder="Action, email, or detail"
         label="Search the audit log"
       />

--- a/src/app/routes/admin/audit.tsx
+++ b/src/app/routes/admin/audit.tsx
@@ -5,54 +5,113 @@
  * links, so it does not belong inside the Links screen: bans, comps and org
  * deletions are recorded here too.
  */
+import { useState } from "react";
 import { useAdminAudit } from "../../lib/hooks";
-import { Card, PageHeader, Table, Td, Th } from "../../ui/misc";
+import { PageHeader, Table, Td, Th } from "../../ui/misc";
+import { SortTh } from "../../ui/sort-th";
+import { sortRows } from "../../lib/sort";
 import { AdminTableSkeleton } from "../../components/skeletons";
 import { shortDate } from "../../lib/dates";
+import { SearchInput } from "./search-input";
+import { paginate } from "./util";
+import { Pager } from "../../ui/pagination";
+import type { Sort } from "@/shared/types";
 
 export function AdminAuditPage() {
   const { data, isPending } = useAdminAudit();
-  const rows = data ?? [];
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<Sort>({ key: "createdAt", dir: -1 });
+  const [page, setPage] = useState(0);
+
+  // Filtered here, not on the server: the endpoint is capped, so the rows
+  // are already in hand.
+  const term = query.trim().toLowerCase();
+  const all = sortRows(
+    (data ?? []).filter(
+      (entry) =>
+        !term ||
+        entry.action.toLowerCase().includes(term) ||
+        (entry.actorEmail ?? "").toLowerCase().includes(term) ||
+        (entry.detail ?? "").toLowerCase().includes(term),
+    ),
+    sort,
+    {
+      createdAt: (e) => e.createdAt,
+      actorEmail: (e) => e.actorEmail ?? "",
+      action: (e) => e.action,
+      detail: (e) => e.detail ?? e.targetId,
+    },
+  );
+  const { rows, totalPages, safePage } = paginate(all, page);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-3">
       <PageHeader
         title="Audit log"
         sub="Every privileged action, newest first. Append-only: entries are never edited or removed."
       />
-      <Card>
-        {isPending ? (
-          <AdminTableSkeleton />
-        ) : rows.length === 0 ? (
-          <p className="py-6 text-center text-sm text-muted">Nothing recorded yet.</p>
-        ) : (
-          <Table fixed>
-            <thead>
-              <tr>
-                <Th className="w-36">When</Th>
-                <Th className="w-56">Who</Th>
-                <Th className="w-44">Action</Th>
-                <Th>Detail</Th>
+
+      <SearchInput
+        value={query}
+        onChange={setQuery}
+        placeholder="Action, email, or detail"
+        label="Search the audit log"
+      />
+
+      {isPending ? (
+        <AdminTableSkeleton />
+      ) : rows.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted">Nothing recorded yet.</p>
+      ) : (
+        <Table fixed>
+          <thead>
+            <tr>
+              <SortTh
+                label="When"
+                sortKey="createdAt"
+                sort={sort}
+                onSort={setSort}
+                className="w-[30%] sm:w-[16%]"
+              />
+              <SortTh
+                label="Who"
+                sortKey="actorEmail"
+                sort={sort}
+                onSort={setSort}
+                className="hidden sm:table-cell sm:w-[22%]"
+              />
+              <SortTh
+                label="Action"
+                sortKey="action"
+                sort={sort}
+                onSort={setSort}
+                className="w-[70%] sm:w-[18%]"
+              />
+              <Th className="hidden sm:table-cell sm:w-[44%]">Detail</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((entry) => (
+              <tr key={entry.id}>
+                <Td className="whitespace-nowrap text-muted">{shortDate(entry.createdAt)}</Td>
+                {/* The address may be gone: the log outlives the account. */}
+                <Td className="hidden truncate sm:table-cell">
+                  {entry.actorEmail ?? <span className="text-muted">deleted account</span>}
+                </Td>
+                <Td className="truncate font-mono text-xs">{entry.action}</Td>
+                <Td
+                  className="hidden truncate text-muted sm:table-cell"
+                  title={entry.detail ?? entry.targetId}
+                >
+                  {entry.detail ?? entry.targetId}
+                </Td>
               </tr>
-            </thead>
-            <tbody>
-              {rows.map((entry) => (
-                <tr key={entry.id}>
-                  <Td className="whitespace-nowrap text-muted">{shortDate(entry.createdAt)}</Td>
-                  {/* The address may be gone: the log outlives the account. */}
-                  <Td className="truncate">
-                    {entry.actorEmail ?? <span className="text-muted">deleted account</span>}
-                  </Td>
-                  <Td className="font-mono text-xs whitespace-nowrap">{entry.action}</Td>
-                  <Td className="truncate text-muted" title={entry.detail ?? entry.targetId}>
-                    {entry.detail ?? entry.targetId}
-                  </Td>
-                </tr>
-              ))}
-            </tbody>
-          </Table>
-        )}
-      </Card>
+            ))}
+          </tbody>
+        </Table>
+      )}
+
+      <Pager page={safePage} totalPages={totalPages} onPageChange={setPage} />
     </div>
   );
 }

--- a/src/app/routes/admin/layout.tsx
+++ b/src/app/routes/admin/layout.tsx
@@ -1,0 +1,51 @@
+/**
+ * The shell every platform-admin page sits in.
+ *
+ * The sidebar carries one "Platform" entry, not four. Four put "Links" in the
+ * sidebar twice, once for the current organization's links and once for every
+ * link on the instance, which is the kind of collision that makes somebody
+ * click the wrong one during an incident. The four sections live here instead,
+ * as tabs, where their labels are unambiguous because everything around them
+ * is platform-wide.
+ */
+import { NavLink, Outlet } from "react-router";
+import { Building2, Globe, Link2, ScrollText, UserCog } from "lucide-react";
+import { cn } from "../../ui/cn";
+
+const TABS = [
+  { to: "/admin", end: true, icon: Globe, label: "Usage" },
+  { to: "/admin/links", end: false, icon: Link2, label: "Links" },
+  { to: "/admin/orgs", end: false, icon: Building2, label: "Organizations" },
+  { to: "/admin/users", end: false, icon: UserCog, label: "Users" },
+  { to: "/admin/audit", end: false, icon: ScrollText, label: "Audit log" },
+];
+
+export function AdminLayout() {
+  return (
+    <div className="flex flex-col gap-5">
+      <nav
+        aria-label="Platform sections"
+        className="-mx-1 flex gap-1 overflow-x-auto border-b border-border px-1 pb-px"
+      >
+        {TABS.map(({ to, end, icon: Icon, label }) => (
+          <NavLink
+            key={to}
+            to={to}
+            end={end}
+            className={({ isActive }) =>
+              cn(
+                "flex items-center gap-1.5 border-b-2 px-3 py-2 text-sm whitespace-nowrap transition-colors",
+                isActive
+                  ? "border-accent text-text"
+                  : "border-transparent text-muted hover:text-text",
+              )
+            }
+          >
+            <Icon size={15} /> {label}
+          </NavLink>
+        ))}
+      </nav>
+      <Outlet />
+    </div>
+  );
+}

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -423,7 +423,7 @@ function AnonymousLinks() {
                   <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
                 </Td>
                 <Td className="text-muted" title="Anonymous links record no clicks">
-                  &mdash;
+                  none
                 </Td>
                 <Td className="whitespace-nowrap text-muted">{shortDate(link.createdAt)}</Td>
                 <Td className="whitespace-nowrap text-muted">{shortDate(link.expiresAt)}</Td>

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -346,63 +346,67 @@ function AnonymousLinks() {
 
   return (
     <div className="flex flex-col gap-3">
-      <p className="text-xs text-muted">
-        Made on the landing page without an account. They expire 24 hours after creation and
-        disappear on their own; delete one to stop it sooner.
-      </p>
-      <SearchInput
-        value={query}
-        onChange={(value) => {
-          setQuery(value);
-          setPage(0);
-        }}
-        placeholder="Slug or destination"
-        label="Search anonymous links"
-      />
+      <div className="flex flex-wrap items-center gap-2">
+        <SearchInput
+          value={query}
+          onChange={(value) => {
+            setQuery(value);
+            setPage(0);
+          }}
+          placeholder="Slug or destination"
+          label="Search anonymous links"
+        />
+      </div>
       {isPending ? (
         <AdminTableSkeleton />
       ) : rows.length === 0 ? (
         <p className="py-6 text-center text-sm text-muted">Nothing here.</p>
       ) : (
-        <Table fixed minWidth="min-w-[48rem]">
+        // Same columns as the owned table, in the same order, so moving
+        // between the two tabs does not mean re-reading the header row. An
+        // anonymous link has no organization and records no clicks; those
+        // cells say so rather than being left out.
+        <Table fixed minWidth="min-w-[64rem]">
           <thead>
             <tr>
               <SortTh
-                label="Slug"
+                label="Link"
                 sortKey="slug"
                 sort={sort}
                 onSort={setSort}
-                className="w-[18%]"
+                className="w-[15%]"
               />
               <SortTh
                 label="Destination"
                 sortKey="destination"
                 sort={sort}
                 onSort={setSort}
-                className="w-[38%]"
+                className="w-[25%]"
               />
+              <Th className="w-[12%]">Organization</Th>
               <SortTh
                 label="Risk"
                 sortKey="riskScore"
                 sort={sort}
                 onSort={setSort}
-                className="w-[14%]"
+                className="w-[12%]"
               />
+              <Th className="w-[7%]">Clicks</Th>
               <SortTh
                 label="Created"
                 sortKey="createdAt"
                 sort={sort}
                 onSort={setSort}
-                className="w-[14%]"
+                className="w-[12%]"
               />
               <SortTh
                 label="Expires"
                 sortKey="expiresAt"
                 sort={sort}
                 onSort={setSort}
-                className="w-[14%]"
+                className="w-[12%]"
               />
-              <Th className="w-[12%]" />
+              <Th className="w-[8%]" />
             </tr>
           </thead>
           <tbody>
@@ -412,17 +416,39 @@ function AnonymousLinks() {
                 <Td className="truncate text-muted" title={link.destination}>
                   {link.destination}
                 </Td>
+                {/* Nobody owns it, and no click is recorded against it: both
+                    are the product boundary, not missing data. */}
+                <Td className="text-muted">none</Td>
                 <Td>
                   <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
+                </Td>
+                <Td className="text-muted" title="Anonymous links record no clicks">
+                  &mdash;
                 </Td>
                 <Td className="whitespace-nowrap text-muted">{shortDate(link.createdAt)}</Td>
                 <Td className="whitespace-nowrap text-muted">{shortDate(link.expiresAt)}</Td>
                 <Td>
-                  <div className="flex justify-end">
-                    <Button size="sm" variant="danger" onClick={() => setDeleting(link)}>
-                      <Trash2 size={13} /> Delete
-                    </Button>
-                  </div>
+                  <Menu
+                    align="end"
+                    label={`Actions for ${link.slug}`}
+                    trigger={
+                      <div className="flex justify-end">
+                        <span className="rounded p-1.5 text-muted transition-transform duration-150 active:scale-[0.96] hover:bg-surface-2 hover:text-text">
+                          <Ellipsis size={15} />
+                        </span>
+                      </div>
+                    }
+                  >
+                    <MenuItem
+                      onClick={() => window.open(link.destination, "_blank", "noopener,noreferrer")}
+                    >
+                      <ExternalLink size={14} /> Open destination
+                    </MenuItem>
+                    <MenuSeparator />
+                    <MenuItem className="text-danger" onClick={() => setDeleting(link)}>
+                      <Trash2 size={14} /> Delete link
+                    </MenuItem>
+                  </Menu>
                 </Td>
               </tr>
             ))}
@@ -565,7 +591,7 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
             setQuery(value);
             setPage(0);
           }}
-          placeholder="Slug or destination, e.g. phishy.example"
+          placeholder="Slug or destination"
           label="Search links"
         />
         {orgFilter && (

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -13,7 +13,7 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Ban, ExternalLink, Trash2, Undo2 } from "lucide-react";
-import { useAdminAnonLinks, useAdminAudit, useAdminLinks } from "../../lib/hooks";
+import { useAdminAnonLinks, useAdminLinks } from "../../lib/hooks";
 import { api } from "../../lib/api";
 import { ADMIN_LINK_SORTS, type AdminLinkRow, type AdminLinkSort } from "@/shared/types";
 import { Badge, Card, PageHeader, Table, Td, Th } from "../../ui/misc";
@@ -25,6 +25,7 @@ import { useToast } from "../../ui/toast";
 import { withErrorToast } from "../../lib/mutation-toast";
 import { shortDate } from "../../lib/dates";
 import { SearchInput } from "./search-input";
+import { cn } from "../../ui/cn";
 
 const SORT_LABELS: Record<AdminLinkSort, string> = {
   created: "Newest",
@@ -115,7 +116,7 @@ function LinkRow({
   return (
     <tr className={link.suspendedAt ? "opacity-60" : undefined}>
       <Td>
-        <span className="font-mono text-xs font-bold">
+        <span className="block truncate font-mono text-xs font-bold">
           {link.domain ?? ""}/{link.slug}
         </span>
         {link.suspendedAt && (
@@ -124,15 +125,15 @@ function LinkRow({
           </span>
         )}
       </Td>
-      <Td className="max-w-64 truncate text-muted" title={link.destination}>
+      <Td className="truncate text-muted" title={link.destination}>
         {link.destination}
       </Td>
-      <Td>{link.orgName}</Td>
+      <Td className="truncate">{link.orgName}</Td>
       <Td>
         <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
       </Td>
       <Td className="tnum">{link.clicks}</Td>
-      <Td className="text-muted">{shortDate(link.createdAt)}</Td>
+      <Td className="whitespace-nowrap text-muted">{shortDate(link.createdAt)}</Td>
       <Td>
         <LinkActions link={link} onSuspend={onSuspend} onRestore={onRestore} />
       </Td>
@@ -197,16 +198,19 @@ function LinksTable({
     return <p className="py-6 text-center text-sm text-muted">No links match that search.</p>;
 
   return (
-    <Table>
+    // Fixed, with widths that add to 100%. In an auto-layout table a long
+    // destination sets the column width and pushes everything past the card,
+    // and `max-w` on the cell is ignored.
+    <Table fixed>
       <thead>
         <tr>
-          <Th>Link</Th>
-          <Th>Destination</Th>
-          <Th>Organization</Th>
-          <Th>Risk</Th>
-          <Th>Clicks</Th>
-          <Th>Created</Th>
-          <Th />
+          <Th className="w-[14%]">Link</Th>
+          <Th className="w-[23%]">Destination</Th>
+          <Th className="w-[14%]">Organization</Th>
+          <Th className="w-[10%]">Risk</Th>
+          <Th className="w-[7%]">Clicks</Th>
+          <Th className="w-[12%]">Created</Th>
+          <Th className="w-[20%]" />
         </tr>
       </thead>
       <tbody>
@@ -274,27 +278,27 @@ function AnonymousLinks() {
       loading={isPending}
       empty={rows.length === 0}
     >
-      <Table>
+      <Table fixed>
         <thead>
           <tr>
-            <Th>Slug</Th>
-            <Th>Destination</Th>
-            <Th>Risk</Th>
-            <Th>Expires</Th>
-            <Th />
+            <Th className="w-[18%]">Slug</Th>
+            <Th className="w-[38%]">Destination</Th>
+            <Th className="w-[14%]">Risk</Th>
+            <Th className="w-[14%]">Expires</Th>
+            <Th className="w-[16%]" />
           </tr>
         </thead>
         <tbody>
           {rows.map((link) => (
             <tr key={link.id}>
-              <Td className="font-mono text-xs font-bold">/{link.slug}</Td>
-              <Td className="max-w-64 truncate text-muted" title={link.destination}>
+              <Td className="truncate font-mono text-xs font-bold">/{link.slug}</Td>
+              <Td className="truncate text-muted" title={link.destination}>
                 {link.destination}
               </Td>
               <Td>
                 <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
               </Td>
-              <Td className="text-muted">{shortDate(link.expiresAt)}</Td>
+              <Td className="whitespace-nowrap text-muted">{shortDate(link.expiresAt)}</Td>
               <Td>
                 <div className="flex justify-end">
                   <Button
@@ -315,47 +319,78 @@ function AnonymousLinks() {
   );
 }
 
-/** The audit trail, so a suspension is answerable later. */
-function AuditLog() {
-  const { data, isPending } = useAdminAudit();
-  const rows = data ?? [];
+const VIEWS = [
+  { id: "links", label: "Owned links" },
+  { id: "anonymous", label: "Anonymous" },
+] as const;
+type View = (typeof VIEWS)[number]["id"];
+
+/** Two sections, switched rather than stacked. Stacked, the anonymous list
+ * sat below up to 200 link rows, which is the same as not being there. */
+function ViewSwitch({ view, onChange }: { view: View; onChange: (v: View) => void }) {
+  return (
+    <div className="flex w-fit gap-1 rounded-lg bg-surface-2 p-1">
+      {VIEWS.map(({ id, label }) => (
+        <button
+          key={id}
+          type="button"
+          onClick={() => onChange(id)}
+          className={cn(
+            "cursor-pointer rounded-md px-3 py-1.5 text-xs transition-colors",
+            view === id ? "bg-surface font-bold text-text shadow-sm" : "text-muted hover:text-text",
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** The cross-org list with its own controls. Split out so the page itself is
+ * just the switch and the three things it switches between. */
+function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<AdminLinkSort>("created");
+  const [suspendedOnly, setSuspendedOnly] = useState(false);
+  const { data, isPending } = useAdminLinks({ q: query, sort, suspended: suspendedOnly });
 
   return (
-    <AdminSection label="Recent admin actions" loading={isPending} empty={rows.length === 0}>
-      <Table>
-        <thead>
-          <tr>
-            <Th>When</Th>
-            <Th>Who</Th>
-            <Th>Action</Th>
-            <Th>Target</Th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((entry) => (
-            <tr key={entry.id}>
-              <Td className="text-muted">{shortDate(entry.createdAt)}</Td>
-              {/* The address may be gone: the log outlives the account. */}
-              <Td>{entry.actorEmail ?? <span className="text-muted">deleted account</span>}</Td>
-              <Td className="font-mono text-xs">{entry.action}</Td>
-              <Td className="max-w-64 truncate text-muted" title={entry.detail ?? entry.targetId}>
-                {entry.detail ?? entry.targetId}
-              </Td>
-            </tr>
+    <Card>
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <SearchInput
+          value={query}
+          onChange={setQuery}
+          placeholder="Slug or destination, e.g. phishy.example"
+          label="Search links"
+        />
+        <Select
+          value={sort}
+          onChange={(event) => setSort(event.target.value as AdminLinkSort)}
+          wrapperClass="w-44"
+        >
+          {ADMIN_LINK_SORTS.map((value) => (
+            <option key={value} value={value}>
+              {SORT_LABELS[value]}
+            </option>
           ))}
-        </tbody>
-      </Table>
-    </AdminSection>
+        </Select>
+        <Button
+          size="sm"
+          variant={suspendedOnly ? "primary" : "outline"}
+          onClick={() => setSuspendedOnly((on) => !on)}
+        >
+          Suspended only
+        </Button>
+      </div>
+      {isPending ? <AdminTableSkeleton /> : <LinksTable rows={data ?? []} onSuspend={onSuspend} />}
+    </Card>
   );
 }
 
 export function AdminLinksPage() {
-  const [query, setQuery] = useState("");
-  const [sort, setSort] = useState<AdminLinkSort>("created");
-  const [suspendedOnly, setSuspendedOnly] = useState(false);
+  const [view, setView] = useState<View>("links");
   const [suspending, setSuspending] = useState<AdminLinkRow | null>(null);
-
-  const { data, isPending } = useAdminLinks({ q: query, sort, suspended: suspendedOnly });
 
   return (
     <div className="flex flex-col gap-4">
@@ -364,42 +399,10 @@ export function AdminLinksPage() {
         sub="Every link across every organization. Search by slug or destination."
       />
 
-      <Card>
-        <div className="mb-3 flex flex-wrap items-center gap-2">
-          <SearchInput
-            value={query}
-            onChange={setQuery}
-            placeholder="Slug or destination, e.g. phishy.example"
-            label="Search links"
-          />
-          <Select
-            value={sort}
-            onChange={(event) => setSort(event.target.value as AdminLinkSort)}
-            wrapperClass="w-44"
-          >
-            {ADMIN_LINK_SORTS.map((value) => (
-              <option key={value} value={value}>
-                {SORT_LABELS[value]}
-              </option>
-            ))}
-          </Select>
-          <Button
-            size="sm"
-            variant={suspendedOnly ? "primary" : "outline"}
-            onClick={() => setSuspendedOnly((on) => !on)}
-          >
-            Suspended only
-          </Button>
-        </div>
-        {isPending ? (
-          <AdminTableSkeleton />
-        ) : (
-          <LinksTable rows={data ?? []} onSuspend={setSuspending} />
-        )}
-      </Card>
+      <ViewSwitch view={view} onChange={setView} />
 
-      <AnonymousLinks />
-      <AuditLog />
+      {view === "links" && <OwnedLinks onSuspend={setSuspending} />}
+      {view === "anonymous" && <AnonymousLinks />}
 
       <SuspendDialog link={suspending} onClose={() => setSuspending(null)} />
     </div>

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -13,14 +13,16 @@
 import { useState } from "react";
 import { Link } from "react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Ban, ExternalLink, Trash2, Undo2, X } from "lucide-react";
+import { Ban, Ellipsis, ExternalLink, Trash2, Undo2 } from "lucide-react";
 import { useAdminAnonLinks, useAdminLinks } from "../../lib/hooks";
 import { api } from "../../lib/api";
-import type { AdminLinkRow, Sort } from "@/shared/types";
+import type { AdminAnonLinkRow, AdminLinkRow, Sort } from "@/shared/types";
 import { Badge, PageHeader, Table, Td, Th } from "../../ui/misc";
 import { Button } from "../../ui/button";
 import { Field, Input } from "../../ui/field";
 import { Dialog } from "../../ui/dialog";
+import { ConfirmDialog } from "../../ui/confirm-dialog";
+import { Menu, MenuItem, MenuSeparator } from "../../ui/menu";
 import { AdminTableSkeleton } from "../../components/skeletons";
 import { useToast } from "../../ui/toast";
 import { withErrorToast } from "../../lib/mutation-toast";
@@ -108,10 +110,12 @@ function LinkRow({
   link,
   onSuspend,
   onRestore,
+  onDelete,
 }: {
   link: AdminLinkRow;
   onSuspend: (l: AdminLinkRow) => void;
-  onRestore: { mutate: (id: string) => void; isPending: boolean };
+  onRestore: (l: AdminLinkRow) => void;
+  onDelete: (l: AdminLinkRow) => void;
 }) {
   return (
     <tr className={link.suspendedAt ? "opacity-60" : undefined}>
@@ -133,82 +137,88 @@ function LinkRow({
             after "who owns this". */}
         <Link
           to={`/admin/links?org=${encodeURIComponent(link.orgId)}`}
-          className="hover:text-accent hover:underline"
+          className="block truncate hover:text-accent hover:underline"
         >
           {link.orgName}
         </Link>
       </Td>
-      <Td className="hidden sm:table-cell">
+      <Td className="hidden md:table-cell">
         <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
       </Td>
-      <Td className="hidden tnum sm:table-cell">{link.clicks}</Td>
-      <Td className="hidden whitespace-nowrap text-muted sm:table-cell">
+      <Td className="hidden tnum lg:table-cell">{link.clicks}</Td>
+      <Td className="hidden whitespace-nowrap text-muted lg:table-cell">
         {shortDate(link.createdAt)}
       </Td>
       <Td>
-        <LinkActions link={link} onSuspend={onSuspend} onRestore={onRestore} />
+        <LinkActions link={link} onSuspend={onSuspend} onRestore={onRestore} onDelete={onDelete} />
       </Td>
     </tr>
   );
 }
 
+/**
+ * Suspend, restore, delete. A menu rather than a row of buttons, matching
+ * every other table here, and because a destructive action sitting in the
+ * open next to a date is one mis-click from an outage.
+ */
 function LinkActions({
   link,
   onSuspend,
   onRestore,
+  onDelete,
 }: {
   link: AdminLinkRow;
   onSuspend: (l: AdminLinkRow) => void;
-  onRestore: { mutate: (id: string) => void; isPending: boolean };
+  onRestore: (l: AdminLinkRow) => void;
+  onDelete: (l: AdminLinkRow) => void;
 }) {
   return (
-    <div className="flex justify-end gap-1.5">
-      <a href={link.destination} target="_blank" rel="noreferrer">
-        <Button size="sm" variant="ghost" aria-label="Open destination">
-          <ExternalLink size={13} />
-        </Button>
-      </a>
+    <Menu
+      align="end"
+      label={`Actions for ${link.slug}`}
+      trigger={
+        <div className="flex justify-end">
+          <span className="rounded p-1.5 text-muted transition-transform duration-150 active:scale-[0.96] hover:bg-surface-2 hover:text-text">
+            <Ellipsis size={15} />
+          </span>
+        </div>
+      }
+    >
+      <MenuItem onClick={() => window.open(link.destination, "_blank", "noopener,noreferrer")}>
+        <ExternalLink size={14} /> Open destination
+      </MenuItem>
+      <MenuSeparator />
       {link.suspendedAt ? (
-        <Button
-          size="sm"
-          variant="outline"
-          disabled={onRestore.isPending}
-          onClick={() => onRestore.mutate(link.id)}
-        >
-          <Undo2 size={13} /> Restore
-        </Button>
+        <MenuItem onClick={() => onRestore(link)}>
+          <Undo2 size={14} /> Restore link
+        </MenuItem>
       ) : (
-        <Button size="sm" variant="danger" onClick={() => onSuspend(link)}>
-          <Ban size={13} /> Suspend
-        </Button>
+        <MenuItem className="text-danger" onClick={() => onSuspend(link)}>
+          <Ban size={14} /> Suspend link
+        </MenuItem>
       )}
-    </div>
+      <MenuItem className="text-danger" onClick={() => onDelete(link)}>
+        <Trash2 size={14} /> Delete link
+      </MenuItem>
+    </Menu>
   );
 }
 
 function LinksTable({
   rows,
-  onSuspend,
   sort,
   onSort,
+  onSuspend,
+  onRestore,
+  onDelete,
 }: {
   rows: AdminLinkRow[];
-  onSuspend: (l: AdminLinkRow) => void;
   sort: Sort;
   onSort: (s: Sort) => void;
+  onSuspend: (l: AdminLinkRow) => void;
+  onRestore: (l: AdminLinkRow) => void;
+  onDelete: (l: AdminLinkRow) => void;
 }) {
-  const toast = useToast();
-  const qc = useQueryClient();
-  const unsuspend = useMutation({
-    mutationFn: (id: string) => api(`/admin/links/${id}/unsuspend`, { method: "POST" }),
-    onSuccess: async () => {
-      await qc.invalidateQueries({ queryKey: ["admin", "links"] });
-      await qc.invalidateQueries({ queryKey: ["admin", "audit"] });
-      toast("Link restored.");
-    },
-    onError: withErrorToast(toast),
-  });
-
   if (rows.length === 0)
     return <p className="py-6 text-center text-sm text-muted">No links match that search.</p>;
 
@@ -216,6 +226,9 @@ function LinksTable({
     // Fixed, with widths that add to 100%. In an auto-layout table a long
     // destination sets the column width and pushes everything past the card,
     // and `max-w` on the cell is ignored.
+    //
+    // Columns drop one breakpoint at a time rather than all at once, so the
+    // table narrows smoothly instead of jumping between two layouts.
     <Table fixed>
       <thead>
         <tr>
@@ -224,53 +237,55 @@ function LinksTable({
             sortKey="slug"
             sort={sort}
             onSort={onSort}
-            className="w-[26%] sm:w-[14%]"
+            className="w-[34%] sm:w-[24%] md:w-[18%] lg:w-[14%]"
           />
-          {/* Hidden on a phone: seven columns in 390px squeezes every one of
-              them into uselessness. The destination and the organization are
-              the two an abuse report is read against, so they are the ones
-              that survive the cut. */}
           <SortTh
             label="Destination"
             sortKey="destination"
             sort={sort}
             onSort={onSort}
-            className="w-[34%] sm:w-[23%]"
+            className="w-[50%] sm:w-[38%] md:w-[30%] lg:w-[23%]"
           />
           <SortTh
             label="Organization"
             sortKey="orgName"
             sort={sort}
             onSort={onSort}
-            className="hidden w-[14%] sm:table-cell"
+            className="hidden sm:table-cell sm:w-[22%] md:w-[18%] lg:w-[14%]"
           />
           <SortTh
             label="Risk"
             sortKey="riskScore"
             sort={sort}
             onSort={onSort}
-            className="hidden w-[10%] sm:table-cell"
+            className="hidden md:table-cell md:w-[18%] lg:w-[10%]"
           />
           <SortTh
             label="Clicks"
             sortKey="clicks"
             sort={sort}
             onSort={onSort}
-            className="hidden w-[7%] sm:table-cell"
+            className="hidden lg:table-cell lg:w-[7%]"
           />
           <SortTh
             label="Created"
             sortKey="createdAt"
             sort={sort}
             onSort={onSort}
-            className="hidden w-[12%] sm:table-cell"
+            className="hidden lg:table-cell lg:w-[12%]"
           />
-          <Th className="w-[40%] sm:w-[20%]" />
+          <Th className="w-[16%] sm:w-[16%] md:w-[16%] lg:w-[20%]" />
         </tr>
       </thead>
       <tbody>
         {rows.map((link) => (
-          <LinkRow key={link.id} link={link} onSuspend={onSuspend} onRestore={unsuspend} />
+          <LinkRow
+            key={link.id}
+            link={link}
+            onSuspend={onSuspend}
+            onRestore={onRestore}
+            onDelete={onDelete}
+          />
         ))}
       </tbody>
     </Table>
@@ -284,6 +299,7 @@ function AnonymousLinks() {
   const [query, setQuery] = useState("");
   const [sort, setSort] = useState<Sort>({ key: "createdAt", dir: -1 });
   const [page, setPage] = useState(0);
+  const [deleting, setDeleting] = useState<AdminAnonLinkRow | null>(null);
   const toast = useToast();
   const qc = useQueryClient();
   const remove = useMutation({
@@ -291,6 +307,7 @@ function AnonymousLinks() {
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ["admin", "anon-links"] });
       toast("Anonymous link deleted.");
+      setDeleting(null);
     },
     onError: withErrorToast(toast),
   });
@@ -341,30 +358,30 @@ function AnonymousLinks() {
                 sortKey="slug"
                 sort={sort}
                 onSort={setSort}
-                className="w-[30%] sm:w-[18%]"
+                className="w-[34%] sm:w-[24%] md:w-[18%]"
               />
               <SortTh
                 label="Destination"
                 sortKey="destination"
                 sort={sort}
                 onSort={setSort}
-                className="w-[40%] sm:w-[38%]"
+                className="w-[50%] sm:w-[44%] md:w-[38%]"
               />
               <SortTh
                 label="Risk"
                 sortKey="riskScore"
                 sort={sort}
                 onSort={setSort}
-                className="hidden w-[14%] sm:table-cell"
+                className="hidden sm:table-cell sm:w-[16%] md:w-[14%]"
               />
               <SortTh
                 label="Expires"
                 sortKey="expiresAt"
                 sort={sort}
                 onSort={setSort}
-                className="hidden w-[14%] sm:table-cell"
+                className="hidden md:table-cell md:w-[14%]"
               />
-              <Th className="w-[30%] sm:w-[16%]" />
+              <Th className="w-[16%]" />
             </tr>
           </thead>
           <tbody>
@@ -377,17 +394,12 @@ function AnonymousLinks() {
                 <Td className="hidden sm:table-cell">
                   <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
                 </Td>
-                <Td className="hidden whitespace-nowrap text-muted sm:table-cell">
+                <Td className="hidden whitespace-nowrap text-muted md:table-cell">
                   {shortDate(link.expiresAt)}
                 </Td>
                 <Td>
                   <div className="flex justify-end">
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      disabled={remove.isPending}
-                      onClick={() => remove.mutate(link.id)}
-                    >
+                    <Button size="sm" variant="danger" onClick={() => setDeleting(link)}>
                       <Trash2 size={13} /> Delete
                     </Button>
                   </div>
@@ -398,6 +410,21 @@ function AnonymousLinks() {
         </Table>
       )}
       <Pager page={safePage} totalPages={totalPages} onPageChange={setPage} />
+
+      <ConfirmDialog
+        title="Delete this link?"
+        open={!!deleting}
+        onClose={() => setDeleting(null)}
+        onConfirm={() => deleting && remove.mutate(deleting.id)}
+        confirmLabel="Delete link"
+        danger
+        pending={remove.isPending}
+      >
+        <p className="text-sm text-muted">
+          <span className="font-mono font-bold text-text">/{deleting?.slug}</span> stops redirecting
+          at once. It would have expired on its own within 24 hours.
+        </p>
+      </ConfirmDialog>
     </div>
   );
 }
@@ -437,9 +464,37 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
   const orgFilter = params.get("org") ?? "";
   const [query, setQuery] = useState("");
   const [sort, setSort] = useState<Sort>({ key: "createdAt", dir: -1 });
-  const [suspendedOnly, setSuspendedOnly] = useState(false);
   const [page, setPage] = useState(0);
-  const { data, isPending } = useAdminLinks({ q: query, suspended: suspendedOnly });
+  const [restoring, setRestoring] = useState<AdminLinkRow | null>(null);
+  const [deleting, setDeleting] = useState<AdminLinkRow | null>(null);
+  const toast = useToast();
+  const qc = useQueryClient();
+  const { data, isPending } = useAdminLinks({ q: query, suspended: false });
+
+  const refresh = async () => {
+    await qc.invalidateQueries({ queryKey: ["admin", "links"] });
+    await qc.invalidateQueries({ queryKey: ["admin", "audit"] });
+  };
+
+  const restore = useMutation({
+    mutationFn: (id: string) => api(`/admin/links/${id}/unsuspend`, { method: "POST" }),
+    onSuccess: async () => {
+      await refresh();
+      toast("Link restored.");
+      setRestoring(null);
+    },
+    onError: withErrorToast(toast),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => api(`/admin/links/${id}`, { method: "DELETE" }),
+    onSuccess: async () => {
+      await refresh();
+      toast("Link deleted.");
+      setDeleting(null);
+    },
+    onError: withErrorToast(toast),
+  });
 
   const all = sortRows(
     (data ?? []).filter((link) => !orgFilter || link.orgId === orgFilter),
@@ -466,32 +521,63 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
           placeholder="Slug or destination, e.g. phishy.example"
           label="Search links"
         />
-        <Button
-          size="sm"
-          variant={suspendedOnly ? "primary" : "outline"}
-          onClick={() => setSuspendedOnly((on) => !on)}
-        >
-          Suspended only
-        </Button>
         {orgFilter && (
           <Button
             size="sm"
-            variant="ghost"
+            variant="outline"
             onClick={() => {
               params.delete("org");
               setParams(params, { replace: true });
             }}
           >
-            <X size={13} /> {all[0]?.orgName ?? "Organization"} only
+            Clear {all[0]?.orgName ?? "organization"} filter
           </Button>
         )}
       </div>
+
       {isPending ? (
         <AdminTableSkeleton />
       ) : (
-        <LinksTable rows={rows} onSuspend={onSuspend} sort={sort} onSort={setSort} />
+        <LinksTable
+          rows={rows}
+          sort={sort}
+          onSort={setSort}
+          onSuspend={onSuspend}
+          onRestore={setRestoring}
+          onDelete={setDeleting}
+        />
       )}
       <Pager page={safePage} totalPages={totalPages} onPageChange={setPage} />
+
+      <ConfirmDialog
+        title="Restore this link?"
+        open={!!restoring}
+        onClose={() => setRestoring(null)}
+        onConfirm={() => restoring && restore.mutate(restoring.id)}
+        confirmLabel="Restore link"
+        pending={restore.isPending}
+      >
+        <p className="text-sm text-muted">
+          <span className="font-mono font-bold text-text">/{restoring?.slug}</span> starts
+          redirecting again immediately.
+        </p>
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        title="Delete this link?"
+        open={!!deleting}
+        onClose={() => setDeleting(null)}
+        onConfirm={() => deleting && remove.mutate(deleting.id)}
+        confirmLabel="Delete link"
+        danger
+        pending={remove.isPending}
+      >
+        <p className="text-sm text-muted">
+          <span className="font-mono font-bold text-text">/{deleting?.slug}</span> and its clicks
+          are removed for good. Suspending stops a link without losing the evidence, and can be
+          undone; this cannot.
+        </p>
+      </ConfirmDialog>
     </div>
   );
 }

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -1,0 +1,407 @@
+/**
+ * Cross-org link moderation (#67).
+ *
+ * The screen somebody opens with an abuse report in front of them. It is
+ * built around that: one search box that takes either a slug or a destination,
+ * because those are the two things a report contains, and one action that
+ * stops a link without touching anything else the organization owns.
+ *
+ * Anonymous links (#96) are listed here too rather than in a tab of their
+ * own. A report naming a slug does not know which table it came from, and
+ * two places to search is one place too many at 2am.
+ */
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Ban, ExternalLink, Trash2, Undo2 } from "lucide-react";
+import { useAdminAnonLinks, useAdminAudit, useAdminLinks } from "../../lib/hooks";
+import { api } from "../../lib/api";
+import { ADMIN_LINK_SORTS, type AdminLinkRow, type AdminLinkSort } from "@/shared/types";
+import { Badge, Card, PageHeader, Table, Td, Th } from "../../ui/misc";
+import { Button } from "../../ui/button";
+import { Field, Input, Select } from "../../ui/field";
+import { Dialog } from "../../ui/dialog";
+import { AdminTableSkeleton } from "../../components/skeletons";
+import { useToast } from "../../ui/toast";
+import { withErrorToast } from "../../lib/mutation-toast";
+import { shortDate } from "../../lib/dates";
+import { SearchInput } from "./search-input";
+
+const SORT_LABELS: Record<AdminLinkSort, string> = {
+  created: "Newest",
+  clicks: "Most clicked",
+  risk: "Riskiest first",
+};
+
+/**
+ * Null is not zero. An unscored link is one nobody has looked at, and showing
+ * it as "clean" is how a provider outage turns into a table of green ticks.
+ */
+function RiskBadge({ score, reasons }: { score: number | null; reasons: string[] }) {
+  if (score === null) return <Badge color="muted">unscored</Badge>;
+  if (score >= 100) return <Badge color="pink">{reasons.join(", ") || "blocked"}</Badge>;
+  return <Badge color="mint">clean</Badge>;
+}
+
+function SuspendDialog({ link, onClose }: { link: AdminLinkRow | null; onClose: () => void }) {
+  const toast = useToast();
+  const qc = useQueryClient();
+  const [reason, setReason] = useState("");
+
+  const suspend = useMutation({
+    mutationFn: (input: { id: string; reason: string }) =>
+      api(`/admin/links/${input.id}/suspend`, {
+        method: "POST",
+        body: { reason: input.reason },
+      }),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ["admin", "links"] });
+      await qc.invalidateQueries({ queryKey: ["admin", "audit"] });
+      toast("Link suspended. It stops redirecting immediately.");
+      setReason("");
+      onClose();
+    },
+    onError: withErrorToast(toast),
+  });
+
+  return (
+    <Dialog open={!!link} onOpenChange={(open) => !open && onClose()} title="Suspend this link">
+      {link && (
+        <div className="flex flex-col gap-4">
+          <div className="rounded-lg bg-surface-2 p-3 text-xs">
+            <p className="font-mono font-bold">/{link.slug}</p>
+            <p className="mt-1 break-all text-muted">{link.destination}</p>
+          </div>
+          <p className="text-xs text-muted">
+            The redirect stops at once and stays stopped, including after the owner edits the link.
+            Nothing is deleted: the link and its clicks survive, and you can restore it.
+          </p>
+          <Field label="Reason">
+            <Input
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              placeholder="Phishing report, ticket 412"
+              autoFocus
+            />
+          </Field>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              disabled={!reason.trim() || suspend.isPending}
+              onClick={() => suspend.mutate({ id: link.id, reason: reason.trim() })}
+            >
+              Suspend link
+            </Button>
+          </div>
+        </div>
+      )}
+    </Dialog>
+  );
+}
+
+/** One row. Its own component because a table row with two conditional
+ * actions and a truncating cell is a component, not an expression. */
+function LinkRow({
+  link,
+  onSuspend,
+  onRestore,
+}: {
+  link: AdminLinkRow;
+  onSuspend: (l: AdminLinkRow) => void;
+  onRestore: { mutate: (id: string) => void; isPending: boolean };
+}) {
+  return (
+    <tr className={link.suspendedAt ? "opacity-60" : undefined}>
+      <Td>
+        <span className="font-mono text-xs font-bold">
+          {link.domain ?? ""}/{link.slug}
+        </span>
+        {link.suspendedAt && (
+          <span className="mt-1 block">
+            <Badge color="pink">suspended</Badge>
+          </span>
+        )}
+      </Td>
+      <Td className="max-w-64 truncate text-muted" title={link.destination}>
+        {link.destination}
+      </Td>
+      <Td>{link.orgName}</Td>
+      <Td>
+        <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
+      </Td>
+      <Td className="tnum">{link.clicks}</Td>
+      <Td className="text-muted">{shortDate(link.createdAt)}</Td>
+      <Td>
+        <LinkActions link={link} onSuspend={onSuspend} onRestore={onRestore} />
+      </Td>
+    </tr>
+  );
+}
+
+function LinkActions({
+  link,
+  onSuspend,
+  onRestore,
+}: {
+  link: AdminLinkRow;
+  onSuspend: (l: AdminLinkRow) => void;
+  onRestore: { mutate: (id: string) => void; isPending: boolean };
+}) {
+  return (
+    <div className="flex justify-end gap-1.5">
+      <a href={link.destination} target="_blank" rel="noreferrer">
+        <Button size="sm" variant="ghost" aria-label="Open destination">
+          <ExternalLink size={13} />
+        </Button>
+      </a>
+      {link.suspendedAt ? (
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={onRestore.isPending}
+          onClick={() => onRestore.mutate(link.id)}
+        >
+          <Undo2 size={13} /> Restore
+        </Button>
+      ) : (
+        <Button size="sm" variant="danger" onClick={() => onSuspend(link)}>
+          <Ban size={13} /> Suspend
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function LinksTable({
+  rows,
+  onSuspend,
+}: {
+  rows: AdminLinkRow[];
+  onSuspend: (l: AdminLinkRow) => void;
+}) {
+  const toast = useToast();
+  const qc = useQueryClient();
+  const unsuspend = useMutation({
+    mutationFn: (id: string) => api(`/admin/links/${id}/unsuspend`, { method: "POST" }),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ["admin", "links"] });
+      await qc.invalidateQueries({ queryKey: ["admin", "audit"] });
+      toast("Link restored.");
+    },
+    onError: withErrorToast(toast),
+  });
+
+  if (rows.length === 0)
+    return <p className="py-6 text-center text-sm text-muted">No links match that search.</p>;
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <Th>Link</Th>
+          <Th>Destination</Th>
+          <Th>Organization</Th>
+          <Th>Risk</Th>
+          <Th>Clicks</Th>
+          <Th>Created</Th>
+          <Th />
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((link) => (
+          <LinkRow key={link.id} link={link} onSuspend={onSuspend} onRestore={unsuspend} />
+        ))}
+      </tbody>
+    </Table>
+  );
+}
+
+/** Card, label, and the "nothing here" case, which both lower sections need
+ * and neither should spell out twice. */
+function AdminSection({
+  label,
+  hint,
+  empty,
+  loading,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  empty: boolean;
+  loading: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <div className="mb-3">
+        <p className="text-2xs tracking-wider text-muted uppercase">{label}</p>
+        {hint && <p className="mt-1 text-xs text-muted">{hint}</p>}
+      </div>
+      {loading ? (
+        <AdminTableSkeleton />
+      ) : empty ? (
+        <p className="py-4 text-center text-sm text-muted">Nothing here.</p>
+      ) : (
+        children
+      )}
+    </Card>
+  );
+}
+
+/** Links made on the landing page with no account. No org, no owner, and
+ * they expire on their own, so deleting is the only action worth having. */
+function AnonymousLinks() {
+  const { data, isPending } = useAdminAnonLinks();
+  const toast = useToast();
+  const qc = useQueryClient();
+  const remove = useMutation({
+    mutationFn: (id: string) => api(`/admin/links/anonymous/${id}`, { method: "DELETE" }),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ["admin", "anon-links"] });
+      toast("Anonymous link deleted.");
+    },
+    onError: withErrorToast(toast),
+  });
+
+  const rows = data ?? [];
+
+  return (
+    <AdminSection
+      label="Anonymous links"
+      hint="Made on the landing page without an account. They expire 24 hours after creation and disappear on their own; delete one to stop it sooner."
+      loading={isPending}
+      empty={rows.length === 0}
+    >
+      <Table>
+        <thead>
+          <tr>
+            <Th>Slug</Th>
+            <Th>Destination</Th>
+            <Th>Risk</Th>
+            <Th>Expires</Th>
+            <Th />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((link) => (
+            <tr key={link.id}>
+              <Td className="font-mono text-xs font-bold">/{link.slug}</Td>
+              <Td className="max-w-64 truncate text-muted" title={link.destination}>
+                {link.destination}
+              </Td>
+              <Td>
+                <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
+              </Td>
+              <Td className="text-muted">{shortDate(link.expiresAt)}</Td>
+              <Td>
+                <div className="flex justify-end">
+                  <Button
+                    size="sm"
+                    variant="danger"
+                    disabled={remove.isPending}
+                    onClick={() => remove.mutate(link.id)}
+                  >
+                    <Trash2 size={13} /> Delete
+                  </Button>
+                </div>
+              </Td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </AdminSection>
+  );
+}
+
+/** The audit trail, so a suspension is answerable later. */
+function AuditLog() {
+  const { data, isPending } = useAdminAudit();
+  const rows = data ?? [];
+
+  return (
+    <AdminSection label="Recent admin actions" loading={isPending} empty={rows.length === 0}>
+      <Table>
+        <thead>
+          <tr>
+            <Th>When</Th>
+            <Th>Who</Th>
+            <Th>Action</Th>
+            <Th>Target</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((entry) => (
+            <tr key={entry.id}>
+              <Td className="text-muted">{shortDate(entry.createdAt)}</Td>
+              {/* The address may be gone: the log outlives the account. */}
+              <Td>{entry.actorEmail ?? <span className="text-muted">deleted account</span>}</Td>
+              <Td className="font-mono text-xs">{entry.action}</Td>
+              <Td className="max-w-64 truncate text-muted" title={entry.detail ?? entry.targetId}>
+                {entry.detail ?? entry.targetId}
+              </Td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </AdminSection>
+  );
+}
+
+export function AdminLinksPage() {
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<AdminLinkSort>("created");
+  const [suspendedOnly, setSuspendedOnly] = useState(false);
+  const [suspending, setSuspending] = useState<AdminLinkRow | null>(null);
+
+  const { data, isPending } = useAdminLinks({ q: query, sort, suspended: suspendedOnly });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Links"
+        sub="Every link across every organization. Search by slug or destination."
+      />
+
+      <Card>
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <SearchInput
+            value={query}
+            onChange={setQuery}
+            placeholder="Slug or destination, e.g. phishy.example"
+            label="Search links"
+          />
+          <Select
+            value={sort}
+            onChange={(event) => setSort(event.target.value as AdminLinkSort)}
+            wrapperClass="w-44"
+          >
+            {ADMIN_LINK_SORTS.map((value) => (
+              <option key={value} value={value}>
+                {SORT_LABELS[value]}
+              </option>
+            ))}
+          </Select>
+          <Button
+            size="sm"
+            variant={suspendedOnly ? "primary" : "outline"}
+            onClick={() => setSuspendedOnly((on) => !on)}
+          >
+            Suspended only
+          </Button>
+        </div>
+        {isPending ? (
+          <AdminTableSkeleton />
+        ) : (
+          <LinksTable rows={data ?? []} onSuspend={setSuspending} />
+        )}
+      </Card>
+
+      <AnonymousLinks />
+      <AuditLog />
+
+      <SuspendDialog link={suspending} onClose={() => setSuspending(null)} />
+    </div>
+  );
+}

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -11,27 +11,27 @@
  * two places to search is one place too many at 2am.
  */
 import { useState } from "react";
+import { Link } from "react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Ban, ExternalLink, Trash2, Undo2 } from "lucide-react";
+import { Ban, ExternalLink, Trash2, Undo2, X } from "lucide-react";
 import { useAdminAnonLinks, useAdminLinks } from "../../lib/hooks";
 import { api } from "../../lib/api";
-import { ADMIN_LINK_SORTS, type AdminLinkRow, type AdminLinkSort } from "@/shared/types";
-import { Badge, Card, PageHeader, Table, Td, Th } from "../../ui/misc";
+import type { AdminLinkRow, Sort } from "@/shared/types";
+import { Badge, PageHeader, Table, Td, Th } from "../../ui/misc";
 import { Button } from "../../ui/button";
-import { Field, Input, Select } from "../../ui/field";
+import { Field, Input } from "../../ui/field";
 import { Dialog } from "../../ui/dialog";
 import { AdminTableSkeleton } from "../../components/skeletons";
 import { useToast } from "../../ui/toast";
 import { withErrorToast } from "../../lib/mutation-toast";
 import { shortDate } from "../../lib/dates";
 import { SearchInput } from "./search-input";
+import { paginate } from "./util";
+import { Pager } from "../../ui/pagination";
+import { SortTh } from "../../ui/sort-th";
+import { sortRows } from "../../lib/sort";
+import { useSearchParams } from "react-router";
 import { cn } from "../../ui/cn";
-
-const SORT_LABELS: Record<AdminLinkSort, string> = {
-  created: "Newest",
-  clicks: "Most clicked",
-  risk: "Riskiest first",
-};
 
 /**
  * Null is not zero. An unscored link is one nobody has looked at, and showing
@@ -128,12 +128,23 @@ function LinkRow({
       <Td className="truncate text-muted" title={link.destination}>
         {link.destination}
       </Td>
-      <Td className="truncate">{link.orgName}</Td>
-      <Td>
+      <Td className="hidden truncate sm:table-cell">
+        {/* Straight to that organization's links, which is the next question
+            after "who owns this". */}
+        <Link
+          to={`/admin/links?org=${encodeURIComponent(link.orgId)}`}
+          className="hover:text-accent hover:underline"
+        >
+          {link.orgName}
+        </Link>
+      </Td>
+      <Td className="hidden sm:table-cell">
         <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
       </Td>
-      <Td className="tnum">{link.clicks}</Td>
-      <Td className="whitespace-nowrap text-muted">{shortDate(link.createdAt)}</Td>
+      <Td className="hidden tnum sm:table-cell">{link.clicks}</Td>
+      <Td className="hidden whitespace-nowrap text-muted sm:table-cell">
+        {shortDate(link.createdAt)}
+      </Td>
       <Td>
         <LinkActions link={link} onSuspend={onSuspend} onRestore={onRestore} />
       </Td>
@@ -178,9 +189,13 @@ function LinkActions({
 function LinksTable({
   rows,
   onSuspend,
+  sort,
+  onSort,
 }: {
   rows: AdminLinkRow[];
   onSuspend: (l: AdminLinkRow) => void;
+  sort: Sort;
+  onSort: (s: Sort) => void;
 }) {
   const toast = useToast();
   const qc = useQueryClient();
@@ -204,13 +219,53 @@ function LinksTable({
     <Table fixed>
       <thead>
         <tr>
-          <Th className="w-[14%]">Link</Th>
-          <Th className="w-[23%]">Destination</Th>
-          <Th className="w-[14%]">Organization</Th>
-          <Th className="w-[10%]">Risk</Th>
-          <Th className="w-[7%]">Clicks</Th>
-          <Th className="w-[12%]">Created</Th>
-          <Th className="w-[20%]" />
+          <SortTh
+            label="Link"
+            sortKey="slug"
+            sort={sort}
+            onSort={onSort}
+            className="w-[26%] sm:w-[14%]"
+          />
+          {/* Hidden on a phone: seven columns in 390px squeezes every one of
+              them into uselessness. The destination and the organization are
+              the two an abuse report is read against, so they are the ones
+              that survive the cut. */}
+          <SortTh
+            label="Destination"
+            sortKey="destination"
+            sort={sort}
+            onSort={onSort}
+            className="w-[34%] sm:w-[23%]"
+          />
+          <SortTh
+            label="Organization"
+            sortKey="orgName"
+            sort={sort}
+            onSort={onSort}
+            className="hidden w-[14%] sm:table-cell"
+          />
+          <SortTh
+            label="Risk"
+            sortKey="riskScore"
+            sort={sort}
+            onSort={onSort}
+            className="hidden w-[10%] sm:table-cell"
+          />
+          <SortTh
+            label="Clicks"
+            sortKey="clicks"
+            sort={sort}
+            onSort={onSort}
+            className="hidden w-[7%] sm:table-cell"
+          />
+          <SortTh
+            label="Created"
+            sortKey="createdAt"
+            sort={sort}
+            onSort={onSort}
+            className="hidden w-[12%] sm:table-cell"
+          />
+          <Th className="w-[40%] sm:w-[20%]" />
         </tr>
       </thead>
       <tbody>
@@ -222,42 +277,13 @@ function LinksTable({
   );
 }
 
-/** Card, label, and the "nothing here" case, which both lower sections need
- * and neither should spell out twice. */
-function AdminSection({
-  label,
-  hint,
-  empty,
-  loading,
-  children,
-}: {
-  label: string;
-  hint?: string;
-  empty: boolean;
-  loading: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <Card>
-      <div className="mb-3">
-        <p className="text-2xs tracking-wider text-muted uppercase">{label}</p>
-        {hint && <p className="mt-1 text-xs text-muted">{hint}</p>}
-      </div>
-      {loading ? (
-        <AdminTableSkeleton />
-      ) : empty ? (
-        <p className="py-4 text-center text-sm text-muted">Nothing here.</p>
-      ) : (
-        children
-      )}
-    </Card>
-  );
-}
-
 /** Links made on the landing page with no account. No org, no owner, and
  * they expire on their own, so deleting is the only action worth having. */
 function AnonymousLinks() {
   const { data, isPending } = useAdminAnonLinks();
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<Sort>({ key: "createdAt", dir: -1 });
+  const [page, setPage] = useState(0);
   const toast = useToast();
   const qc = useQueryClient();
   const remove = useMutation({
@@ -269,53 +295,110 @@ function AnonymousLinks() {
     onError: withErrorToast(toast),
   });
 
-  const rows = data ?? [];
+  // Filtered here rather than on the server: the whole table is at most a
+  // day of anonymous links, so it is already small enough to hold.
+  const term = query.trim().toLowerCase();
+  const all = sortRows(
+    (data ?? []).filter(
+      (link) =>
+        !term ||
+        link.slug.toLowerCase().includes(term) ||
+        link.destination.toLowerCase().includes(term),
+    ),
+    sort,
+    {
+      slug: (l) => l.slug,
+      destination: (l) => l.destination,
+      riskScore: (l) => l.riskScore ?? -1,
+      expiresAt: (l) => l.expiresAt,
+      createdAt: (l) => l.createdAt,
+    },
+  );
+  const { rows, totalPages, safePage } = paginate(all, page);
 
   return (
-    <AdminSection
-      label="Anonymous links"
-      hint="Made on the landing page without an account. They expire 24 hours after creation and disappear on their own; delete one to stop it sooner."
-      loading={isPending}
-      empty={rows.length === 0}
-    >
-      <Table fixed>
-        <thead>
-          <tr>
-            <Th className="w-[18%]">Slug</Th>
-            <Th className="w-[38%]">Destination</Th>
-            <Th className="w-[14%]">Risk</Th>
-            <Th className="w-[14%]">Expires</Th>
-            <Th className="w-[16%]" />
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((link) => (
-            <tr key={link.id}>
-              <Td className="truncate font-mono text-xs font-bold">/{link.slug}</Td>
-              <Td className="truncate text-muted" title={link.destination}>
-                {link.destination}
-              </Td>
-              <Td>
-                <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
-              </Td>
-              <Td className="whitespace-nowrap text-muted">{shortDate(link.expiresAt)}</Td>
-              <Td>
-                <div className="flex justify-end">
-                  <Button
-                    size="sm"
-                    variant="danger"
-                    disabled={remove.isPending}
-                    onClick={() => remove.mutate(link.id)}
-                  >
-                    <Trash2 size={13} /> Delete
-                  </Button>
-                </div>
-              </Td>
+    <div className="flex flex-col gap-3">
+      <p className="text-xs text-muted">
+        Made on the landing page without an account. They expire 24 hours after creation and
+        disappear on their own; delete one to stop it sooner.
+      </p>
+      <SearchInput
+        value={query}
+        onChange={setQuery}
+        placeholder="Slug or destination"
+        label="Search anonymous links"
+      />
+      {isPending ? (
+        <AdminTableSkeleton />
+      ) : rows.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted">Nothing here.</p>
+      ) : (
+        <Table fixed>
+          <thead>
+            <tr>
+              <SortTh
+                label="Slug"
+                sortKey="slug"
+                sort={sort}
+                onSort={setSort}
+                className="w-[30%] sm:w-[18%]"
+              />
+              <SortTh
+                label="Destination"
+                sortKey="destination"
+                sort={sort}
+                onSort={setSort}
+                className="w-[40%] sm:w-[38%]"
+              />
+              <SortTh
+                label="Risk"
+                sortKey="riskScore"
+                sort={sort}
+                onSort={setSort}
+                className="hidden w-[14%] sm:table-cell"
+              />
+              <SortTh
+                label="Expires"
+                sortKey="expiresAt"
+                sort={sort}
+                onSort={setSort}
+                className="hidden w-[14%] sm:table-cell"
+              />
+              <Th className="w-[30%] sm:w-[16%]" />
             </tr>
-          ))}
-        </tbody>
-      </Table>
-    </AdminSection>
+          </thead>
+          <tbody>
+            {rows.map((link) => (
+              <tr key={link.id}>
+                <Td className="truncate font-mono text-xs font-bold">/{link.slug}</Td>
+                <Td className="truncate text-muted" title={link.destination}>
+                  {link.destination}
+                </Td>
+                <Td className="hidden sm:table-cell">
+                  <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
+                </Td>
+                <Td className="hidden whitespace-nowrap text-muted sm:table-cell">
+                  {shortDate(link.expiresAt)}
+                </Td>
+                <Td>
+                  <div className="flex justify-end">
+                    <Button
+                      size="sm"
+                      variant="danger"
+                      disabled={remove.isPending}
+                      onClick={() => remove.mutate(link.id)}
+                    >
+                      <Trash2 size={13} /> Delete
+                    </Button>
+                  </div>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+      <Pager page={safePage} totalPages={totalPages} onPageChange={setPage} />
+    </div>
   );
 }
 
@@ -348,33 +431,41 @@ function ViewSwitch({ view, onChange }: { view: View; onChange: (v: View) => voi
 }
 
 /** The cross-org list with its own controls. Split out so the page itself is
- * just the switch and the three things it switches between. */
+ * just the switch and the two things it switches between. */
 function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
+  const [params, setParams] = useSearchParams();
+  const orgFilter = params.get("org") ?? "";
   const [query, setQuery] = useState("");
-  const [sort, setSort] = useState<AdminLinkSort>("created");
+  const [sort, setSort] = useState<Sort>({ key: "createdAt", dir: -1 });
   const [suspendedOnly, setSuspendedOnly] = useState(false);
-  const { data, isPending } = useAdminLinks({ q: query, sort, suspended: suspendedOnly });
+  const [page, setPage] = useState(0);
+  const { data, isPending } = useAdminLinks({ q: query, suspended: suspendedOnly });
+
+  const all = sortRows(
+    (data ?? []).filter((link) => !orgFilter || link.orgId === orgFilter),
+    sort,
+    {
+      slug: (l) => l.slug,
+      destination: (l) => l.destination,
+      orgName: (l) => l.orgName,
+      // Unscored sorts below every score rather than as a zero: nobody has
+      // looked at it, which is not the same as clean.
+      riskScore: (l) => l.riskScore ?? -1,
+      clicks: (l) => l.clicks,
+      createdAt: (l) => l.createdAt,
+    },
+  );
+  const { rows, totalPages, safePage } = paginate(all, page);
 
   return (
-    <Card>
-      <div className="mb-3 flex flex-wrap items-center gap-2">
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
         <SearchInput
           value={query}
           onChange={setQuery}
           placeholder="Slug or destination, e.g. phishy.example"
           label="Search links"
         />
-        <Select
-          value={sort}
-          onChange={(event) => setSort(event.target.value as AdminLinkSort)}
-          wrapperClass="w-44"
-        >
-          {ADMIN_LINK_SORTS.map((value) => (
-            <option key={value} value={value}>
-              {SORT_LABELS[value]}
-            </option>
-          ))}
-        </Select>
         <Button
           size="sm"
           variant={suspendedOnly ? "primary" : "outline"}
@@ -382,9 +473,26 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
         >
           Suspended only
         </Button>
+        {orgFilter && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              params.delete("org");
+              setParams(params, { replace: true });
+            }}
+          >
+            <X size={13} /> {all[0]?.orgName ?? "Organization"} only
+          </Button>
+        )}
       </div>
-      {isPending ? <AdminTableSkeleton /> : <LinksTable rows={data ?? []} onSuspend={onSuspend} />}
-    </Card>
+      {isPending ? (
+        <AdminTableSkeleton />
+      ) : (
+        <LinksTable rows={rows} onSuspend={onSuspend} sort={sort} onSort={setSort} />
+      )}
+      <Pager page={safePage} totalPages={totalPages} onPageChange={setPage} />
+    </div>
   );
 }
 

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -518,7 +518,7 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
   const [deleting, setDeleting] = useState<AdminLinkRow | null>(null);
   const toast = useToast();
   const qc = useQueryClient();
-  const { data, isPending } = useAdminLinks({ q: search, suspended: false });
+  const { data, isPending } = useAdminLinks({ q: search, suspended: false, org: orgFilter });
 
   const refresh = async () => {
     await qc.invalidateQueries({ queryKey: ["admin", "links"] });
@@ -563,20 +563,18 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
     onError: withErrorToast(toast),
   });
 
-  const all = sortRows(
-    (data ?? []).filter((link) => !orgFilter || link.orgId === orgFilter),
-    sort,
-    {
-      slug: (l) => l.slug,
-      destination: (l) => l.destination,
-      orgName: (l) => l.orgName,
-      // Unscored sorts below every score rather than as a zero: nobody has
-      // looked at it, which is not the same as clean.
-      riskScore: (l) => l.riskScore ?? -1,
-      clicks: (l) => l.clicks,
-      createdAt: (l) => l.createdAt,
-    },
-  );
+  // No client-side org filter: the query applies it, so the cap counts this
+  // organization's links rather than the instance's.
+  const all = sortRows(data ?? [], sort, {
+    slug: (l) => l.slug,
+    destination: (l) => l.destination,
+    orgName: (l) => l.orgName,
+    // Unscored sorts below every score rather than as a zero: nobody has
+    // looked at it, which is not the same as clean.
+    riskScore: (l) => l.riskScore ?? -1,
+    clicks: (l) => l.clicks,
+    createdAt: (l) => l.createdAt,
+  });
   const { rows, totalPages, safePage } = paginate(all, page);
 
   return (

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -13,7 +13,7 @@
 import { useState } from "react";
 import { Link } from "react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Ban, Ellipsis, ExternalLink, Trash2, Undo2 } from "lucide-react";
+import { Ban, Ellipsis, ExternalLink, ShieldQuestionMark, Trash2, Undo2 } from "lucide-react";
 import { useAdminAnonLinks, useAdminLinks } from "../../lib/hooks";
 import { api } from "../../lib/api";
 import type { AdminAnonLinkRow, AdminLinkRow, Sort } from "@/shared/types";
@@ -112,11 +112,15 @@ function LinkRow({
   onSuspend,
   onRestore,
   onDelete,
+  onRescore,
+  rescoring,
 }: {
   link: AdminLinkRow;
   onSuspend: (l: AdminLinkRow) => void;
   onRestore: (l: AdminLinkRow) => void;
   onDelete: (l: AdminLinkRow) => void;
+  onRescore: (l: AdminLinkRow) => void;
+  rescoring: boolean;
 }) {
   return (
     <tr className={link.suspendedAt ? "opacity-60" : undefined}>
@@ -149,7 +153,14 @@ function LinkRow({
       <Td className="tnum">{link.clicks}</Td>
       <Td className="whitespace-nowrap text-muted">{shortDate(link.createdAt)}</Td>
       <Td>
-        <LinkActions link={link} onSuspend={onSuspend} onRestore={onRestore} onDelete={onDelete} />
+        <LinkActions
+          link={link}
+          onSuspend={onSuspend}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onRescore={onRescore}
+          rescoring={rescoring}
+        />
       </Td>
     </tr>
   );
@@ -165,11 +176,15 @@ function LinkActions({
   onSuspend,
   onRestore,
   onDelete,
+  onRescore,
+  rescoring,
 }: {
   link: AdminLinkRow;
   onSuspend: (l: AdminLinkRow) => void;
   onRestore: (l: AdminLinkRow) => void;
   onDelete: (l: AdminLinkRow) => void;
+  onRescore: (l: AdminLinkRow) => void;
+  rescoring: boolean;
 }) {
   return (
     <Menu
@@ -185,6 +200,9 @@ function LinkActions({
     >
       <MenuItem onClick={() => window.open(link.destination, "_blank", "noopener,noreferrer")}>
         <ExternalLink size={14} /> Open destination
+      </MenuItem>
+      <MenuItem onClick={() => onRescore(link)}>
+        <ShieldQuestionMark size={14} /> {rescoring ? "Checking…" : "Re-check destination"}
       </MenuItem>
       <MenuSeparator />
       {link.suspendedAt ? (
@@ -210,6 +228,8 @@ function LinksTable({
   onSuspend,
   onRestore,
   onDelete,
+  onRescore,
+  rescoringId,
 }: {
   rows: AdminLinkRow[];
   sort: Sort;
@@ -217,6 +237,8 @@ function LinksTable({
   onSuspend: (l: AdminLinkRow) => void;
   onRestore: (l: AdminLinkRow) => void;
   onDelete: (l: AdminLinkRow) => void;
+  onRescore: (l: AdminLinkRow) => void;
+  rescoringId: string | null;
 }) {
   if (rows.length === 0)
     return <p className="py-6 text-center text-sm text-muted">No links match that search.</p>;
@@ -272,6 +294,8 @@ function LinksTable({
             onSuspend={onSuspend}
             onRestore={onRestore}
             onDelete={onDelete}
+            onRescore={onRescore}
+            rescoring={rescoringId === link.id}
           />
         ))}
       </tbody>
@@ -495,6 +519,24 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
     onError: withErrorToast(toast),
   });
 
+  /** No confirmation: it reads a destination and writes a score, and the
+   * worst it can do is tell you something you did not want to hear. */
+  const rescore = useMutation({
+    mutationFn: (id: string) =>
+      api<{ scored: boolean; score: number | null }>(`/admin/links/${id}/rescore`, {
+        method: "POST",
+      }),
+    onSuccess: async (result) => {
+      await refresh();
+      // "Unscored" is reported as such, never as clean: the provider was
+      // unreachable or said something we do not recognise (#68).
+      if (!result.scored) toast("No answer from the checker. The link is still unscored.", "error");
+      else if (result.score && result.score >= 100) toast("Checked: the destination is blocked.");
+      else toast("Checked: nothing known against the destination.");
+    },
+    onError: withErrorToast(toast),
+  });
+
   const all = sortRows(
     (data ?? []).filter((link) => !orgFilter || link.orgId === orgFilter),
     sort,
@@ -550,6 +592,8 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
           onSuspend={onSuspend}
           onRestore={setRestoring}
           onDelete={setDeleting}
+          onRescore={(link) => rescore.mutate(link.id)}
+          rescoringId={rescore.isPending ? (rescore.variables ?? null) : null}
         />
       )}
       <Pager page={safePage} totalPages={totalPages} onPageChange={setPage} />

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -30,6 +30,7 @@ import { shortDate } from "../../lib/dates";
 import { SearchInput } from "./search-input";
 import { paginate } from "./util";
 import { Pager } from "../../ui/pagination";
+import { useDebounced } from "../../lib/use-debounced";
 import { SortTh } from "../../ui/sort-th";
 import { sortRows } from "../../lib/sort";
 import { useSearchParams } from "react-router";
@@ -341,7 +342,10 @@ function AnonymousLinks() {
       </p>
       <SearchInput
         value={query}
-        onChange={setQuery}
+        onChange={(value) => {
+          setQuery(value);
+          setPage(0);
+        }}
         placeholder="Slug or destination"
         label="Search anonymous links"
       />
@@ -463,13 +467,16 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
   const [params, setParams] = useSearchParams();
   const orgFilter = params.get("org") ?? "";
   const [query, setQuery] = useState("");
+  // The term reaches the server, so it waits for a pause in typing. Without
+  // this, "testing" was eight requests.
+  const search = useDebounced(query);
   const [sort, setSort] = useState<Sort>({ key: "createdAt", dir: -1 });
   const [page, setPage] = useState(0);
   const [restoring, setRestoring] = useState<AdminLinkRow | null>(null);
   const [deleting, setDeleting] = useState<AdminLinkRow | null>(null);
   const toast = useToast();
   const qc = useQueryClient();
-  const { data, isPending } = useAdminLinks({ q: query, suspended: false });
+  const { data, isPending } = useAdminLinks({ q: search, suspended: false });
 
   const refresh = async () => {
     await qc.invalidateQueries({ queryKey: ["admin", "links"] });
@@ -517,7 +524,13 @@ function OwnedLinks({ onSuspend }: { onSuspend: (l: AdminLinkRow) => void }) {
       <div className="flex flex-wrap items-center gap-2">
         <SearchInput
           value={query}
-          onChange={setQuery}
+          // Back to the first page with the term: paginate() clamps, so a
+          // narrower result set would otherwise leave you on its last page
+          // wondering where everything went.
+          onChange={(value) => {
+            setQuery(value);
+            setPage(0);
+          }}
           placeholder="Slug or destination, e.g. phishy.example"
           label="Search links"
         />

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -133,7 +133,7 @@ function LinkRow({
       <Td className="truncate text-muted" title={link.destination}>
         {link.destination}
       </Td>
-      <Td className="hidden truncate sm:table-cell">
+      <Td className="truncate">
         {/* Straight to that organization's links, which is the next question
             after "who owns this". */}
         <Link
@@ -143,13 +143,11 @@ function LinkRow({
           {link.orgName}
         </Link>
       </Td>
-      <Td className="hidden md:table-cell">
+      <Td>
         <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
       </Td>
-      <Td className="hidden tnum lg:table-cell">{link.clicks}</Td>
-      <Td className="hidden whitespace-nowrap text-muted lg:table-cell">
-        {shortDate(link.createdAt)}
-      </Td>
+      <Td className="tnum">{link.clicks}</Td>
+      <Td className="whitespace-nowrap text-muted">{shortDate(link.createdAt)}</Td>
       <Td>
         <LinkActions link={link} onSuspend={onSuspend} onRestore={onRestore} onDelete={onDelete} />
       </Td>
@@ -230,52 +228,40 @@ function LinksTable({
     //
     // Columns drop one breakpoint at a time rather than all at once, so the
     // table narrows smoothly instead of jumping between two layouts.
-    <Table fixed>
+    <Table fixed minWidth="min-w-[64rem]">
       <thead>
         <tr>
-          <SortTh
-            label="Link"
-            sortKey="slug"
-            sort={sort}
-            onSort={onSort}
-            className="w-[34%] sm:w-[24%] md:w-[18%] lg:w-[14%]"
-          />
+          <SortTh label="Link" sortKey="slug" sort={sort} onSort={onSort} className="w-[15%]" />
           <SortTh
             label="Destination"
             sortKey="destination"
             sort={sort}
             onSort={onSort}
-            className="w-[50%] sm:w-[38%] md:w-[30%] lg:w-[23%]"
+            className="w-[27%]"
           />
           <SortTh
             label="Organization"
             sortKey="orgName"
             sort={sort}
             onSort={onSort}
-            className="hidden sm:table-cell sm:w-[22%] md:w-[18%] lg:w-[14%]"
+            className="w-[16%]"
           />
           <SortTh
             label="Risk"
             sortKey="riskScore"
             sort={sort}
             onSort={onSort}
-            className="hidden md:table-cell md:w-[18%] lg:w-[10%]"
+            className="w-[12%]"
           />
-          <SortTh
-            label="Clicks"
-            sortKey="clicks"
-            sort={sort}
-            onSort={onSort}
-            className="hidden lg:table-cell lg:w-[7%]"
-          />
+          <SortTh label="Clicks" sortKey="clicks" sort={sort} onSort={onSort} className="w-[8%]" />
           <SortTh
             label="Created"
             sortKey="createdAt"
             sort={sort}
             onSort={onSort}
-            className="hidden lg:table-cell lg:w-[12%]"
+            className="w-[14%]"
           />
-          <Th className="w-[16%] sm:w-[16%] md:w-[16%] lg:w-[20%]" />
+          <Th className="w-[8%]" />
         </tr>
       </thead>
       <tbody>
@@ -354,7 +340,7 @@ function AnonymousLinks() {
       ) : rows.length === 0 ? (
         <p className="py-6 text-center text-sm text-muted">Nothing here.</p>
       ) : (
-        <Table fixed>
+        <Table fixed minWidth="min-w-[48rem]">
           <thead>
             <tr>
               <SortTh
@@ -362,30 +348,37 @@ function AnonymousLinks() {
                 sortKey="slug"
                 sort={sort}
                 onSort={setSort}
-                className="w-[34%] sm:w-[24%] md:w-[18%]"
+                className="w-[18%]"
               />
               <SortTh
                 label="Destination"
                 sortKey="destination"
                 sort={sort}
                 onSort={setSort}
-                className="w-[50%] sm:w-[44%] md:w-[38%]"
+                className="w-[38%]"
               />
               <SortTh
                 label="Risk"
                 sortKey="riskScore"
                 sort={sort}
                 onSort={setSort}
-                className="hidden sm:table-cell sm:w-[16%] md:w-[14%]"
+                className="w-[14%]"
+              />
+              <SortTh
+                label="Created"
+                sortKey="createdAt"
+                sort={sort}
+                onSort={setSort}
+                className="w-[14%]"
               />
               <SortTh
                 label="Expires"
                 sortKey="expiresAt"
                 sort={sort}
                 onSort={setSort}
-                className="hidden md:table-cell md:w-[14%]"
+                className="w-[14%]"
               />
-              <Th className="w-[16%]" />
+              <Th className="w-[12%]" />
             </tr>
           </thead>
           <tbody>
@@ -395,12 +388,11 @@ function AnonymousLinks() {
                 <Td className="truncate text-muted" title={link.destination}>
                   {link.destination}
                 </Td>
-                <Td className="hidden sm:table-cell">
+                <Td>
                   <RiskBadge score={link.riskScore} reasons={link.riskReasons} />
                 </Td>
-                <Td className="hidden whitespace-nowrap text-muted md:table-cell">
-                  {shortDate(link.expiresAt)}
-                </Td>
+                <Td className="whitespace-nowrap text-muted">{shortDate(link.createdAt)}</Td>
+                <Td className="whitespace-nowrap text-muted">{shortDate(link.expiresAt)}</Td>
                 <Td>
                   <div className="flex justify-end">
                     <Button size="sm" variant="danger" onClick={() => setDeleting(link)}>

--- a/src/app/routes/admin/orgs.tsx
+++ b/src/app/routes/admin/orgs.tsx
@@ -192,7 +192,7 @@ export function AdminOrgsPage() {
         placeholder="Search by org name or owner…"
         label="Search organizations"
       />
-      <Table>
+      <Table minWidth="min-w-[56rem]">
         <thead>
           <tr>
             <SortTh label="Name" sortKey="name" sort={sort} onSort={setSort} />

--- a/src/app/routes/admin/orgs.tsx
+++ b/src/app/routes/admin/orgs.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Ellipsis, Eye, Trash2 } from "lucide-react";
+import { ArrowRight, Ellipsis, Eye, Trash2 } from "lucide-react";
+import { Link } from "react-router";
+import { Button } from "../../ui/button";
 import { useAdminOrgDetail, useAdminOrgs } from "../../lib/hooks";
 import { api } from "../../lib/api";
 import type { AdminOrgRow, OrgPlan, OrgRole, Sort } from "@/shared/types";
@@ -12,7 +14,7 @@ import { AdminTableSkeleton, OrgDetailSkeleton } from "../../components/skeleton
 import { useToast } from "../../ui/toast";
 import { ConfirmDialog } from "../../ui/confirm-dialog";
 import { SearchInput } from "./search-input";
-import { linkLabel, paginate } from "./util";
+import { paginate } from "./util";
 import { SortTh } from "../../ui/sort-th";
 import { sortRows } from "../../lib/sort";
 import { withErrorToast } from "../../lib/mutation-toast";
@@ -63,32 +65,38 @@ function OrgMembersTable({
   );
 }
 
-function OrgLinksTable({
+/**
+ * A count and a way through, instead of the org's links inline.
+ *
+ * The dialog listed every link with its destination, which is the Links tab's
+ * job and did it worse: no search, no sort, no suspend. This says how many
+ * there are and hands the question over.
+ */
+function OrgLinksRecap({
+  orgId,
   links,
+  onNavigate,
 }: {
+  orgId: string;
   links: NonNullable<ReturnType<typeof useAdminOrgDetail>["data"]>["links"];
+  onNavigate: () => void;
 }) {
+  const clicks = links.reduce((total, link) => total + link.clicks, 0);
   return (
-    <div>
-      <p className="mb-2 text-2xs tracking-wider text-muted uppercase">Links</p>
-      <Table>
-        <thead>
-          <tr>
-            <Th>Short link</Th>
-            <Th>Destination</Th>
-            <Th className="text-right">Clicks</Th>
-          </tr>
-        </thead>
-        <tbody>
-          {links.map((l) => (
-            <tr key={l.id}>
-              <Td className="font-bold text-accent">{linkLabel(l)}</Td>
-              <Td className="max-w-64 truncate text-muted">{l.destination}</Td>
-              <Td className="tnum text-right">{l.clicks}</Td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
+    <div className="flex flex-wrap items-center gap-3 rounded-lg bg-surface-2 px-4 py-3">
+      <div className="flex-1">
+        <p className="text-2xs tracking-wider text-muted uppercase">Links</p>
+        <p className="mt-0.5 text-sm">
+          <span className="font-bold tnum">{links.length}</span>{" "}
+          {links.length === 1 ? "link" : "links"},{" "}
+          <span className="font-bold tnum">{clicks.toLocaleString()}</span> clicks between them
+        </p>
+      </div>
+      <Link to={`/admin/links?org=${encodeURIComponent(orgId)}`} onClick={onNavigate}>
+        <Button size="sm" variant="outline">
+          Open in Links <ArrowRight size={13} />
+        </Button>
+      </Link>
     </div>
   );
 }
@@ -116,7 +124,11 @@ function OrgDetailDialog({ org, onClose }: { org: AdminOrgRow | null; onClose: (
               </Card>
 
               <OrgMembersTable members={detail.data.members} />
-              <OrgLinksTable links={detail.data.links} />
+              <OrgLinksRecap
+                orgId={detail.data.id}
+                links={detail.data.links}
+                onNavigate={onClose}
+              />
             </>
           )}
         </div>

--- a/src/app/routes/admin/users.tsx
+++ b/src/app/routes/admin/users.tsx
@@ -324,7 +324,7 @@ function UsersTable({
   searchTerm: string;
 }) {
   return (
-    <Table>
+    <Table minWidth="min-w-[64rem]">
       <thead>
         <tr>
           <SortTh label="Name" sortKey="name" sort={sort} onSort={setSort} />

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -110,6 +110,9 @@ function PlatformNav({ visible }: { visible: boolean }) {
         <NavLink to="/admin" end className={navClass}>
           <Globe size={15} /> Usage
         </NavLink>
+        <NavLink to="/admin/links" className={navClass}>
+          Links
+        </NavLink>
         <NavLink to="/admin/orgs" className={navClass}>
           <Building2 size={15} /> Organizations
         </NavLink>

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -2,7 +2,7 @@ import { Suspense, useState, type ReactNode } from "react";
 import { NavLink, Navigate, Outlet, useNavigate, useLocation } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, LazyMotion, domAnimation, m } from "motion/react";
-import { Globe, Building2, UserCog, ChevronsUpDown, Plus, Check, LogOut } from "lucide-react";
+import { Globe, ChevronsUpDown, Plus, Check, LogOut } from "lucide-react";
 // MorphIcon animates between two icons, so it takes lucide icon nodes, not
 // the React components lucide-react exports.
 import { Sun, Moon, Menu as MenuIcon, X } from "lucide";
@@ -101,23 +101,19 @@ function OrgSwitcherMenu({
   );
 }
 
+/**
+ * One entry, not four. The four sections are tabs inside /admin now: as
+ * sidebar items they sat directly under the organization's own nav, where
+ * "Links" appeared twice meaning two different things.
+ */
 function PlatformNav({ visible }: { visible: boolean }) {
   if (!visible) return null;
   return (
     <div className="mt-2 px-3">
-      <p className="px-2.5 pb-1 text-3xs tracking-widest text-muted uppercase">Platform</p>
+      <p className="px-2.5 pb-1 text-3xs tracking-widest text-muted uppercase">Admin</p>
       <nav className="flex flex-col gap-0.5">
-        <NavLink to="/admin" end className={navClass}>
-          <Globe size={15} /> Usage
-        </NavLink>
-        <NavLink to="/admin/links" className={navClass}>
-          Links
-        </NavLink>
-        <NavLink to="/admin/orgs" className={navClass}>
-          <Building2 size={15} /> Organizations
-        </NavLink>
-        <NavLink to="/admin/users" className={navClass}>
-          <UserCog size={15} /> Users
+        <NavLink to="/admin" className={navClass}>
+          <Globe size={15} /> Platform
         </NavLink>
       </nav>
     </div>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -136,6 +136,11 @@ html {
   /* reserve the scrollbar's width even on pages short enough to not need
      one, so a page that grows past the fold doesn't shift content left */
   scrollbar-gutter: stable;
+  /* No sideways rubber-band. Nothing here scrolls horizontally by design, so
+     a trackpad flick at the end of a wide table would otherwise bounce the
+     whole document and show the area beyond the app beside it. Vertical
+     overscroll is left alone: that one is the platform behaving normally. */
+  overscroll-behavior-x: none;
 }
 
 /* Theme changes cross-fade through a view transition, not a CSS transition.

--- a/src/app/ui/misc.tsx
+++ b/src/app/ui/misc.tsx
@@ -96,10 +96,11 @@ export function Table({
   minWidth?: string;
 }) {
   return (
-    // overscroll-x-contain: a horizontal scroll that reaches the end of the
-    // table stops there instead of chaining to the page, which on a trackpad
-    // is a back-navigation waiting to happen.
-    <div className="overflow-x-auto overscroll-x-contain rounded-lg bg-surface smooth-shadow-ring-xs">
+    // overscroll-x-none, not -contain. `contain` only stops the scroll
+    // chaining to the page; the container still rubber-bands at each end,
+    // and that bounce drags the table off its own background so the page
+    // shows through beside it. `none` disables the bounce as well.
+    <div className="overflow-x-auto overscroll-x-none rounded-lg bg-surface smooth-shadow-ring-xs">
       <table
         className={cn(
           "w-full text-sm [&_tbody_tr]:transition-colors [&_tbody_tr:hover]:bg-surface-2/40",

--- a/src/app/ui/misc.tsx
+++ b/src/app/ui/misc.tsx
@@ -83,11 +83,29 @@ export function Card({ className, children }: { className?: string; children: Re
   );
 }
 
-export function Table({ children, fixed }: { children: ReactNode; fixed?: boolean }) {
+export function Table({
+  children,
+  fixed,
+  minWidth,
+}: {
+  children: ReactNode;
+  fixed?: boolean;
+  /** Tailwind min-width for the table itself, e.g. "min-w-[64rem]". Use it
+   * when every column has to stay on screen and the wrapper should scroll
+   * rather than the columns shrinking into uselessness. */
+  minWidth?: string;
+}) {
   return (
-    <div className="overflow-x-auto rounded-lg bg-surface smooth-shadow-ring-xs">
+    // overscroll-x-contain: a horizontal scroll that reaches the end of the
+    // table stops there instead of chaining to the page, which on a trackpad
+    // is a back-navigation waiting to happen.
+    <div className="overflow-x-auto overscroll-x-contain rounded-lg bg-surface smooth-shadow-ring-xs">
       <table
-        className={`w-full text-sm [&_tbody_tr]:transition-colors [&_tbody_tr:hover]:bg-surface-2/40 ${fixed ? "table-fixed" : ""}`}
+        className={cn(
+          "w-full text-sm [&_tbody_tr]:transition-colors [&_tbody_tr:hover]:bg-surface-2/40",
+          fixed && "table-fixed",
+          minWidth,
+        )}
       >
         {children}
       </table>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -406,6 +406,53 @@ export interface AdminOrgDetail {
   series: SeriesPoint[];
 }
 
+/** One link in the cross-org admin list (#67). Never returned to an org. */
+export interface AdminLinkRow {
+  id: string;
+  slug: string;
+  domain: string | null;
+  destination: string;
+  orgId: string;
+  orgName: string;
+  createdBy: string | null;
+  createdAt: number;
+  clicks: number;
+  suspendedAt: number | null;
+  suspendReason: string | null;
+  /** Destination scoring (#68). Null means unscored, never clean. */
+  riskScore: number | null;
+  riskReasons: string[];
+  riskCheckedAt: number | null;
+}
+
+/** An anonymous link made on the landing page (Direction A of #96). It has no
+ * org and no owner, so it cannot share AdminLinkRow's shape. */
+export interface AdminAnonLinkRow {
+  id: string;
+  slug: string;
+  destination: string;
+  createdAt: number;
+  expiresAt: number;
+  riskScore: number | null;
+  riskReasons: string[];
+}
+
+export interface AdminActionRow {
+  id: string;
+  actorUserId: string;
+  actorEmail: string | null;
+  action: string;
+  targetType: string;
+  targetId: string;
+  detail: string | null;
+  createdAt: number;
+}
+
+/** How the admin link list may be ordered. `risk` puts the worst first, which
+ * is the whole reason #68 fills those columns. */
+export const ADMIN_LINK_SORTS = ["created", "clicks", "risk"] as const;
+export type AdminLinkSort = (typeof ADMIN_LINK_SORTS)[number];
+
 export interface AdminUserRow {
   id: string;
   name: string;

--- a/src/worker/audit.ts
+++ b/src/worker/audit.ts
@@ -20,6 +20,7 @@ export type AdminAction =
   | "link.suspend"
   | "link.unsuspend"
   | "link.delete"
+  | "link.rescore"
   | "org.suspend_links"
   | "org.unsuspend_links"
   | "org.delete"

--- a/src/worker/audit.ts
+++ b/src/worker/audit.ts
@@ -19,6 +19,7 @@ import { uid } from "./util";
 export type AdminAction =
   | "link.suspend"
   | "link.unsuspend"
+  | "link.delete"
   | "org.suspend_links"
   | "org.unsuspend_links"
   | "org.delete"

--- a/src/worker/audit.ts
+++ b/src/worker/audit.ts
@@ -1,0 +1,80 @@
+/**
+ * The admin audit log (#67).
+ *
+ * One row per privileged mutation, appended and never updated. Small on
+ * purpose: #22 covers the larger admin identity work (immutable root id,
+ * roles, MFA) and should build on this table rather than adding a second one.
+ *
+ * Writing is best-effort and never blocks the action. That is the right way
+ * round for this table: an admin stopping a phishing link at 2am must not be
+ * refused because a log insert failed, and a missing entry is a smaller
+ * problem than a live malware redirect. Failures are logged loudly so the gap
+ * is visible.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { and, desc, eq } from "drizzle-orm";
+import * as schema from "./db/schema";
+import type { Env } from "./env";
+import { uid } from "./util";
+
+export type AdminAction =
+  | "link.suspend"
+  | "link.unsuspend"
+  | "org.suspend_links"
+  | "org.unsuspend_links"
+  | "org.delete"
+  | "user.ban"
+  | "user.unban"
+  | "user.delete"
+  | "user.comp_grant"
+  | "user.comp_revoke"
+  | "anon_link.delete";
+
+export async function recordAdminAction(
+  env: Env,
+  entry: {
+    actorUserId: string;
+    action: AdminAction;
+    targetType: "link" | "org" | "user" | "anon_link";
+    targetId: string;
+    /** Anything needed to read this entry once its target is gone. */
+    detail?: Record<string, unknown>;
+  },
+): Promise<void> {
+  try {
+    await drizzle(env.DB, { schema })
+      .insert(schema.adminActions)
+      .values({
+        id: uid(),
+        actorUserId: entry.actorUserId,
+        action: entry.action,
+        targetType: entry.targetType,
+        targetId: entry.targetId,
+        detail: entry.detail ? JSON.stringify(entry.detail) : null,
+        createdAt: Date.now(),
+      });
+  } catch (error) {
+    console.error("admin_audit_write_failed", entry.action, entry.targetId, error);
+  }
+}
+
+/** Newest first, optionally narrowed to one target while investigating it. */
+export async function readAdminActions(
+  env: Env,
+  filter: { targetType?: string; targetId?: string; limit?: number } = {},
+) {
+  const db = drizzle(env.DB, { schema });
+  const where =
+    filter.targetType && filter.targetId
+      ? and(
+          eq(schema.adminActions.targetType, filter.targetType),
+          eq(schema.adminActions.targetId, filter.targetId),
+        )
+      : undefined;
+  return db
+    .select()
+    .from(schema.adminActions)
+    .where(where)
+    .orderBy(desc(schema.adminActions.createdAt))
+    .limit(Math.min(filter.limit ?? 100, 200));
+}

--- a/src/worker/audit.ts
+++ b/src/worker/audit.ts
@@ -12,7 +12,6 @@
  * is visible.
  */
 import { drizzle } from "drizzle-orm/d1";
-import { and, desc, eq } from "drizzle-orm";
 import * as schema from "./db/schema";
 import type { Env } from "./env";
 import { uid } from "./util";
@@ -56,25 +55,4 @@ export async function recordAdminAction(
   } catch (error) {
     console.error("admin_audit_write_failed", entry.action, entry.targetId, error);
   }
-}
-
-/** Newest first, optionally narrowed to one target while investigating it. */
-export async function readAdminActions(
-  env: Env,
-  filter: { targetType?: string; targetId?: string; limit?: number } = {},
-) {
-  const db = drizzle(env.DB, { schema });
-  const where =
-    filter.targetType && filter.targetId
-      ? and(
-          eq(schema.adminActions.targetType, filter.targetType),
-          eq(schema.adminActions.targetId, filter.targetId),
-        )
-      : undefined;
-  return db
-    .select()
-    .from(schema.adminActions)
-    .where(where)
-    .orderBy(desc(schema.adminActions.createdAt))
-    .limit(Math.min(filter.limit ?? 100, 200));
 }

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -238,8 +238,41 @@ export const links = sqliteTable(
     riskReasons: text("risk_reasons"),
     riskCheckedAt: integer("risk_checked_at"),
     riskProvider: text("risk_provider"),
+    // Admin moderation (#67). Null means active. One flag covers every
+    // address the link answers to, and the redirect stops because
+    // desiredKvValue refuses to publish a suspended link's key: put the
+    // check anywhere else and the next edit un-suspends it in silence.
+    suspendedAt: integer("suspended_at"),
+    suspendedBy: text("suspended_by").references(() => user.id, { onDelete: "set null" }),
+    suspendReason: text("suspend_reason"),
   },
   (t) => [index("idx_links_org").on(t.orgId)],
+);
+
+/**
+ * Every privileged mutation an admin makes, appended and never updated (#67).
+ *
+ * No foreign keys: an admin account can be deleted, and the record of what
+ * they did has to outlive them. The same goes for target_id, which often
+ * points at exactly the row this entry exists to remember the deletion of.
+ */
+export const adminActions = sqliteTable(
+  "admin_actions",
+  {
+    id: text("id").primaryKey(),
+    actorUserId: text("actor_user_id").notNull(),
+    /** e.g. "link.suspend", "org.suspend_links", "user.ban". */
+    action: text("action").notNull(),
+    targetType: text("target_type").notNull(),
+    targetId: text("target_id").notNull(),
+    /** Free-form JSON, so an entry still reads once its target is gone. */
+    detail: text("detail"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (t) => [
+    index("idx_admin_actions_created").on(t.createdAt),
+    index("idx_admin_actions_target").on(t.targetType, t.targetId),
+  ],
 );
 
 // Every address a link answers to, including its own primary as a row kept

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -14,7 +14,7 @@ import { adminRoutes } from "./routes/admin";
 import { billingRoutes, handlePolarWebhook } from "./routes/billing";
 import { domainRoutes } from "./routes/domains";
 import { capRoutes } from "./routes/cap";
-import { sweepLinkRisk } from "./risk";
+import { revalidateOnRedirect } from "./risk";
 import { shortenRoutes, sweepExpiredAnonLinks } from "./routes/shorten";
 import { resolveSlug, resolveDomain, type KVLink } from "./kv";
 import { RESERVED_SLUGS } from "./util";
@@ -87,6 +87,10 @@ function redirectWithClick(c: Context<AppEnv>, hit: KVLink): Response {
   // read it. Skipping the write is also the honest version of the pitch:
   // analytics is what signing up buys.
   if (hit.orgId) c.executionCtx.waitUntil(enqueueClick(c, hit));
+  // Re-check the destination if its verdict has gone stale (#68). After the
+  // redirect is sent, so it costs the person clicking nothing, and only for
+  // hosts nobody has checked in the last day.
+  c.executionCtx.waitUntil(revalidateOnRedirect(c.env, hit));
   return c.redirect(hit.url, 302);
 }
 
@@ -267,11 +271,5 @@ export default {
     // Daily: drop anonymous links nobody claimed inside their 24 hours, and
     // the KV keys they were resolving through (Direction A of #96).
     await sweepExpiredAnonLinks(env);
-
-    // Daily: re-score link destinations, unscored first then oldest (#68).
-    // Bounded, because the point is that the table cycles rather than that
-    // any one run finishes it: a destination that turns bad long after it
-    // was created gets caught on some later day.
-    await sweepLinkRisk(env.DB);
   },
 };

--- a/src/worker/risk.ts
+++ b/src/worker/risk.ts
@@ -23,6 +23,7 @@
  *    Google Web Risk is the upgrade for full-URL scoring, when there is
  *    evidence of that specific abuse to justify the credential.
  */
+import type { Env } from "./env";
 
 /** 0 = nothing known against it, 100 = a provider refuses to resolve it. */
 export type RiskVerdict = {
@@ -124,62 +125,68 @@ export async function scoreAndRecord(
 }
 
 /**
- * Re-scores links, oldest first, with never-scored ones taking priority.
- *
- * Bounded, because the whole point is that the table cycles rather than that
- * any one run finishes it: a destination that turns bad long after creation
- * is caught on some later day, and one run can never blow the daily job's
- * time budget.
- *
- * Sequential rather than parallel on purpose. This is a background sweep
- * with all day to finish, and firing a batch of lookups at a public resolver
- * at once is how you get rate limited by it.
+ * How long a hostname's verdict is trusted before the next click re-checks it.
  */
-export async function sweepLinkRisk(db: D1Database, batchSize = 50): Promise<number> {
-  // Half the batch at most for the never-scored, so they cannot crowd out the
-  // rescans. A destination the resolver keeps timing out on stays unscored,
-  // and unscored sorts first: enough of those and every run spends its whole
-  // budget retrying the same failures, while destinations that were clean a
-  // year ago are never looked at again. That is the sweep quietly giving up
-  // on the job it exists for, with nothing on screen to say so.
-  // Together: two independent reads of our own database, which is not the
-  // resolver the loop below is careful with.
-  const [unscored, scored] = await Promise.all([
-    pickToScore(db, "risk_checked_at is null", batchSize),
-    pickToScore(db, "risk_checked_at is not null", batchSize),
-  ]);
-  // The cap gives way when the other side cannot fill the batch: it exists to
-  // stop the unscored crowding out rescans, not to leave the budget unspent.
-  const room = Math.max(Math.ceil(batchSize / 2), batchSize - scored.length);
-  const take = unscored.slice(0, room);
-  const results = [...take, ...scored.slice(0, batchSize - take.length)];
+const HOST_VERDICT_TTL_SECONDS = 24 * 60 * 60;
 
-  // Sequential on purpose: a daily background sweep with all day to finish,
-  // and firing a batch of lookups at a public resolver at once is how you get
-  // rate limited by it. Promise.all would trade a slow job nobody waits on
-  // for a provider that stops answering.
-  // react-doctor-disable-next-line react-doctor/async-await-in-loop
-  for (const row of results) await scoreAndRecord(db, row.id, row.destination);
-  return results.length;
-}
+/**
+ * Re-checks a destination when somebody clicks it, if the answer is stale.
+ *
+ * This replaced a nightly sweep, which was the wrong axis: a sweep has to get
+ * through the whole table, so it loses the race as soon as the table is big,
+ * and it spends most of its budget on links nobody visits. A link nobody
+ * clicks harms nobody, so it can stay unscored.
+ *
+ * The work is proportional to distinct hosts being clicked, not to how many
+ * links exist. Ten thousand links pointing at one host cost one check a day
+ * between them, because the verdict is cached per hostname rather than per
+ * link: our provider only ever looks at the hostname anyway, so this loses
+ * no accuracy.
+ *
+ * Meant for `waitUntil` after the redirect has already been sent. Nothing
+ * here is on the path of the person clicking, and every failure is
+ * swallowed: a redirect must not depend on a resolver.
+ */
+export async function revalidateOnRedirect(
+  env: Env,
+  hit: { linkId: string; orgId: string; url: string },
+): Promise<void> {
+  // Anonymous links (#96) are checked when they are made and expire within
+  // 24 hours, so there is never a stale one to catch.
+  if (!hit.orgId) return;
 
-/** One side of the sweep's batch: the oldest rows in the given state. */
-async function pickToScore(
-  db: D1Database,
-  state: string,
-  limit: number,
-): Promise<{ id: string; destination: string }[]> {
-  if (limit <= 0) return [];
-  const { results } = await db
-    .prepare(
-      `select id, destination from links
-       where ${state}
-       order by risk_checked_at asc
-       limit ?`,
+  const hostname = hostnameOf(hit.url);
+  if (!hostname) return;
+
+  try {
+    const cacheKey = `risk:host:${hostname}`;
+    // One KV read is the whole cost of a click on a host checked recently,
+    // and KV reads at the edge are what this hot path is already made of.
+    if (await env.LINKS.get(cacheKey)) return;
+
+    const verdict = await scoreDestination(hit.url);
+    if (!verdict) return;
+
+    // Written before the row: if the update fails, the next click should not
+    // immediately repeat a lookup that just succeeded.
+    await env.LINKS.put(cacheKey, String(verdict.score), {
+      expirationTtl: HOST_VERDICT_TTL_SECONDS,
+    });
+    await env.DB.prepare(
+      `update links set risk_score = ?, risk_reasons = ?, risk_checked_at = ?, risk_provider = ?
+       where id = ?`,
     )
-    .bind(limit)
-    .all<{ id: string; destination: string }>();
-  return results;
+      .bind(
+        verdict.score,
+        JSON.stringify(verdict.reasons),
+        Date.now(),
+        verdict.provider,
+        hit.linkId,
+      )
+      .run();
+  } catch (error) {
+    console.warn("risk_revalidate_failed", hit.linkId, error);
+  }
 }
 
 /** The host a destination points at, or null if it is not a URL we can read. */

--- a/src/worker/risk.ts
+++ b/src/worker/risk.ts
@@ -24,6 +24,7 @@
  *    evidence of that specific abuse to justify the credential.
  */
 import type { Env } from "./env";
+import { stripUtmParams } from "./util";
 
 /** 0 = nothing known against it, 100 = a provider refuses to resolve it. */
 export type RiskVerdict = {
@@ -162,19 +163,32 @@ export async function revalidateOnRedirect(
     const cacheKey = `risk:host:${hostname}`;
     // One KV read is the whole cost of a click on a host checked recently,
     // and KV reads at the edge are what this hot path is already made of.
-    if (await env.LINKS.get(cacheKey)) return;
-
-    const verdict = await scoreDestination(hit.url);
+    // The whole verdict is cached, not just its score: a click on a host
+    // somebody else's link warmed still has to be able to record it.
+    const cached = await env.LINKS.get<RiskVerdict>(cacheKey, "json");
+    const verdict = cached ?? (await scoreDestination(hit.url));
     if (!verdict) return;
 
     // Written before the row: if the update fails, the next click should not
     // immediately repeat a lookup that just succeeded.
-    await env.LINKS.put(cacheKey, String(verdict.score), {
-      expirationTtl: HOST_VERDICT_TTL_SECONDS,
-    });
+    if (!cached)
+      await env.LINKS.put(cacheKey, JSON.stringify(verdict), {
+        expirationTtl: HOST_VERDICT_TTL_SECONDS,
+      });
+
+    // Every link on the host, not only the one that warmed the cache. The
+    // verdict used to be written to the clicked link alone, so a host scored
+    // 100 marked whichever link happened to be clicked while the cache was
+    // cold and left every other link pointing at it unscored: the admin
+    // table sorts by that score, so the rest hid in plain sight.
+    //
+    // The two conditions are what keep this off the hot path in practice: a
+    // link already carrying this verdict is not written again, and a link
+    // whose destination has moved on is not relabelled by a KV entry that
+    // predates the edit.
     await env.DB.prepare(
       `update links set risk_score = ?, risk_reasons = ?, risk_checked_at = ?, risk_provider = ?
-       where id = ?`,
+       where id = ? and destination = ? and (risk_checked_at is null or risk_checked_at < ?)`,
     )
       .bind(
         verdict.score,
@@ -182,6 +196,8 @@ export async function revalidateOnRedirect(
         Date.now(),
         verdict.provider,
         hit.linkId,
+        stripUtmParams(hit.url),
+        Date.now() - HOST_VERDICT_TTL_SECONDS * 1000,
       )
       .run();
   } catch (error) {

--- a/src/worker/routes/admin-links.ts
+++ b/src/worker/routes/admin-links.ts
@@ -147,10 +147,19 @@ adminLinkRoutes.get("/", async (c) => {
     ? (sortParam as AdminLinkSort)
     : "created";
   const onlySuspended = c.req.query("suspended") === "1";
+  const org = (c.req.query("org") ?? "").trim();
 
   const filters = [
     q ? or(like(schema.links.slug, `%${q}%`), like(schema.links.destination, `%${q}%`)) : undefined,
     onlySuspended ? isNotNull(schema.links.suspendedAt) : undefined,
+    // Here rather than in the browser. The page used to narrow the rows this
+    // query had already capped at 200, so "show me this organization's links"
+    // meant "show me whichever of its links happen to be in the newest 200
+    // across every organization on the instance": for a busy instance, or a
+    // big account, usually none of them. An abuse report names an
+    // organization, and answering it with an empty table is worse than
+    // answering it slowly.
+    org ? eq(schema.links.orgId, org) : undefined,
   ].filter(Boolean);
 
   const rows = await db

--- a/src/worker/routes/admin-links.ts
+++ b/src/worker/routes/admin-links.ts
@@ -198,6 +198,46 @@ adminLinkRoutes.post("/:linkId/unsuspend", async (c) =>
 );
 
 /**
+ * Delete a link outright.
+ *
+ * Suspension is the usual answer, because it is reversible and keeps the
+ * evidence. This exists for the cases where the row itself should not
+ * survive, and it is deliberately the second option in the menu rather than
+ * the first: clicks cascade with it and nothing here can put it back.
+ */
+adminLinkRoutes.delete("/:linkId", async (c) => {
+  const db = c.var.db;
+  const linkId = c.req.param("linkId")!;
+  const rows = await db.select().from(schema.links).where(eq(schema.links.id, linkId));
+  const link = rows[0];
+  if (!link) throw new HTTPException(404, { message: "Link not found" });
+
+  // Addresses first: after the row is gone there is nothing to read them
+  // from, and each one is a live KV key until it is swept.
+  const addresses = await addressesOf(db, linkId);
+  await db.delete(schema.links).where(eq(schema.links.id, linkId));
+  if (addresses.length > 0)
+    await enqueueStorage(
+      c.env,
+      addresses.map((a) => syncLinkMsg(a.slug, a.hostname)),
+    );
+
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: "link.delete",
+    targetType: "link",
+    targetId: linkId,
+    detail: {
+      slug: link.slug,
+      orgId: link.orgId,
+      destination: link.destination,
+      addresses: addresses.length,
+    },
+  });
+  return c.json({ ok: true });
+});
+
+/**
  * Suspend or restore every link in one org, without deleting it.
  *
  * For when the whole account is bad but the evidence should survive and an

--- a/src/worker/routes/admin-links.ts
+++ b/src/worker/routes/admin-links.ts
@@ -1,0 +1,328 @@
+/**
+ * Cross-org link moderation (#67).
+ *
+ * A shortener is phishing and malware infrastructure by default, and until
+ * now the only answer to an abuse report was deleting the whole organization.
+ * That destroys a possibly-legitimate customer's other links to deal with one
+ * bad one, and it cannot be undone.
+ *
+ * Everything here is admin-only and 404s for everyone else, matching the rest
+ * of /api/admin: a 403 confirms the route exists.
+ *
+ * Suspension itself is enforced in storage.ts's desiredKvValue, not here.
+ * These routes set the flag and republish; the republish is what stops the
+ * redirect, and because every future republish runs through the same
+ * function, a later edit cannot quietly bring a suspended link back.
+ */
+import { Hono, type Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { and, desc, eq, isNull, isNotNull, like, or, sql } from "drizzle-orm";
+import * as schema from "../db/schema";
+import type { AppEnv, DB, Env } from "../env";
+import { enqueueStorage, syncLinkMsg } from "../storage";
+import { recordAdminAction } from "../audit";
+import { jsonBodyLimit } from "../body-limit";
+import {
+  ADMIN_LINK_SORTS,
+  type AdminActionRow,
+  type AdminAnonLinkRow,
+  type AdminLinkRow,
+  type AdminLinkSort,
+} from "@/shared/types";
+
+export const adminLinkRoutes = new Hono<AppEnv>();
+adminLinkRoutes.use("*", jsonBodyLimit());
+
+const MAX_ROWS = 200;
+
+function parseReasons(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((r): r is string => typeof r === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+const clickCount = sql<number>`(
+  select count(*) from clicks where clicks.link_id = links.id
+)`;
+
+/**
+ * Every address a link answers to, so suspending or restoring one republishes
+ * all of them. A link with three aliases that only republished its primary
+ * would keep redirecting on the other two.
+ */
+async function addressesOf(db: DB, linkId: string) {
+  return db
+    .select({
+      slug: schema.linkAddresses.slug,
+      hostname: schema.domains.hostname,
+    })
+    .from(schema.linkAddresses)
+    .leftJoin(schema.domains, eq(schema.linkAddresses.domainId, schema.domains.id))
+    .where(and(eq(schema.linkAddresses.linkId, linkId), isNull(schema.linkAddresses.retiredAt)));
+}
+
+async function republish(env: Env, db: DB, linkId: string): Promise<number> {
+  const addresses = await addressesOf(db, linkId);
+  if (addresses.length > 0)
+    await enqueueStorage(
+      env,
+      addresses.map((a) => syncLinkMsg(a.slug, a.hostname)),
+    );
+  return addresses.length;
+}
+
+/**
+ * The cross-org search. Matches a slug or a destination, which are the two
+ * things an abuse report actually contains.
+ *
+ * `like` on destination rather than a parsed host: a report usually names a
+ * domain, and the destination column holds a full URL, so a substring match
+ * finds it wherever in the URL it sits. It is a moderation tool used by one
+ * person, not a hot path.
+ */
+adminLinkRoutes.get("/", async (c) => {
+  const db = c.var.db;
+  const q = (c.req.query("q") ?? "").trim();
+  const sortParam = c.req.query("sort") ?? "created";
+  const sort: AdminLinkSort = (ADMIN_LINK_SORTS as readonly string[]).includes(sortParam)
+    ? (sortParam as AdminLinkSort)
+    : "created";
+  const onlySuspended = c.req.query("suspended") === "1";
+
+  const filters = [
+    q ? or(like(schema.links.slug, `%${q}%`), like(schema.links.destination, `%${q}%`)) : undefined,
+    onlySuspended ? isNotNull(schema.links.suspendedAt) : undefined,
+  ].filter(Boolean);
+
+  const rows = await db
+    .select({
+      id: schema.links.id,
+      slug: schema.links.slug,
+      domain: schema.domains.hostname,
+      destination: schema.links.destination,
+      orgId: schema.links.orgId,
+      orgName: schema.orgs.name,
+      createdBy: schema.links.createdBy,
+      createdAt: schema.links.createdAt,
+      clicks: clickCount,
+      suspendedAt: schema.links.suspendedAt,
+      suspendReason: schema.links.suspendReason,
+      riskScore: schema.links.riskScore,
+      riskReasons: schema.links.riskReasons,
+      riskCheckedAt: schema.links.riskCheckedAt,
+    })
+    .from(schema.links)
+    .innerJoin(schema.orgs, eq(schema.links.orgId, schema.orgs.id))
+    .leftJoin(schema.domains, eq(schema.links.domainId, schema.domains.id))
+    .where(filters.length ? and(...filters) : undefined)
+    // Nulls last on risk: unscored is not "safe", and letting it sort above a
+    // score of 100 would put the worst links below links nobody has looked at.
+    .orderBy(
+      sort === "clicks"
+        ? desc(clickCount)
+        : sort === "risk"
+          ? sql`${schema.links.riskScore} is null, ${schema.links.riskScore} desc`
+          : desc(schema.links.createdAt),
+    )
+    .limit(MAX_ROWS);
+
+  return c.json(
+    rows.map((r) => ({ ...r, riskReasons: parseReasons(r.riskReasons) })) satisfies AdminLinkRow[],
+  );
+});
+
+async function setSuspended(
+  c: Context<AppEnv>,
+  linkId: string,
+  suspend: boolean,
+  reason: string | null,
+) {
+  const db = c.var.db;
+  const rows = await db.select().from(schema.links).where(eq(schema.links.id, linkId));
+  const link = rows[0];
+  if (!link) throw new HTTPException(404, { message: "Link not found" });
+
+  await db
+    .update(schema.links)
+    .set({
+      suspendedAt: suspend ? Date.now() : null,
+      suspendedBy: suspend ? c.var.user!.id : null,
+      suspendReason: suspend ? reason : null,
+    })
+    .where(eq(schema.links.id, linkId));
+
+  const addresses = await republish(c.env, db, linkId);
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: suspend ? "link.suspend" : "link.unsuspend",
+    targetType: "link",
+    targetId: linkId,
+    // The slug and org travel with the entry: the row may be deleted later,
+    // and "suspended some link" is not an audit trail.
+    detail: {
+      slug: link.slug,
+      orgId: link.orgId,
+      destination: link.destination,
+      reason,
+      addresses,
+    },
+  });
+  return { addresses };
+}
+
+adminLinkRoutes.post("/:linkId/suspend", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as { reason?: unknown };
+  const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, 500) : "";
+  if (!reason) throw new HTTPException(400, { message: "A reason is required" });
+  return c.json(await setSuspended(c, c.req.param("linkId")!, true, reason));
+});
+
+adminLinkRoutes.post("/:linkId/unsuspend", async (c) =>
+  c.json(await setSuspended(c, c.req.param("linkId")!, false, null)),
+);
+
+/**
+ * Suspend or restore every link in one org, without deleting it.
+ *
+ * For when the whole account is bad but the evidence should survive and an
+ * appeal should be possible. Deleting the org is still available and still
+ * irreversible; this is the reversible version.
+ */
+adminLinkRoutes.post("/orgs/:orgId/suspend", async (c) => {
+  const suspend = c.req.query("suspend") !== "0";
+  const body = (await c.req.json().catch(() => ({}))) as { reason?: unknown };
+  const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, 500) : "";
+  if (suspend && !reason) throw new HTTPException(400, { message: "A reason is required" });
+
+  const db = c.var.db;
+  const orgId = c.req.param("orgId")!;
+  const links = await db
+    .select({ id: schema.links.id })
+    .from(schema.links)
+    .where(
+      and(
+        eq(schema.links.orgId, orgId),
+        suspend ? isNull(schema.links.suspendedAt) : isNotNull(schema.links.suspendedAt),
+      ),
+    );
+
+  if (links.length > 0) {
+    await db
+      .update(schema.links)
+      .set({
+        suspendedAt: suspend ? Date.now() : null,
+        suspendedBy: suspend ? c.var.user!.id : null,
+        suspendReason: suspend ? reason : null,
+      })
+      .where(
+        and(
+          eq(schema.links.orgId, orgId),
+          suspend ? isNull(schema.links.suspendedAt) : isNotNull(schema.links.suspendedAt),
+        ),
+      );
+    // One republish per link, after the flag is written, so a message
+    // consumed early cannot read the old value.
+    for (const link of links) await republish(c.env, db, link.id);
+  }
+
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: suspend ? "org.suspend_links" : "org.unsuspend_links",
+    targetType: "org",
+    targetId: orgId,
+    detail: { count: links.length, reason },
+  });
+  return c.json({ count: links.length });
+});
+
+/**
+ * Anonymous links from the landing page (Direction A of #96).
+ *
+ * They live in their own table with no org and no owner, so they cannot
+ * appear in the list above, but an abuse report naming a slug will not know
+ * or care which table it came from. Listed here so there is one screen to
+ * check.
+ *
+ * Deleting one is the only action: they expire in 24 hours anyway, and
+ * suspending something that is about to vanish is bookkeeping nobody reads.
+ */
+adminLinkRoutes.get("/anonymous", async (c) => {
+  const rows = await c.var.db
+    .select({
+      id: schema.anonLinks.id,
+      slug: schema.anonLinks.slug,
+      destination: schema.anonLinks.destination,
+      createdAt: schema.anonLinks.createdAt,
+      expiresAt: schema.anonLinks.expiresAt,
+      riskScore: schema.anonLinks.riskScore,
+      riskReasons: schema.anonLinks.riskReasons,
+    })
+    .from(schema.anonLinks)
+    .orderBy(desc(schema.anonLinks.createdAt))
+    .limit(MAX_ROWS);
+
+  return c.json(
+    rows.map((r) => ({
+      ...r,
+      riskReasons: parseReasons(r.riskReasons),
+    })) satisfies AdminAnonLinkRow[],
+  );
+});
+
+adminLinkRoutes.delete("/anonymous/:id", async (c) => {
+  const db = c.var.db;
+  const id = c.req.param("id")!;
+  const rows = await db.select().from(schema.anonLinks).where(eq(schema.anonLinks.id, id));
+  const anon = rows[0];
+  if (!anon) throw new HTTPException(404, { message: "Link not found" });
+
+  await db.delete(schema.anonLinks).where(eq(schema.anonLinks.id, id));
+  // The row is gone, so the KV key would resolve to nothing on its next
+  // sync; this makes that immediate rather than eventual.
+  await enqueueStorage(c.env, [syncLinkMsg(anon.slug, null)]);
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: "anon_link.delete",
+    targetType: "anon_link",
+    targetId: id,
+    detail: { slug: anon.slug, destination: anon.destination },
+  });
+  return c.json({ ok: true });
+});
+
+/** The audit log, newest first, optionally narrowed to one target. */
+adminLinkRoutes.get("/audit", async (c) => {
+  const db = c.var.db;
+  const targetType = c.req.query("targetType");
+  const targetId = c.req.query("targetId");
+  const rows = await db
+    .select({
+      id: schema.adminActions.id,
+      actorUserId: schema.adminActions.actorUserId,
+      actorEmail: schema.user.email,
+      action: schema.adminActions.action,
+      targetType: schema.adminActions.targetType,
+      targetId: schema.adminActions.targetId,
+      detail: schema.adminActions.detail,
+      createdAt: schema.adminActions.createdAt,
+    })
+    .from(schema.adminActions)
+    // Left join: the actor may have been deleted since, and the entry has to
+    // outlive them. That is why the table holds no foreign key.
+    .leftJoin(schema.user, eq(schema.user.id, schema.adminActions.actorUserId))
+    .where(
+      targetType && targetId
+        ? and(
+            eq(schema.adminActions.targetType, targetType),
+            eq(schema.adminActions.targetId, targetId),
+          )
+        : undefined,
+    )
+    .orderBy(desc(schema.adminActions.createdAt))
+    .limit(MAX_ROWS);
+  return c.json(rows satisfies AdminActionRow[]);
+});

--- a/src/worker/routes/admin-links.ts
+++ b/src/worker/routes/admin-links.ts
@@ -21,6 +21,7 @@ import * as schema from "../db/schema";
 import type { AppEnv, DB, Env } from "../env";
 import { enqueueStorage, syncLinkMsg } from "../storage";
 import { recordAdminAction } from "../audit";
+import { scoreDestination } from "../risk";
 import { jsonBodyLimit } from "../body-limit";
 import {
   ADMIN_LINK_SORTS,
@@ -196,6 +197,55 @@ adminLinkRoutes.post("/:linkId/suspend", async (c) =>
 adminLinkRoutes.post("/:linkId/unsuspend", async (c) =>
   c.json(await setSuspended(c, c.req.param("linkId")!, false, null)),
 );
+
+/**
+ * Re-run the destination check on demand (#68).
+ *
+ * Awaited rather than deferred to waitUntil, unlike the checks on create and
+ * edit: an admin who asked for this is looking at the row and wants the
+ * answer, not a promise that something will happen shortly. One DNS lookup
+ * with a three second ceiling.
+ *
+ * Recorded in the audit log because it writes to the row. Reconstructing why
+ * a score changed is exactly what that log is for, and "somebody re-checked
+ * it at 02:14" is part of the answer.
+ */
+adminLinkRoutes.post("/:linkId/rescore", async (c) => {
+  const db = c.var.db;
+  const linkId = c.req.param("linkId")!;
+  const rows = await db.select().from(schema.links).where(eq(schema.links.id, linkId));
+  const link = rows[0];
+  if (!link) throw new HTTPException(404, { message: "Link not found" });
+
+  const verdict = await scoreDestination(link.destination);
+  if (verdict)
+    await db
+      .update(schema.links)
+      .set({
+        riskScore: verdict.score,
+        riskReasons: JSON.stringify(verdict.reasons),
+        riskCheckedAt: Date.now(),
+        riskProvider: verdict.provider,
+      })
+      .where(eq(schema.links.id, linkId));
+
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: "link.rescore",
+    targetType: "link",
+    targetId: linkId,
+    detail: { slug: link.slug, destination: link.destination, score: verdict?.score ?? null },
+  });
+
+  // A null verdict is "still unscored", never "clean": the provider was
+  // unreachable or answered something we do not recognise, and the row keeps
+  // whatever it had.
+  return c.json({
+    scored: !!verdict,
+    score: verdict?.score ?? null,
+    reasons: verdict?.reasons ?? [],
+  });
+});
 
 /**
  * Delete a link outright.

--- a/src/worker/routes/admin-links.ts
+++ b/src/worker/routes/admin-links.ts
@@ -45,6 +45,25 @@ function parseReasons(raw: string | null): string[] {
   }
 }
 
+/** The columns a suspension writes, or clears. Shared by the single-link and
+ * whole-org routes so the two can never set them differently. */
+function suspensionPatch(suspend: boolean, actorId: string, reason: string | null) {
+  return {
+    suspendedAt: suspend ? Date.now() : null,
+    suspendedBy: suspend ? actorId : null,
+    suspendReason: suspend ? reason : null,
+  };
+}
+
+/** The reason a moderation action must carry. Suspending without one leaves
+ * a decision nobody can account for later. */
+async function requiredReason(c: Context<AppEnv>, required: boolean): Promise<string> {
+  const body = (await c.req.json().catch(() => ({}))) as { reason?: unknown };
+  const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, 500) : "";
+  if (required && !reason) throw new HTTPException(400, { message: "A reason is required" });
+  return reason;
+}
+
 const clickCount = sql<number>`(
   select count(*) from clicks where clicks.link_id = links.id
 )`;
@@ -148,11 +167,7 @@ async function setSuspended(
 
   await db
     .update(schema.links)
-    .set({
-      suspendedAt: suspend ? Date.now() : null,
-      suspendedBy: suspend ? c.var.user!.id : null,
-      suspendReason: suspend ? reason : null,
-    })
+    .set(suspensionPatch(suspend, c.var.user!.id, reason))
     .where(eq(schema.links.id, linkId));
 
   const addresses = await republish(c.env, db, linkId);
@@ -174,12 +189,9 @@ async function setSuspended(
   return { addresses };
 }
 
-adminLinkRoutes.post("/:linkId/suspend", async (c) => {
-  const body = (await c.req.json().catch(() => ({}))) as { reason?: unknown };
-  const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, 500) : "";
-  if (!reason) throw new HTTPException(400, { message: "A reason is required" });
-  return c.json(await setSuspended(c, c.req.param("linkId")!, true, reason));
-});
+adminLinkRoutes.post("/:linkId/suspend", async (c) =>
+  c.json(await setSuspended(c, c.req.param("linkId")!, true, await requiredReason(c, true))),
+);
 
 adminLinkRoutes.post("/:linkId/unsuspend", async (c) =>
   c.json(await setSuspended(c, c.req.param("linkId")!, false, null)),
@@ -194,39 +206,27 @@ adminLinkRoutes.post("/:linkId/unsuspend", async (c) =>
  */
 adminLinkRoutes.post("/orgs/:orgId/suspend", async (c) => {
   const suspend = c.req.query("suspend") !== "0";
-  const body = (await c.req.json().catch(() => ({}))) as { reason?: unknown };
-  const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, 500) : "";
-  if (suspend && !reason) throw new HTTPException(400, { message: "A reason is required" });
+  const reason = await requiredReason(c, suspend);
 
   const db = c.var.db;
   const orgId = c.req.param("orgId")!;
-  const links = await db
-    .select({ id: schema.links.id })
-    .from(schema.links)
-    .where(
-      and(
-        eq(schema.links.orgId, orgId),
-        suspend ? isNull(schema.links.suspendedAt) : isNotNull(schema.links.suspendedAt),
-      ),
-    );
+  // One expression, used to select and then to update: built twice they can
+  // drift, and a drift here means updating rows the count never mentioned.
+  const affected = and(
+    eq(schema.links.orgId, orgId),
+    suspend ? isNull(schema.links.suspendedAt) : isNotNull(schema.links.suspendedAt),
+  );
+  const links = await db.select({ id: schema.links.id }).from(schema.links).where(affected);
 
   if (links.length > 0) {
     await db
       .update(schema.links)
-      .set({
-        suspendedAt: suspend ? Date.now() : null,
-        suspendedBy: suspend ? c.var.user!.id : null,
-        suspendReason: suspend ? reason : null,
-      })
-      .where(
-        and(
-          eq(schema.links.orgId, orgId),
-          suspend ? isNull(schema.links.suspendedAt) : isNotNull(schema.links.suspendedAt),
-        ),
-      );
-    // One republish per link, after the flag is written, so a message
-    // consumed early cannot read the old value.
-    for (const link of links) await republish(c.env, db, link.id);
+      .set(suspensionPatch(suspend, c.var.user!.id, reason))
+      .where(affected);
+    // After the flag is written, so a message consumed early cannot read the
+    // old value. Together rather than in series: an org can hold thousands of
+    // links, and these are independent queue sends.
+    await Promise.all(links.map((link) => republish(c.env, db, link.id)));
   }
 
   await recordAdminAction(c.env, {

--- a/src/worker/routes/admin-links.ts
+++ b/src/worker/routes/admin-links.ts
@@ -85,6 +85,41 @@ async function addressesOf(db: DB, linkId: string) {
     .where(and(eq(schema.linkAddresses.linkId, linkId), isNull(schema.linkAddresses.retiredAt)));
 }
 
+/** Cloudflare caps a queue send at 100 messages. */
+const QUEUE_BATCH = 100;
+
+/**
+ * Republishes every address the org owns, in a fixed number of round trips.
+ *
+ * One query and one send per link does not survive the size of org this is
+ * for. At the Pro cap of 3,000 links it asked D1 for 3,002 statements and
+ * made 3,000 queue sends, past both D1's 1,000-query invocation limit and
+ * the subrequest ceiling: the request died partway, *after* the suspension
+ * flag was committed. An admin got an error, the links were flagged
+ * suspended in D1, and the ones whose messages never went out kept
+ * redirecting, with nothing scheduled to notice. The one control meant for
+ * the worst accounts failed on exactly the biggest ones.
+ *
+ * Every address in one query, then sends of at most a hundred: 3,000 links
+ * become 31 round trips rather than 6,002. Republishing an address whose
+ * link was already in the right state costs nothing, because the consumer
+ * reads the current row and writes what it should be, so this does not need
+ * to know which links the update actually touched.
+ */
+async function republishOrg(env: Env, db: DB, orgId: string): Promise<void> {
+  const addresses = await db
+    .select({ slug: schema.linkAddresses.slug, hostname: schema.domains.hostname })
+    .from(schema.linkAddresses)
+    .innerJoin(schema.links, eq(schema.linkAddresses.linkId, schema.links.id))
+    .leftJoin(schema.domains, eq(schema.linkAddresses.domainId, schema.domains.id))
+    .where(and(eq(schema.links.orgId, orgId), isNull(schema.linkAddresses.retiredAt)));
+
+  const batches: Array<ReturnType<typeof syncLinkMsg>[]> = [];
+  for (let i = 0; i < addresses.length; i += QUEUE_BATCH)
+    batches.push(addresses.slice(i, i + QUEUE_BATCH).map((a) => syncLinkMsg(a.slug, a.hostname)));
+  await Promise.all(batches.map((batch) => enqueueStorage(env, batch)));
+}
+
 async function republish(env: Env, db: DB, linkId: string): Promise<number> {
   const addresses = await addressesOf(db, linkId);
   if (addresses.length > 0)
@@ -314,9 +349,8 @@ adminLinkRoutes.post("/orgs/:orgId/suspend", async (c) => {
       .set(suspensionPatch(suspend, c.var.user!.id, reason))
       .where(affected);
     // After the flag is written, so a message consumed early cannot read the
-    // old value. Together rather than in series: an org can hold thousands of
-    // links, and these are independent queue sends.
-    await Promise.all(links.map((link) => republish(c.env, db, link.id)));
+    // old value.
+    await republishOrg(c.env, db, orgId);
   }
 
   await recordAdminAction(c.env, {

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -17,6 +17,8 @@ import { fillSeries, computeDelta, deleteOrg } from "./orgs";
 import { orgPlan } from "../plan";
 import { effectivePlanSql, subscriptionGrantsAccess } from "../entitlement";
 import { jsonBodyLimit } from "../body-limit";
+import { adminLinkRoutes } from "./admin-links";
+import { recordAdminAction } from "../audit";
 
 // An org's effective plan is its owner's plan (billing is per-user). A single
 // correlated subquery pulls it for list views. Note: `user` is a SQL keyword,
@@ -43,9 +45,16 @@ const ownerEmail = sql<string | null>`(
 
 // Mounted at /api/admin: platform-level views for the instance admin.
 export const adminRoutes = new Hono<AppEnv>();
+
 adminRoutes.use("*", jsonBodyLimit());
 
 adminRoutes.use("*", requireAdmin);
+
+// Mounted after requireAdmin, and that order is the whole security of it:
+// Hono applies middleware registered before a route, so a sub-router mounted
+// above this line is reachable by any signed-in user. It was, briefly, and a
+// test caught it (#67).
+adminRoutes.route("/links", adminLinkRoutes);
 
 const day = sql<string>`date(ts / 1000, 'unixepoch')`;
 const userDay = sql<string>`date(created_at / 1000, 'unixepoch')`;
@@ -590,7 +599,21 @@ adminRoutes.get("/orgs/:orgId", async (c) => {
 });
 
 adminRoutes.delete("/orgs/:orgId", async (c) => {
-  await deleteOrg(c.var.db, c.env, c.req.param("orgId"));
+  const orgId = c.req.param("orgId");
+  // Read the name before the teardown removes it: an audit entry saying
+  // which org was deleted is the entire value of the entry (#67).
+  const rows = await c.var.db
+    .select({ name: schema.orgs.name })
+    .from(schema.orgs)
+    .where(eq(schema.orgs.id, orgId));
+  await deleteOrg(c.var.db, c.env, orgId);
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: "org.delete",
+    targetType: "org",
+    targetId: orgId,
+    detail: { name: rows[0]?.name ?? null },
+  });
   return c.json({ ok: true });
 });
 
@@ -701,6 +724,14 @@ adminRoutes.patch("/users/:userId", async (c) => {
   // Banning kicks the user out immediately: all their sessions are wiped, and
   // better-auth refuses to create new ones (see better-auth.ts).
   if (patch.banned) await db.delete(schema.session).where(eq(schema.session.userId, targetId));
+  if (patch.banned !== undefined)
+    await recordAdminAction(c.env, {
+      actorUserId: self.id,
+      action: patch.banned ? "user.ban" : "user.unban",
+      targetType: "user",
+      targetId: targetId,
+      detail: { isAdminChanged: patch.isAdmin !== undefined },
+    });
   return c.json({ ok: true });
 });
 
@@ -751,6 +782,13 @@ adminRoutes.post("/users/:userId/comp", async (c) => {
     reason,
     grantedBy: c.var.user!.id,
   });
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: "user.comp_grant",
+    targetType: "user",
+    targetId: c.req.param("userId")!,
+    detail: { plan, reason },
+  });
   return c.json({ ok: true });
 });
 
@@ -758,6 +796,12 @@ adminRoutes.post("/users/:userId/comp", async (c) => {
  * `plan` re-derives from the columns the webhook owns. */
 adminRoutes.delete("/users/:userId/comp", async (c) => {
   await writeComp(c.var.db, c.req.param("userId"), null);
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: "user.comp_revoke",
+    targetType: "user",
+    targetId: c.req.param("userId")!,
+  });
   return c.json({ ok: true });
 });
 
@@ -774,8 +818,21 @@ adminRoutes.delete("/users/:userId", async (c) => {
     throw new HTTPException(409, {
       message: "User owns organizations, delete those orgs first",
     });
+  // Read the address first: the entry has to say who was deleted, and after
+  // this statement there is nowhere left to look it up (#67).
+  const target = await db
+    .select({ email: schema.user.email })
+    .from(schema.user)
+    .where(eq(schema.user.id, targetId));
   // sessions/accounts/org memberships cascade; authored links/invites keep
   // created_by NULL (ON DELETE SET NULL)
   await db.delete(schema.user).where(eq(schema.user.id, targetId));
+  await recordAdminAction(c.env, {
+    actorUserId: c.var.user!.id,
+    action: "user.delete",
+    targetType: "user",
+    targetId: targetId,
+    detail: { email: target[0]?.email ?? null },
+  });
   return c.json({ ok: true });
 });

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -583,6 +583,10 @@ function newLinkRow(
     riskReasons: null,
     riskCheckedAt: null,
     riskProvider: null,
+    // New links are never born suspended; only an admin sets this (#67).
+    suspendedAt: null,
+    suspendedBy: null,
+    suspendReason: null,
   };
 }
 

--- a/src/worker/routes/shorten.ts
+++ b/src/worker/routes/shorten.ts
@@ -236,6 +236,10 @@ export async function claimAnonLink(
     riskReasons: anon.riskReasons,
     riskCheckedAt: anon.riskCheckedAt,
     riskProvider: anon.riskProvider,
+    // New links are never born suspended; only an admin sets this (#67).
+    suspendedAt: null,
+    suspendedBy: null,
+    suspendReason: null,
   };
   const address = {
     id: uid(),

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -117,6 +117,11 @@ async function desiredKvValue(db: DB, key: string): Promise<string | null> {
         and(
           eq(schema.linkAddresses.slug, slug),
           isNull(schema.linkAddresses.retiredAt),
+          // Suspension is enforced here and nowhere else (#67). Every
+          // republish runs through this function, so a suspended link stays
+          // dark through any later edit, rename, or alias change. A check in
+          // the suspend route alone would be undone by the next save.
+          isNull(schema.links.suspendedAt),
           hostname === null
             ? isNull(schema.linkAddresses.domainId)
             : eq(schema.domains.hostname, hostname),

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -45,6 +45,7 @@ export const RESERVED_SLUGS = new Set([
   "domains",
   "settings",
   "admin",
+  "audit",
 ]);
 
 const UTM_KEYS = [

--- a/tests/e2e/admin-moderation.pw.ts
+++ b/tests/e2e/admin-moderation.pw.ts
@@ -59,11 +59,14 @@ test("an admin can find a link by destination and suspend it", async ({ page }) 
   await expect(page).toHaveURL(/\/admin\/links$/);
   await expect(page.getByRole("heading", { name: "Links" })).toBeVisible();
 
-  await page.getByPlaceholder(/Slug or destination/).fill(destination);
+  await page.getByRole("textbox", { name: "Search links" }).fill(destination);
   const row = page.getByRole("row").filter({ hasText: slug });
   await expect(row).toBeVisible({ timeout: 10_000 });
 
-  await row.getByRole("button", { name: "Suspend" }).click();
+  // Suspend lives in the row's actions menu, next to restore and delete,
+  // rather than as a button of its own on every row.
+  await row.getByRole("button", { name: `Actions for ${slug}` }).click();
+  await page.getByRole("menuitem", { name: "Suspend link" }).click();
   const dialog = page.getByRole("dialog", { name: "Suspend this link" });
   await expect(dialog).toBeVisible();
   // A suspension with no reason is not answerable later, so it is refused.
@@ -117,15 +120,15 @@ test("anonymous links and the audit log are reachable, not buried under the list
   // being there at all.
   const email = `admin-nav-${Date.now()}@gmail.com`;
   await signUpAndVerify(page, email, password);
-  await createOrg(page, "Nav Org");
   await makePlatformAdmin(page, email);
 
   await page.goto("/admin/links");
   await page.getByRole("button", { name: "Anonymous" }).click();
-  await expect(page.getByText("Anonymous links")).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Search anonymous links" })).toBeVisible();
 
-  // And the big table is out of the way while it is open.
-  await expect(page.getByPlaceholder(/Slug or destination/)).toHaveCount(0);
+  // And the big table is out of the way while it is open. Both searches carry
+  // the same placeholder, so the label is what tells them apart.
+  await expect(page.getByRole("textbox", { name: "Search links" })).toHaveCount(0);
 
   await page
     .getByRole("navigation", { name: "Platform sections" })

--- a/tests/e2e/admin-moderation.pw.ts
+++ b/tests/e2e/admin-moderation.pw.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
+import { createOrg } from "./orgs";
+import { makePlatformAdmin, queryRows } from "./db";
+
+/**
+ * Admin link moderation through the screen an admin actually uses (#67).
+ *
+ * The worker tests cover enforcement. This covers the part only a browser
+ * can: that somebody holding an abuse report can find the link by its
+ * destination, stop it, and see that it stopped.
+ */
+
+const password = "test-password-123";
+
+test("an admin can find a link by destination and suspend it", async ({ page }) => {
+  // A normal account with a link to be reported.
+  const ownerEmail = `owner-${Date.now()}@gmail.com`;
+  const destination = `https://phishy-${Date.now()}.example/login`;
+  await signUpAndVerify(page, ownerEmail, password);
+  await createOrg(page, "Reported Org");
+
+  const field = page.getByPlaceholder("https://example.com/launch").first();
+  await expect(field).toBeVisible();
+  await field.fill(destination);
+  await page.getByRole("button", { name: "Create link" }).click();
+  await expect(page.getByRole("dialog", { name: "Link created" })).toBeVisible();
+
+  const slug = (
+    await queryRows<{ slug: string }>(page, "select slug from links where destination = ?", [
+      destination,
+    ])
+  )[0].slug;
+
+  // The link redirects, which is the thing suspension has to stop. Polled,
+  // because publishing rides the storage queue and is eventual by design.
+  await expect
+    .poll(async () => (await page.request.get(`/${slug}`, { maxRedirects: 0 })).status(), {
+      timeout: 15_000,
+      message: "the link never started redirecting",
+    })
+    .toBe(302);
+
+  // Now an admin, holding the report.
+  await makePlatformAdmin(page, ownerEmail);
+  await page.goto("/admin/links");
+  await expect(page.getByRole("heading", { name: "Links" })).toBeVisible();
+
+  await page.getByPlaceholder(/Slug or destination/).fill(destination);
+  const row = page.getByRole("row").filter({ hasText: slug });
+  await expect(row).toBeVisible({ timeout: 10_000 });
+
+  await row.getByRole("button", { name: "Suspend" }).click();
+  const dialog = page.getByRole("dialog", { name: "Suspend this link" });
+  await expect(dialog).toBeVisible();
+  // A suspension with no reason is not answerable later, so it is refused.
+  await expect(dialog.getByRole("button", { name: "Suspend link" })).toBeDisabled();
+  await dialog.getByLabel("Reason").fill("phishing report, ticket 412");
+  await dialog.getByRole("button", { name: "Suspend link" }).click();
+
+  await expect(page.getByText("suspended").first()).toBeVisible({ timeout: 10_000 });
+
+  // The redirect is gone, and the row and its clicks are not.
+  await expect
+    .poll(async () => (await page.request.get(`/${slug}`, { maxRedirects: 0 })).status(), {
+      timeout: 15_000,
+    })
+    .not.toBe(302);
+
+  const rows = await queryRows<{ n: number }>(
+    page,
+    "select count(*) as n from links where slug = ?",
+    [slug],
+  );
+  expect(Number(rows[0].n)).toBe(1);
+
+  // And it is answerable: the audit log names the action and the reason.
+  await expect(page.getByText("link.suspend").first()).toBeVisible();
+  await expect(page.getByText(/ticket 412/).first()).toBeVisible();
+});
+
+test("the Links tab is invisible and unreachable for a normal user", async ({ page }) => {
+  await signUpAndVerify(page, `plain-${Date.now()}@gmail.com`, password);
+  await createOrg(page, "Plain Org");
+
+  // By href, not by label: the app's own "Links" tab is called that too, and
+  // a name-based assertion would pass for the wrong reason.
+  await expect(page.locator('a[href="/admin/links"]')).toHaveCount(0);
+
+  // 404, not 403: a 403 would confirm the route exists.
+  const res = await page.request.get("/api/admin/links");
+  expect(res.status()).toBe(404);
+});

--- a/tests/e2e/admin-moderation.pw.ts
+++ b/tests/e2e/admin-moderation.pw.ts
@@ -43,7 +43,20 @@ test("an admin can find a link by destination and suspend it", async ({ page }) 
 
   // Now an admin, holding the report.
   await makePlatformAdmin(page, ownerEmail);
-  await page.goto("/admin/links");
+
+  // Reached the way an admin reaches it: one Platform entry in the sidebar,
+  // then the section tabs. Four sidebar entries put "Links" there twice
+  // meaning two different things.
+  await page.goto("/dashboard");
+  await page.getByRole("link", { name: "Platform" }).click();
+  // Scoped to the section tabs: the sidebar's own "Links" (the current
+  // organization's) is still on screen, and that ambiguity is why the four
+  // platform entries came out of the sidebar in the first place.
+  await page
+    .getByRole("navigation", { name: "Platform sections" })
+    .getByRole("link", { name: "Links" })
+    .click();
+  await expect(page).toHaveURL(/\/admin\/links$/);
   await expect(page.getByRole("heading", { name: "Links" })).toBeVisible();
 
   await page.getByPlaceholder(/Slug or destination/).fill(destination);
@@ -74,7 +87,12 @@ test("an admin can find a link by destination and suspend it", async ({ page }) 
   );
   expect(Number(rows[0].n)).toBe(1);
 
-  // And it is answerable: the audit log names the action and the reason.
+  // And it is answerable. The log is its own section, since it records bans
+  // and org deletions too, not only link actions.
+  await page
+    .getByRole("navigation", { name: "Platform sections" })
+    .getByRole("link", { name: "Audit log" })
+    .click();
   await expect(page.getByText("link.suspend").first()).toBeVisible();
   await expect(page.getByText(/ticket 412/).first()).toBeVisible();
 });
@@ -90,4 +108,51 @@ test("the Links tab is invisible and unreachable for a normal user", async ({ pa
   // 404, not 403: a 403 would confirm the route exists.
   const res = await page.request.get("/api/admin/links");
   expect(res.status()).toBe(404);
+});
+
+test("anonymous links and the audit log are reachable, not buried under the list (#67)", async ({
+  page,
+}) => {
+  // They used to sit below up to 200 link rows, which is the same as not
+  // being there at all.
+  const email = `admin-nav-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, email, password);
+  await createOrg(page, "Nav Org");
+  await makePlatformAdmin(page, email);
+
+  await page.goto("/admin/links");
+  await page.getByRole("button", { name: "Anonymous" }).click();
+  await expect(page.getByText("Anonymous links")).toBeVisible();
+
+  // And the big table is out of the way while it is open.
+  await expect(page.getByPlaceholder(/Slug or destination/)).toHaveCount(0);
+
+  await page
+    .getByRole("navigation", { name: "Platform sections" })
+    .getByRole("link", { name: "Audit log" })
+    .click();
+  await expect(page.getByRole("heading", { name: "Audit log" })).toBeVisible();
+});
+
+test("the platform table fits its card instead of running off the side", async ({ page }) => {
+  // An auto-layout table lets a long destination set the column width and
+  // push the row past the card, and `max-w` on the cell does nothing about
+  // it. Asserted as "the page never scrolls sideways", which is the symptom.
+  const email = `admin-layout-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, email, password);
+  await createOrg(page, "Layout Org");
+
+  const field = page.getByPlaceholder("https://example.com/launch").first();
+  await field.fill(`https://example.com/${"a-very-long-path-segment-".repeat(6)}end`);
+  await page.getByRole("button", { name: "Create link" }).click();
+  await expect(page.getByRole("dialog", { name: "Link created" })).toBeVisible();
+
+  await makePlatformAdmin(page, email);
+  await page.goto("/admin/links");
+  await expect(page.getByRole("heading", { name: "Links" })).toBeVisible();
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
 });

--- a/tests/e2e/anon-shortener.pw.ts
+++ b/tests/e2e/anon-shortener.pw.ts
@@ -52,9 +52,14 @@ test("an anonymous link records no clicks, which is what signing up buys", async
   await page.request.get(`/${slug}`, { maxRedirects: 0 });
   await page.waitForTimeout(1000);
 
-  // No org and no links row means nothing a click could belong to. The
-  // absence is the product boundary, not an oversight.
-  const clicks = await queryRows<{ n: number }>(page, "select count(*) as n from clicks");
+  // Scoped to clicks belonging to no real link, which is the only shape an
+  // anonymous click could take. Counting every row in the table made this
+  // depend on whatever else the suite had done, and it started failing the
+  // day another test created a click of its own.
+  const clicks = await queryRows<{ n: number }>(
+    page,
+    "select count(*) as n from clicks where link_id not in (select id from links)",
+  );
   expect(Number(clicks[0].n)).toBe(0);
 });
 

--- a/tests/e2e/resend.ts
+++ b/tests/e2e/resend.ts
@@ -51,9 +51,14 @@ export async function signUpAndVerify(page: Page, email: string, password: strin
   await page.getByLabel("Password").fill(password);
   await page.getByRole("button", { name: "Sign up" }).click();
 
-  await expect(page.getByRole("heading", { name: "Enter your code" })).toBeVisible();
+  // Not the default 5s: a sign-up here is a Cap proof-of-work solve, an
+  // account write and a mail send, and with the suite running in parallel
+  // that round trip regularly outlasts five seconds. Every caller of this
+  // helper was failing here for that reason and no other.
+  const codeScreen = page.getByRole("heading", { name: "Enter your code" });
+  await expect(codeScreen).toBeVisible({ timeout: 30_000 });
   await page.reload();
-  await expect(page.getByRole("heading", { name: "Enter your code" })).toBeVisible();
+  await expect(codeScreen).toBeVisible({ timeout: 30_000 });
   const otp = await latestOtp(page, email);
   await page.locator("input").first().focus();
   await page.keyboard.insertText(otp);

--- a/tests/worker/admin-moderation.worker.ts
+++ b/tests/worker/admin-moderation.worker.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { reset } from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "../../src/worker/db/schema";
+import { applyStorageMessage, syncLinkMsg } from "../../src/worker/storage";
+import { adminCookie, applyTestMigrations, authEnv, fetchWorker, freeOwnerCookie } from "./support";
+
+/**
+ * Admin link moderation (#67).
+ *
+ * The assertion that matters most is that a suspended link stays suspended
+ * after a later edit. Suspension is enforced in desiredKvValue, which every
+ * republish runs through; a check in the suspend route alone would be undone
+ * by the next save, silently, and the link would be live again with nobody
+ * having asked for it.
+ */
+
+async function createLink(cookie: string, destination = "https://example.com/one") {
+  const res = await fetchWorker(
+    new Request("http://localhost/api/orgs/org-1/links", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ destination }),
+    }),
+  );
+  return (await res.json()) as { id: string; slug: string };
+}
+
+const admin = (path: string, cookie: string, init: RequestInit = {}) =>
+  fetchWorker(
+    new Request(`http://localhost/api/admin${path}`, {
+      ...init,
+      headers: { cookie, "content-type": "application/json", ...(init.headers ?? {}) },
+    }),
+  );
+
+/**
+ * Storage messages ride a queue that nothing consumes in these tests, so a
+ * publish only reaches KV when it is applied by hand. Applying it is also
+ * exactly what proves the point: the route enqueues, and desiredKvValue is
+ * what decides whether the key survives.
+ */
+async function syncKv(...slugs: string[]) {
+  for (const slug of slugs)
+    await applyStorageMessage(env as never, drizzle(env.DB, { schema }), syncLinkMsg(slug, null));
+}
+
+/** What the redirect path would find: KV is the only thing that decides. */
+const kvFor = (slug: string) => env.LINKS.get(`slug:${slug}`);
+
+/** Every live slug a link answers on. */
+async function slugsOf(linkId: string): Promise<string[]> {
+  const { results } = await env.DB.prepare(
+    "select slug from link_addresses where link_id = ? and retired_at is null",
+  )
+    .bind(linkId)
+    .all<{ slug: string }>();
+  return results.map((r) => r.slug);
+}
+
+const realFetch = globalThis.fetch;
+
+beforeEach(async () => {
+  reset();
+  await applyTestMigrations();
+  // The destination scorer (#68) runs on create through waitUntil and would
+  // otherwise reach the real resolver and write real scores, which the risk
+  // sort test then has to fight.
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (url.startsWith("https://security.cloudflare-dns.com")) throw new Error("offline");
+    return realFetch(input);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Create a link and publish its keys, so KV reflects a live link. */
+async function createLiveLink(cookie: string, destination?: string) {
+  const link = await createLink(cookie, destination);
+  await syncKv(...(await slugsOf(link.id)));
+  return link;
+}
+
+/** Call a moderation route, then apply the republishes it enqueued. */
+async function moderate(path: string, cookie: string, body?: object, linkIds: string[] = []) {
+  const res = await admin(path, cookie, {
+    method: "POST",
+    body: JSON.stringify(body ?? {}),
+  });
+  for (const id of linkIds) await syncKv(...(await slugsOf(id)));
+  return res;
+}
+
+describe("suspending one link", () => {
+  it("stops the redirect and records who did it", async () => {
+    const owner = await freeOwnerCookie();
+    const link = await createLiveLink(owner);
+    expect(await kvFor(link.slug)).toBeTruthy();
+
+    const cookie = await adminCookie();
+    const res = await moderate(
+      `/links/${link.id}/suspend`,
+      cookie,
+      { reason: "phishing report #412" },
+      [link.id],
+    );
+    expect(res.status).toBe(200);
+    expect(await kvFor(link.slug)).toBeNull();
+
+    const audit = (await (await admin("/links/audit", cookie)).json()) as {
+      action: string;
+      targetId: string;
+      detail: string | null;
+    }[];
+    const entry = audit.find((a) => a.action === "link.suspend");
+    expect(entry?.targetId).toBe(link.id);
+    expect(entry?.detail).toContain("phishing report #412");
+  });
+
+  it("keeps the row and its clicks: suspension is reversible, deletion is not", async () => {
+    const owner = await freeOwnerCookie();
+    const link = await createLink(owner);
+    await env.DB.prepare(
+      "insert into clicks (link_id, org_id, ts, country, referrer, device) values (?, 'org-1', 0, 'US', '', 'desktop')",
+    )
+      .bind(link.id)
+      .run();
+
+    await admin(`/links/${link.id}/suspend`, await adminCookie(), {
+      method: "POST",
+      body: JSON.stringify({ reason: "spam" }),
+    });
+
+    const rows = await env.DB.prepare(
+      "select (select count(*) from links where id = ?) as links, (select count(*) from clicks where link_id = ?) as clicks",
+    )
+      .bind(link.id, link.id)
+      .first<{ links: number; clicks: number }>();
+    expect(rows).toEqual({ links: 1, clicks: 1 });
+  });
+
+  it("comes back when unsuspended", async () => {
+    const owner = await freeOwnerCookie();
+    const link = await createLiveLink(owner);
+    const cookie = await adminCookie();
+
+    await moderate(`/links/${link.id}/suspend`, cookie, { reason: "spam" }, [link.id]);
+    expect(await kvFor(link.slug)).toBeNull();
+
+    await moderate(`/links/${link.id}/unsuspend`, cookie, {}, [link.id]);
+    expect(await kvFor(link.slug)).toBeTruthy();
+  });
+
+  it("refuses a suspension with no reason", async () => {
+    const owner = await freeOwnerCookie();
+    const link = await createLink(owner);
+    const res = await admin(`/links/${link.id}/suspend`, await adminCookie(), {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("suspension survives what would undo it", () => {
+  it("stays dark after the owner edits the link", async () => {
+    // The whole reason the check lives in desiredKvValue. An edit republishes
+    // the key, and a suspension enforced anywhere else would be lifted by it.
+    const owner = await freeOwnerCookie();
+    const link = await createLiveLink(owner);
+    await moderate(`/links/${link.id}/suspend`, await adminCookie(), { reason: "malware" }, [
+      link.id,
+    ]);
+
+    const res = await fetchWorker(
+      new Request(`http://localhost/api/orgs/org-1/links/${link.id}`, {
+        method: "PATCH",
+        headers: { cookie: owner, "content-type": "application/json" },
+        body: JSON.stringify({ destination: "https://example.com/changed" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    // The edit republished the key. It is still dark.
+    await syncKv(...(await slugsOf(link.id)));
+    expect(await kvFor(link.slug)).toBeNull();
+  });
+
+  it("stays dark on every address, not only the primary", async () => {
+    const owner = await freeOwnerCookie();
+    const link = await createLiveLink(owner);
+    const aliasRes = await fetchWorker(
+      new Request(`http://localhost/api/orgs/org-1/links/${link.id}/addresses`, {
+        method: "POST",
+        headers: { cookie: owner, "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(aliasRes.status).toBe(201);
+    const aliases = await env.DB.prepare(
+      "select slug from link_addresses where link_id = ? and retired_at is null",
+    )
+      .bind(link.id)
+      .all<{ slug: string }>();
+    expect(aliases.results.length).toBe(2);
+
+    await syncKv(...aliases.results.map((r) => r.slug));
+    await moderate(`/links/${link.id}/suspend`, await adminCookie(), { reason: "malware" }, [
+      link.id,
+    ]);
+
+    for (const row of aliases.results) expect(await kvFor(row.slug)).toBeNull();
+  });
+});
+
+describe("suspending a whole org", () => {
+  it("takes every link down without deleting the org", async () => {
+    const owner = await freeOwnerCookie();
+    const a = await createLiveLink(owner, "https://example.com/a");
+    const b = await createLiveLink(owner, "https://example.com/b");
+
+    const res = await moderate(
+      "/links/orgs/org-1/suspend",
+      await adminCookie(),
+      { reason: "account compromised" },
+      [a.id, b.id],
+    );
+    expect(await res.json()).toEqual({ count: 2 });
+    expect(await kvFor(a.slug)).toBeNull();
+    expect(await kvFor(b.slug)).toBeNull();
+
+    const org = await env.DB.prepare("select count(*) as n from orgs where id = 'org-1'").first<{
+      n: number;
+    }>();
+    expect(org?.n).toBe(1);
+  });
+
+  it("restores them all again", async () => {
+    const owner = await freeOwnerCookie();
+    const a = await createLiveLink(owner, "https://example.com/a");
+    const cookie = await adminCookie();
+    await moderate("/links/orgs/org-1/suspend", cookie, { reason: "checking" }, [a.id]);
+    await moderate("/links/orgs/org-1/suspend?suspend=0", cookie, {}, [a.id]);
+    expect(await kvFor(a.slug)).toBeTruthy();
+  });
+});
+
+describe("the cross-org search", () => {
+  it("finds a link by destination, which is what an abuse report names", async () => {
+    const owner = await freeOwnerCookie();
+    await createLink(owner, "https://phishy.example/login");
+    await createLink(owner, "https://legit.example/docs");
+
+    const rows = (await (await admin("/links?q=phishy.example", await adminCookie())).json()) as {
+      destination: string;
+      orgName: string;
+    }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].destination).toContain("phishy.example");
+    expect(rows[0].orgName).toBe("Test");
+  });
+
+  it("sorts by risk with unscored last, since unscored is not safe", async () => {
+    const owner = await freeOwnerCookie();
+    const clean = await createLink(owner, "https://clean.example/a");
+    const bad = await createLink(owner, "https://bad.example/b");
+    await createLink(owner, "https://unknown.example/c");
+    await env.DB.prepare("update links set risk_score = 0 where id = ?").bind(clean.id).run();
+    await env.DB.prepare("update links set risk_score = 100 where id = ?").bind(bad.id).run();
+    // Explicitly unscored, so the assertion is about ordering rather than
+    // about whatever the scorer happened to do.
+    await env.DB.prepare("update links set risk_score = null where id not in (?, ?)")
+      .bind(clean.id, bad.id)
+      .run();
+
+    const rows = (await (await admin("/links?sort=risk", await adminCookie())).json()) as {
+      riskScore: number | null;
+    }[];
+    expect(rows.map((r) => r.riskScore)).toEqual([100, 0, null]);
+  });
+
+  it("can show only what is suspended", async () => {
+    const owner = await freeOwnerCookie();
+    const link = await createLink(owner);
+    await createLink(owner, "https://example.com/other");
+    const cookie = await adminCookie();
+    await moderate(`/links/${link.id}/suspend`, cookie, { reason: "spam" }, [link.id]);
+
+    const rows = (await (await admin("/links?suspended=1", cookie)).json()) as { id: string }[];
+    expect(rows.map((r) => r.id)).toEqual([link.id]);
+  });
+});
+
+describe("who may reach any of this", () => {
+  it("404s for a signed-in non-admin, so the route does not announce itself", async () => {
+    const owner = await freeOwnerCookie();
+    const link = await createLiveLink(owner);
+    for (const [path, init] of [
+      ["/links", {}],
+      ["/links/anonymous", {}],
+      ["/links/audit", {}],
+      [`/links/${link.id}/suspend`, { method: "POST", body: JSON.stringify({ reason: "x" }) }],
+    ] as const) {
+      const res = await admin(path, owner, init);
+      expect(res.status, `${path} should 404 for a non-admin`).toBe(404);
+    }
+    // And nothing happened to the link.
+    expect(await kvFor(link.slug)).toBeTruthy();
+  });
+
+  it("404s for a signed-out caller", async () => {
+    const res = await fetchWorker(
+      new Request("http://localhost/api/admin/links", { headers: {} }),
+      authEnv(),
+    );
+    expect([401, 404]).toContain(res.status);
+  });
+});

--- a/tests/worker/admin-moderation.worker.ts
+++ b/tests/worker/admin-moderation.worker.ts
@@ -31,7 +31,7 @@ const admin = (path: string, cookie: string, init: RequestInit = {}) =>
   fetchWorker(
     new Request(`http://localhost/api/admin${path}`, {
       ...init,
-      headers: { cookie, "content-type": "application/json", ...(init.headers ?? {}) },
+      headers: { cookie, "content-type": "application/json", ...init.headers },
     }),
   );
 

--- a/tests/worker/admin-moderation.worker.ts
+++ b/tests/worker/admin-moderation.worker.ts
@@ -238,6 +238,44 @@ describe("suspending a whole org", () => {
     expect(org?.n).toBe(1);
   });
 
+  it("suspends a big org in a fixed number of round trips", async () => {
+    // One address query and one queue send per link is fine for two links
+    // and fatal for three thousand: it asked D1 for 3,002 statements and
+    // made 3,000 sends, past both D1's 1,000-query invocation limit and the
+    // subrequest ceiling. The request died after the suspension flag was
+    // committed, so the links read as suspended and the ones whose messages
+    // never went out kept redirecting.
+    //
+    // Counted rather than sized: running 3,000 links here would test the
+    // fixture, not the route. What matters is that the cost stops growing
+    // with the number of links.
+    const owner = await freeOwnerCookie();
+    const ids: string[] = [];
+    for (let i = 0; i < 12; i++)
+      ids.push((await createLiveLink(owner, `https://example.com/b${i}`)).id);
+
+    let sends = 0;
+    const realSendBatch = env.STORAGE_QUEUE.sendBatch.bind(env.STORAGE_QUEUE);
+    env.STORAGE_QUEUE.sendBatch = (async (batch: unknown[]) => {
+      sends++;
+      expect(batch.length).toBeLessThanOrEqual(100);
+      return realSendBatch(batch as Parameters<typeof realSendBatch>[0]);
+    }) as typeof env.STORAGE_QUEUE.sendBatch;
+
+    try {
+      const res = await admin("/links/orgs/org-1/suspend", await adminCookie(), {
+        method: "POST",
+        body: JSON.stringify({ reason: "account compromised" }),
+      });
+      expect(await res.json()).toEqual({ count: 12 });
+    } finally {
+      env.STORAGE_QUEUE.sendBatch = realSendBatch;
+    }
+
+    // Twelve links, one send. Per link it would have been twelve.
+    expect(sends).toBe(1);
+  });
+
   it("restores them all again", async () => {
     const owner = await freeOwnerCookie();
     const a = await createLiveLink(owner, "https://example.com/a");

--- a/tests/worker/admin-moderation.worker.ts
+++ b/tests/worker/admin-moderation.worker.ts
@@ -287,6 +287,24 @@ describe("suspending a whole org", () => {
 });
 
 describe("the cross-org search", () => {
+  it("filters by organization in the query, not in the browser", async () => {
+    // The page used to narrow the rows this endpoint had already capped at
+    // 200. "Show me this organization's links" therefore meant "show me
+    // whichever of its links are in the newest 200 across the whole
+    // instance", which for a busy instance is usually none of them: an abuse
+    // report naming an org was answered with an empty table.
+    const owner = await freeOwnerCookie();
+    await createLink(owner, "https://example.com/mine");
+
+    const cookie = await adminCookie();
+    const mine = (await (await admin("/links?org=org-1", cookie)).json()) as { orgId: string }[];
+    expect(mine.length).toBeGreaterThan(0);
+    expect(mine.every((r) => r.orgId === "org-1")).toBe(true);
+
+    const other = (await (await admin("/links?org=org-nobody", cookie)).json()) as unknown[];
+    expect(other).toEqual([]);
+  });
+
   it("finds a link by destination, which is what an abuse report names", async () => {
     const owner = await freeOwnerCookie();
     await createLink(owner, "https://phishy.example/login");

--- a/tests/worker/link-risk.worker.ts
+++ b/tests/worker/link-risk.worker.ts
@@ -3,7 +3,7 @@ import { env } from "cloudflare:workers";
 import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
 import worker from "../../src/worker";
 import { applyTestMigrations, authEnv, freeOwnerCookie } from "./support";
-import { scoreAndRecord, sweepLinkRisk } from "../../src/worker/risk";
+import { scoreAndRecord } from "../../src/worker/risk";
 
 /**
  * Destination risk scoring end to end (#68).
@@ -20,17 +20,13 @@ const CLEAN = "https://example.com/x";
 const realFetch = globalThis.fetch;
 
 /** A resolver that refuses BLOCKED's host and resolves everything else. */
-function stubResolver(options: { fail?: boolean; failHost?: string } = {}) {
+function stubResolver(options: { fail?: boolean } = {}) {
   const calls: string[] = [];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
     if (!url.startsWith("https://security.cloudflare-dns.com")) return realFetch(input);
     calls.push(url);
-    // failHost, because the resolver is asked about a host: the query carries
-    // no path, so a test that needs some links to keep failing and others to
-    // succeed has to separate them by hostname.
-    if (options.fail || (options.failHost && url.includes(options.failHost)))
-      throw new Error("resolver unreachable");
+    if (options.fail) throw new Error("resolver unreachable");
     const blocked = url.includes("malware.example");
     return new Response(
       JSON.stringify({ Status: 0, Answer: [{ data: blocked ? "0.0.0.0" : "93.184.216.34" }] }),
@@ -196,63 +192,5 @@ describe("re-scoring on a destination edit", () => {
 
     await patchLink(cookie, linkId, { title: "Renamed" });
     expect(await riskRow(linkId)).toEqual(before);
-  });
-});
-
-describe("the cron sweep", () => {
-  it("picks up unscored links first, then the oldest", async () => {
-    stubResolver({ fail: true });
-    const cookie = await freeOwnerCookie();
-    const a = await createLink(cookie, BLOCKED);
-    const b = await createLink(cookie, CLEAN);
-    expect((await riskRow(a))?.risk_score).toBeNull();
-
-    globalThis.fetch = realFetch;
-    stubResolver();
-    expect(await sweepLinkRisk(env.DB)).toBe(2);
-
-    expect((await riskRow(a))?.risk_score).toBe(100);
-    expect((await riskRow(b))?.risk_score).toBe(0);
-  });
-
-  it("keeps rescanning even when the unscored never come good", async () => {
-    // A destination the resolver keeps failing on stays unscored, and
-    // unscored is picked first. Enough of those and every run spent its whole
-    // budget retrying the same failures, so a link scored a year ago was
-    // never looked at again: the sweep still returned a number and still did
-    // nothing useful.
-    const cookie = await freeOwnerCookie();
-
-    // Four that can never be scored, on their own host so they can keep
-    // failing while the fifth succeeds.
-    stubResolver({ fail: true });
-    for (let i = 0; i < 4; i++)
-      await postLink(cookie, { destination: `https://stuck.example/${i}` });
-
-    globalThis.fetch = realFetch;
-    stubResolver();
-    const old = await createLink(cookie, CLEAN);
-    const scoredAt = (await riskRow(old))?.risk_checked_at as number;
-    expect(scoredAt).not.toBeNull();
-
-    globalThis.fetch = realFetch;
-    stubResolver({ failHost: "stuck.example" });
-    await new Promise((done) => setTimeout(done, 5));
-    await sweepLinkRisk(env.DB, 4);
-
-    // Half the batch went to the never-scored, so the rescan still got its
-    // turn: the timestamp moved.
-    expect((await riskRow(old))?.risk_checked_at).toBeGreaterThan(scoredAt);
-  });
-
-  it("stops at the batch size, so one run cannot blow the daily budget", async () => {
-    stubResolver({ fail: true });
-    const cookie = await freeOwnerCookie();
-    for (let i = 0; i < 4; i++) await postLink(cookie, { destination: `${CLEAN}/${i}` });
-
-    globalThis.fetch = realFetch;
-    const calls = stubResolver();
-    expect(await sweepLinkRisk(env.DB, 2)).toBe(2);
-    expect(calls).toHaveLength(2);
   });
 });

--- a/tests/worker/link-risk.worker.ts
+++ b/tests/worker/link-risk.worker.ts
@@ -3,7 +3,7 @@ import { env } from "cloudflare:workers";
 import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
 import worker from "../../src/worker";
 import { applyTestMigrations, authEnv, freeOwnerCookie } from "./support";
-import { scoreAndRecord } from "../../src/worker/risk";
+import { revalidateOnRedirect, scoreAndRecord } from "../../src/worker/risk";
 
 /**
  * Destination risk scoring end to end (#68).
@@ -191,6 +191,70 @@ describe("re-scoring on a destination edit", () => {
     const before = await riskRow(linkId);
 
     await patchLink(cookie, linkId, { title: "Renamed" });
+    expect(await riskRow(linkId)).toEqual(before);
+  });
+});
+
+describe("re-checking on a click", () => {
+  // The nightly sweep is gone: a destination is re-checked when somebody
+  // actually visits it, and the answer is cached per hostname so ten
+  // thousand links pointing at one host cost one lookup a day between them.
+  const clickOn = (linkId: string, url: string) =>
+    revalidateOnRedirect(authEnv(), { linkId, orgId: "org-1", url });
+
+  it("records the verdict for the link that was clicked", async () => {
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const linkId = await createLink(cookie, BLOCKED);
+    await env.DB.prepare("update links set risk_checked_at = null, risk_score = null where id = ?")
+      .bind(linkId)
+      .run();
+
+    await clickOn(linkId, BLOCKED);
+
+    expect((await riskRow(linkId))?.risk_score).toBe(100);
+  });
+
+  it("records it for every link on the host, not just the one that warmed the cache", async () => {
+    // The cache is keyed by hostname and the write was keyed by link. A host
+    // scored 100 therefore marked whichever link happened to be clicked
+    // while the cache was cold, and left every other link pointing at it
+    // unscored. The admin table sorts by that score, so the rest hid in
+    // plain sight, which is the opposite of what scoring is for.
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    // Two paths on one host: an identical destination would be merged into
+    // the first link rather than making a second.
+    const firstUrl = "https://malware.example/one";
+    const secondUrl = "https://malware.example/two";
+    const first = await createLink(cookie, firstUrl);
+    const second = await createLink(cookie, secondUrl);
+    for (const id of [first, second])
+      await env.DB.prepare(
+        "update links set risk_checked_at = null, risk_score = null where id = ?",
+      )
+        .bind(id)
+        .run();
+
+    await clickOn(first, firstUrl);
+    expect((await riskRow(first))?.risk_score).toBe(100);
+
+    // Second click, same host: the cache is warm, and this link still has to
+    // come away with the verdict.
+    await clickOn(second, secondUrl);
+    expect((await riskRow(second))?.risk_score).toBe(100);
+  });
+
+  it("leaves a link alone when its destination has moved on", async () => {
+    // KV can hold a redirect that predates an edit, and a click on it must
+    // not label the new destination with the old one's verdict.
+    stubResolver();
+    const cookie = await freeOwnerCookie();
+    const linkId = await createLink(cookie, CLEAN);
+    const before = await riskRow(linkId);
+
+    await clickOn(linkId, BLOCKED);
+
     expect(await riskRow(linkId)).toEqual(before);
   });
 });


### PR DESCRIPTION
Closes #67. Part of #68.

Until now the only answer to an abuse report was deleting the whole
organization. That destroys a possibly-legitimate customer's other links to
deal with one bad one, and it cannot be undone.

- **Per-link suspension**, enforced in `desiredKvValue` rather than in the route
  that sets it. Every republish runs through that function, so a suspended link
  stays dark through any later edit, rename or alias change. Put the check
  anywhere else and the owner's next save quietly brings it back, which is the
  failure this exists to prevent, so it has a test of its own.
- **A Links tab**: cross-org search by slug or destination, which is what an
  abuse report actually contains, sorted by risk score with unscored last.
  Unscored is not safe, and letting it sort above 100 would bury the worst links
  under the ones nobody has looked at.
- **`admin_actions` records every privileged mutation**, including the ones that
  already existed. It holds no foreign keys, because an admin can be deleted and
  the record of what they did has to outlive them. Writing is best-effort: an
  admin stopping a phishing link at 2am must not be refused because a log insert
  failed.
- **Destinations are re-checked on click** rather than on a nightly sweep, and
  an admin can re-run the check from the row's menu.
- **The platform tables look like every other table here**: row actions in a
  menu, columns that drop one at a time, a debounced search that no longer tears
  out an open menu, and no sideways rubber-band showing the page behind them.

Part of splitting #105 up. Based on #113.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified admin area with Usage, Links, Organizations, Users, and Audit Log sections.
  * Added link moderation tools to search, filter, review risk, suspend, restore, rescore, and delete links.
  * Added anonymous-link management and detailed administrative audit records.
  * Added organization-level suspension controls and improved organization link summaries.

* **Bug Fixes**
  * Suspended links no longer redirect or reappear after updates.
  * Improved table behavior to prevent horizontal page overflow.
  * Link risk checks now refresh during redirects when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->