### PR TITLE
Give the legal pages the same footer as every other public page

### DIFF
--- a/src/app/ui/misc.tsx
+++ b/src/app/ui/misc.tsx
@@ -151,13 +151,21 @@ export function PageHeader({
 
 export function LegalPageLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12">
-      <header className="mb-8">
-        <Link to="/" className="text-lg font-bold tracking-widest">
-          rdyrct
-        </Link>
-      </header>
-      <div className="flex flex-col gap-8 text-sm">{children}</div>
+    // Two widths, not one. The page shell matches the landing page and the
+    // QR generator so the footer's rule and links come out the same length
+    // on every public page; the prose keeps its own narrower measure inside
+    // it, which is what the outer max-w-3xl used to be for. Sharing one
+    // width made the footer 720 here against 976 there, and the seam showed
+    // when somebody followed a footer link.
+    <div className="mx-auto max-w-5xl px-6 py-12">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-8">
+          <Link to="/" className="text-lg font-bold tracking-widest">
+            rdyrct
+          </Link>
+        </header>
+        <div className="flex flex-col gap-8 text-sm">{children}</div>
+      </div>
       <Footer />
     </div>
   );

--- a/tests/e2e/public-pages.pw.ts
+++ b/tests/e2e/public-pages.pw.ts
@@ -116,3 +116,20 @@ test("a dark operating system still opens dark by default", async ({ browser }) 
 
   await context.close();
 });
+
+test("the footer is the same width on every public page", async ({ page }) => {
+  // The legal pages shared one container with their prose, so their footer
+  // came out 720px against the landing page's 976: the rule above the links
+  // visibly changed length when somebody followed a footer link, which is
+  // the one journey that puts the two footers back to back.
+  const widths: Record<string, number> = {};
+  for (const path of ["/", "/privacy", "/terms"]) {
+    await page.goto(path);
+    const box = await page.locator("footer").boundingBox();
+    widths[path] = Math.round(box?.width ?? 0);
+  }
+
+  expect(widths["/privacy"]).toBe(widths["/"]);
+  expect(widths["/terms"]).toBe(widths["/"]);
+  expect(widths["/"]).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Reported: the footer changes size between the marketing page and the legal pages.

`LegalPageLayout` wrapped the footer in the same `max-w-3xl` container as its prose, so `/privacy` and `/terms` rendered it **720px** wide against **976px** on the landing page and the QR generator. The rule above the links visibly changed length exactly where you would notice it: following a footer link from one to the other.

Two widths now. The page shell matches the other public pages, and the prose keeps its own narrower measure inside it. Measured at 1280: all four footers 976px at the same offset. Mobile is unchanged at 342px with no sideways scroll. The legal text gains the 48px the shared padding used to take and sits where it did.

The e2e fails on `main` (720 against 976) and passes here.

This predates the #105 split, so it is off `main` rather than in the stack.