### PR TITLE
Let CodeRabbit review a stacked pull request

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# CodeRabbit review settings.
+#
+# By default it reviews only pull requests aimed at the default branch, so a
+# stack (a chain of small PRs, each based on the one below it) goes entirely
+# unreviewed: every link but the bottom one targets another branch. The skip
+# is quiet, and a PR with no comments reads like a PR with no findings.
+#
+# `.*` matches any base branch. It extends the default rather than replacing
+# it, so `main` stays covered.
+reviews:
+  auto_review:
+    base_branches:
+      - ".*"


### PR DESCRIPTION
CodeRabbit reviews only PRs aimed at the default branch unless told otherwise:

> Auto reviews are disabled on base/target branches other than the default branch.

So in a stack, where every PR but the bottom one is based on the branch below it, only the bottom one gets reviewed. That is what happened to #106 through #115: one review, nine silent skips, and a skipped PR looks exactly like a clean one.

`base_branches` takes regex and extends the default rather than replacing it, so `.*` covers every base and `main` stays covered.

Worth having on `main` on its own, ahead of the stack, so the reviews actually run.