### PR TITLE
Price every signup attempt with Cap proof-of-work

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -33,3 +33,9 @@ BETTERSTACK_INGEST_URL=
 # rdyrct-blog: run its dev server (bun run dev in that repo) and /blog here
 # proxies to it. Leave blank to skip the proxy.
 BLOG_ORIGIN_URL=http://localhost:3000
+
+# Cap proof-of-work (#98). In production this is `openssl rand -hex 32`; the
+# fixed value here is deliberate, so CI and the browser tests run the real
+# challenge/solve/redeem loop instead of the disabled path. The disabled path
+# is covered by unit tests, which do not need a browser to prove it.
+CAP_SECRET=dev-only-cap-secret-not-a-real-one-0000000000000000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,13 @@ analyticsDays }`). Slugs on the **shared** domain are always random (every
   and `databaseHooks.session.create.before` (in `better-auth.ts`) refuses new
   ones, while their orgs/links keep working.
   Self-service account deletion is blocked while the user still owns an org.
+- **Bot protection**: Cap proof-of-work (`src/worker/cap.ts`, routes at
+  `/api/cap/:scope/{challenge,redeem}`) guards signup and password reset. The
+  token rides in an `x-cap-token` header and is spent in `hooks.before`. No
+  third party sees the visitor: `capjs-core` runs in this Worker, the widget
+  is bundled from npm, and the WASM solver is a same-origin Vite asset. Unset
+  `CAP_SECRET` disables it. See `docs/rate-limiting.md` for all three layers
+  (WAF rules, Workers limiters, Cap) and the dashboard rules to apply by hand.
 - **KV keys**: `slug:{slug}` (shared host), `slug:{host}:{slug}` (custom domain),
   `domain:{host}`. D1 is authoritative; KV is the redirect hot path. Clicks are
   recorded via `waitUntil` after the redirect is sent, and store only

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -175,7 +175,7 @@ SOFTWARE.
 
 ### @cap.js/wasm, @cap.js/widget, capjs-core
 
-```
+```text
 Copyright 2025 Tiago
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -170,8 +170,27 @@ SOFTWARE.
 
 ## Apache License 2.0
 
-`drizzle-orm`, `posthog-js` (dual Apache-2.0/MIT; see below for the vendored
-MIT-licensed portions)
+`@cap.js/wasm`, `@cap.js/widget`, `capjs-core`, `drizzle-orm`, `posthog-js`
+(dual Apache-2.0/MIT; see below for the vendored MIT-licensed portions)
+
+### @cap.js/wasm, @cap.js/widget, capjs-core
+
+```
+Copyright 2025 Tiago
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. (Full Apache License 2.0 text below, under
+drizzle-orm.)
+```
 
 ### drizzle-orm
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "name": "rdyrct",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
+        "@cap.js/wasm": "^0.0.7",
+        "@cap.js/widget": "^0.1.56",
         "@fontsource/jetbrains-mono": "^5.3.0",
         "@hookform/resolvers": "^5.5.7",
         "@polar-sh/sdk": "^0.48.1",
@@ -15,6 +17,7 @@
         "better-auth": "^1.6.25",
         "browser-image-compression": "^2.0.2",
         "canvas-confetti": "^1.9.4",
+        "capjs-core": "0.1.2",
         "d3-geo": "^3.1.1",
         "d3-scale": "^4.0.2",
         "drizzle-orm": "^0.45.2",
@@ -135,6 +138,10 @@
     "@better-auth/utils": ["@better-auth/utils@0.4.2", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.3.1", "", {}, "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g=="],
+
+    "@cap.js/wasm": ["@cap.js/wasm@0.0.7", "", {}, "sha512-IgUjrPOUBaOjTp+BkrhfEBBeQ4An7fQiSWWezDy9Uvd+OdTYm4+h3AJU0j/CpHYayp7FltZU+UePC6p28oGQaw=="],
+
+    "@cap.js/widget": ["@cap.js/widget@0.1.56", "", {}, "sha512-j640dNNNIF8IWmwqmSx0ihgU8sz/6Jm9mHveeDWUk8aXVqFm+2TSsp5bawtMtgf0aa7rFkmT9p76jrqO1uSEpQ=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
@@ -329,6 +336,16 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
+
+    "@inversifyjs/common": ["@inversifyjs/common@1.3.3", "", {}, "sha512-ZH0wrgaJwIo3s9gMCDM2wZoxqrJ6gB97jWXncROfYdqZJv8f3EkqT57faZqN5OTeHWgtziQ6F6g3L8rCvGceCw=="],
+
+    "@inversifyjs/core": ["@inversifyjs/core@1.3.4", "", { "dependencies": { "@inversifyjs/common": "1.3.3", "@inversifyjs/reflect-metadata-utils": "0.2.3" } }, "sha512-gCCmA4BdbHEFwvVZ2elWgHuXZWk6AOu/1frxsS+2fWhjEk2c/IhtypLo5ytSUie1BCiT6i9qnEo4bruBomQsAA=="],
+
+    "@inversifyjs/reflect-metadata-utils": ["@inversifyjs/reflect-metadata-utils@0.2.3", "", { "peerDependencies": { "reflect-metadata": "0.2.2" } }, "sha512-d3D0o9TeSlvaGM2I24wcNw/Aj3rc4OYvHXOKDC09YEph5fMMiKd6fq1VTQd9tOkDNWvVbw+cnt45Wy9P/t5Lvw=="],
+
+    "@javascript-obfuscator/escodegen": ["@javascript-obfuscator/escodegen@2.3.1", "", { "dependencies": { "@javascript-obfuscator/estraverse": "^5.3.0", "esprima": "^4.0.1", "esutils": "^2.0.2", "optionator": "^0.8.1" }, "optionalDependencies": { "source-map": "~0.6.1" } }, "sha512-Z0HEAVwwafOume+6LFXirAVZeuEMKWuPzpFbQhCEU9++BMz0IwEa9bmedJ+rMn/IlXRBID9j3gQ0XYAa6jM10g=="],
+
+    "@javascript-obfuscator/estraverse": ["@javascript-obfuscator/estraverse@5.4.0", "", {}, "sha512-CZFX7UZVN9VopGbjTx4UXaXsi9ewoM1buL0kY7j1ftYdSs7p2spv9opxFjHlQ/QGTgh4UqufYqJJ0WKLml7b6w=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -660,6 +677,8 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
+    "@types/minimatch": ["@types/minimatch@3.0.5", "", {}, "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="],
+
     "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
@@ -671,6 +690,8 @@
     "@types/topojson-specification": ["@types/topojson-specification@1.0.5", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/validator": ["@types/validator@13.15.10", "", {}, "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA=="],
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.64.0", "", {}, "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA=="],
 
@@ -730,7 +751,7 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
-    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
@@ -746,6 +767,14 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "array-differ": ["array-differ@3.0.0", "", {}, "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
+
+    "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
@@ -753,6 +782,8 @@
     "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
+    "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -778,15 +809,31 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001806", "", {}, "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw=="],
 
     "canvas-confetti": ["canvas-confetti@1.9.4", "", {}, "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw=="],
+
+    "capjs-core": ["capjs-core@0.1.2", "", { "dependencies": { "esbuild": "^0.28.0" }, "optionalDependencies": { "javascript-obfuscator": "^4.2.2" } }, "sha512-2NavC99XsbPD0DoBWBapqyznaM0y6SFNqfUG4If18XM+hR0qYPBZa8bUAbwSyC/MNE/Oi8mK0pgU6yjVmBWM5Q=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "chance": ["chance@1.1.13", "", {}, "sha512-V6lQCljcLznE7tUYUM9EOAnnKXbctE6j/rdQkYOHIWbfGQbrzTsAXNW9CdU5XCo4ArXQCj/rb6HgxPlmGJcaUg=="],
+
+    "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
+
+    "charenc": ["charenc@0.0.2", "", {}, "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="],
+
     "cjs-module-lexer": ["cjs-module-lexer@1.2.3", "", {}, "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="],
+
+    "class-validator": ["class-validator@0.14.3", "", { "dependencies": { "@types/validator": "^13.15.3", "libphonenumber-js": "^1.11.1", "validator": "^13.15.20" } }, "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA=="],
 
     "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
 
@@ -798,7 +845,13 @@
 
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "conf": ["conf@15.1.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "atomically": "^2.0.3", "debounce-fn": "^6.0.0", "dot-prop": "^10.0.0", "env-paths": "^3.0.0", "json-schema-typed": "^8.0.1", "semver": "^7.7.2", "uint8array-extras": "^1.5.0" } }, "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og=="],
 
@@ -815,6 +868,8 @@
     "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
@@ -854,6 +909,10 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "deslop-js": ["deslop-js@0.9.3", "", { "dependencies": { "@oxc-project/types": "^0.142.0", "fast-glob": "^3.3.3", "minimatch": "^10.2.5", "oxc-parser": "^0.142.0", "oxc-resolver": "^11.24.2", "typescript": ">=5.0.4 <6" } }, "sha512-sJcR5LLnEG+w58Oy5CdZfwAfm8XiERbXp9c941Aoeb8JmBHk/56TbZQlLJseJtClg0dkn88wpmnI82+iF0jagg=="],
@@ -876,6 +935,8 @@
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.393", "", {}, "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw=="],
@@ -888,7 +949,13 @@
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
 
@@ -907,6 +974,8 @@
     "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
@@ -954,19 +1023,41 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
     "framer-motion": ["framer-motion@12.43.0", "", { "dependencies": { "motion-dom": "^12.43.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
@@ -982,21 +1073,39 @@
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "ink": ["ink@7.1.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w=="],
 
     "ink-spinner": ["ink-spinner@5.0.0", "", { "dependencies": { "cli-spinners": "^2.7.0" }, "peerDependencies": { "ink": ">=4.0.0", "react": ">=18.0.0" } }, "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
+    "inversify": ["inversify@6.1.4", "", { "dependencies": { "@inversifyjs/common": "1.3.3", "@inversifyjs/core": "1.3.4" } }, "sha512-PbxrZH/gTa1fpPEEGAjJQzK8tKMIp5gRg6EFNJlCtzUcycuNdmhv3uk5P8Itm/RIjgHJO16oQRLo9IHzQN51bA=="],
+
+    "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
+
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
+
+    "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
+    "is-nan": ["is-nan@1.3.2", "", { "dependencies": { "call-bind": "^1.0.0", "define-properties": "^1.1.3" } }, "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
+    "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
@@ -1004,9 +1113,13 @@
 
     "iso-3166-1": ["iso-3166-1@2.1.1", "", {}, "sha512-RZxXf8cw5Y8LyHZIwIRvKw8sWTIHh2/txBT+ehO0QroesVfnz3JNFFX4i/OC/Yuv2bDIVYrHna5PMvjtpefq5w=="],
 
+    "javascript-obfuscator": ["javascript-obfuscator@4.2.2", "", { "dependencies": { "@javascript-obfuscator/escodegen": "2.3.1", "@javascript-obfuscator/estraverse": "5.4.0", "acorn": "8.15.0", "assert": "2.1.0", "chalk": "4.1.2", "chance": "1.1.13", "class-validator": "0.14.3", "commander": "12.1.0", "conf": "15.0.2", "eslint-scope": "8.4.0", "eslint-visitor-keys": "4.2.1", "fast-deep-equal": "3.1.3", "inversify": "6.1.4", "js-string-escape": "1.0.1", "md5": "2.3.0", "mkdirp": "3.0.1", "multimatch": "5.0.0", "process": "0.11.10", "reflect-metadata": "0.2.2", "source-map-support": "0.5.21", "string-template": "1.0.0", "stringz": "2.1.0", "tslib": "2.8.1" }, "bin": { "javascript-obfuscator": "bin/javascript-obfuscator" } }, "sha512-+7oXAUnFCA6vS0omIGHcWpSr67dUBIF7FKGYSXyzxShSLqM6LBgdugWKFl0XrYtGWyJMGfQR5F4LL85iCefkRA=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": "lib/jiti-cli.mjs" }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "js-string-escape": ["js-string-escape@1.0.1", "", {}, "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1054,6 +1167,8 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "libphonenumber-js": ["libphonenumber-js@1.13.10", "", {}, "sha512-xJxrdqvbl2rtn2MaUJrUejz8J7/uZNC0V77oks2LxYrO/+ZtVpRmz+fEQMuu6VusnEB1fmpByiLS1WXecOnAnw=="],
+
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -1090,6 +1205,10 @@
 
     "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "md5": ["md5@2.3.0", "", { "dependencies": { "charenc": "0.0.2", "crypt": "0.0.2", "is-buffer": "~1.1.6" } }, "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g=="],
+
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
@@ -1106,6 +1225,8 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
+
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "morphicons": ["morphicons@1.2.0", "", { "peerDependencies": { "react": ">=18", "vue": ">=3.3" }, "optionalPeers": ["react", "vue"] }, "sha512-HuPIwS5PVv/N85k/38e5qhL1vDZArtumd9je0xB1H77eT20HuiCswmmWPogiRj7t9MAiBlcNNoPkfxSxmSzuTw=="],
@@ -1118,6 +1239,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "multimatch": ["multimatch@5.0.0", "", { "dependencies": { "@types/minimatch": "^3.0.3", "array-differ": "^3.0.0", "array-union": "^2.1.0", "arrify": "^2.0.1", "minimatch": "^3.0.4" } }, "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA=="],
+
     "nanoid": ["nanoid@3.3.16", "", { "bin": "bin/nanoid.cjs" }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "nanostores": ["nanostores@1.4.0", "", {}, "sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA=="],
@@ -1127,6 +1250,12 @@
     "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
@@ -1168,6 +1297,8 @@
 
     "portless": ["portless@0.15.5", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-zmJu4Q8/fY54oVUT/5NnmF4Ih8wTdCvCf6JCN783dRYl9mXkJBzXSckX2lztGCLIbM70varDjCudAbGKT73XPg=="],
 
+    "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
+
     "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 
     "posthog-js": ["posthog-js@1.410.4", "", { "dependencies": { "@posthog/browser-common": "^0.3.1", "@posthog/core": "^1.46.5", "@posthog/types": "^1.400.0", "core-js": "^3.49.0", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-+Om1tJaUkjRC9MWXWcgPLm5DQipqIXZtCSwrL31WBI2tJ+K3xjbC6nQXwA7B2EBzQXw6SsvMST3cpgXvqlUkbw=="],
@@ -1175,6 +1306,8 @@
     "preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
@@ -1202,6 +1335,8 @@
 
     "react-router": ["react-router@8.3.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ=="],
 
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
@@ -1220,6 +1355,8 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
@@ -1229,6 +1366,8 @@
     "semver": ["semver@7.8.5", "", { "bin": "bin/semver.js" }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.1.2", "", {}, "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
     "shadow-plugin": ["shadow-plugin@1.2.7", "", {}, "sha512-VW+flas6o3jhkE2Um6gf3FFSLXSCoP//yhS4DP2KWeUEgDsbxA0A+mObqcZZVEbClFXZ3XByhCDkDddR1cgDvg=="],
 
@@ -1260,7 +1399,11 @@
 
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
+    "string-template": ["string-template@1.0.0", "", {}, "sha512-SLqR3GBUXuoPP5MmYtD7ompvXiG87QjT6lzOszyXjTM86Uu7At7vNnt2xgyTLq5o9T4IxTYFyGxcULqpsmsfdg=="],
+
     "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
+
+    "stringz": ["stringz@2.1.0", "", { "dependencies": { "char-regex": "^1.0.2" } }, "sha512-KlywLT+MZ+v0IRepfMxRtnSvDCMc3nR1qqCs3m/qIbSOWkNZYT8XHQA31rS3TnKp0c5xjZu3M4GY/2aRKSi/6A=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -1268,7 +1411,7 @@
 
     "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
 
-    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "svgo": ["svgo@4.0.2", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng=="],
 
@@ -1320,9 +1463,13 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
+
     "uzip": ["uzip@0.20201231.0", "", {}, "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="],
 
     "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
+
+    "validator": ["validator@13.15.35", "", {}, "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw=="],
 
     "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "yaml"], "bin": "bin/vite.js" }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
 
@@ -1345,6 +1492,8 @@
     "when-exit": ["when-exit@2.1.5", "", {}, "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-typed-array": ["which-typed-array@1.1.22", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.9", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
@@ -1392,6 +1541,8 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@javascript-obfuscator/escodegen/optionator": ["optionator@0.8.3", "", { "dependencies": { "deep-is": "~0.1.3", "fast-levenshtein": "~2.0.6", "levn": "~0.3.0", "prelude-ls": "~1.1.2", "type-check": "~0.3.2", "word-wrap": "~1.2.3" } }, "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA=="],
+
     "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
@@ -1399,6 +1550,8 @@
     "@polar-sh/sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@poppinss/colors/kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
@@ -1422,9 +1575,23 @@
 
     "eslint-plugin-react-hooks/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "espree/acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
     "import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
+    "javascript-obfuscator/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "javascript-obfuscator/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "javascript-obfuscator/conf": ["conf@15.0.2", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "atomically": "^2.0.3", "debounce-fn": "^6.0.0", "dot-prop": "^10.0.0", "env-paths": "^3.0.0", "json-schema-typed": "^8.0.1", "semver": "^7.7.2", "uint8array-extras": "^1.5.0" } }, "sha512-JBSrutapCafTrddF9dH3lc7+T2tBycGF4uPkI4Js+g4vLLEhG6RZcFi3aJd5zntdf5tQxAejJt8dihkoQ/eSJw=="],
+
+    "javascript-obfuscator/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "javascript-obfuscator/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "multimatch/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -1482,6 +1649,12 @@
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
+    "@javascript-obfuscator/escodegen/optionator/levn": ["levn@0.3.0", "", { "dependencies": { "prelude-ls": "~1.1.2", "type-check": "~0.3.2" } }, "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA=="],
+
+    "@javascript-obfuscator/escodegen/optionator/prelude-ls": ["prelude-ls@1.1.2", "", {}, "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="],
+
+    "@javascript-obfuscator/escodegen/optionator/type-check": ["type-check@0.3.2", "", { "dependencies": { "prelude-ls": "~1.1.2" } }, "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg=="],
+
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
@@ -1537,5 +1710,11 @@
     "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "javascript-obfuscator/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "multimatch/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
+
+    "multimatch/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -33,14 +33,16 @@ Add them at **Security → WAF → Rate limiting rules** on the `rdyrct.com` zon
 | Expression      | `(http.request.uri.path contains "/api/auth/")` |
 | Characteristics | IP                                              |
 | Period          | 1 minute                                        |
-| Requests        | 20                                              |
+| Requests        | 60                                              |
 | Action          | Block                                           |
 | Duration        | 10 minutes                                      |
 
-Above the Worker's own limit of 10/minute, deliberately. The Worker's
-counters are per-location, so a caller spread across colos can exceed 10
-globally while never tripping one; this catches that without punishing a
-person whose corporate NAT shares an address.
+Above the Worker's own 30/minute, deliberately, and counted across every
+auth path at once. The Worker's counters are per-location and per-path, so a
+caller spread across colos, or across the several paths one sign-up touches,
+can go well past any single one. This catches that without punishing a person
+whose corporate NAT shares an address: one sign-up costs a handful of
+requests, so 60 is a bot and 20 was a family.
 
 ### Rule 2: proof-of-work challenges
 
@@ -91,15 +93,22 @@ enforcement.
 
 | Binding              | Limit   | Keyed by          | Guards                        |
 | -------------------- | ------- | ----------------- | ----------------------------- |
-| `RL_AUTH_PUBLIC`     | 10/min  | IP                | `/api/auth/*`, `/api/cap/*`   |
-| `RL_EMAIL`           | 3/min   | IP                | Anything that sends mail      |
-| `RL_EMAIL_RECIPIENT` | 2/min   | Recipient address | One inbox, many callers (#50) |
-| `RL_WRITE_FREE`      | 30/min  | User              | Writes on a free plan         |
-| `RL_WRITE_PAID`      | 120/min | User              | Writes on a paid plan         |
-| `RL_QR_UPLOAD`       | 5/min   | User              | QR logo uploads to R2         |
-| `RL_DOMAIN_SETUP`    | 12/min  | User              | Custom hostname calls         |
-| `RL_BILLING`         | 3/min   | User              | Polar checkout                |
+| `RL_AUTH_PUBLIC`     | 30/min  | IP, path          | `/api/auth/*`, `/api/cap/*`   |
+| `RL_EMAIL`           | 10/min  | IP, path          | Anything that sends mail      |
+| `RL_EMAIL_RECIPIENT` | 4/min   | Recipient address | One inbox, many callers (#50) |
+| `RL_WRITE_FREE`      | 90/min  | User              | Writes on a free plan         |
+| `RL_WRITE_PAID`      | 300/min | User              | Writes on a paid plan         |
+| `RL_QR_UPLOAD`       | 20/min  | User              | QR logo uploads to R2         |
+| `RL_DOMAIN_SETUP`    | 30/min  | User              | Custom hostname calls         |
+| `RL_BILLING`         | 10/min  | User              | Polar checkout                |
 | `RL_CLICK_RECORDING` | 600/min | Slug              | Click ingestion               |
+
+These are set for the person having trouble, not for the bot: someone who
+mistypes a password, retries a signup or pastes six links in a row must never
+meet a wall, because a wall reads as the product being broken. Only
+`RL_EMAIL_RECIPIENT` stays tight, because it is the one that bounds what an
+inbox can be made to receive however many callers aim at it. The real
+ceilings are the WAF rules above and the CPU Cap charges per attempt.
 
 `period` accepts only 10 or 60, so every one of these caps a rate, not a
 daily total. Closing that gap needs a durable counter; see the follow-up on

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,163 @@
+# Rate limiting and bot protection
+
+Three layers sit in front of this app, and they fail differently, which is
+why all three exist.
+
+| Layer                   | Where it runs                      | Counts                  | Catches                |
+| ----------------------- | ---------------------------------- | ----------------------- | ---------------------- |
+| WAF rate limiting rules | Cloudflare edge, before the Worker | Globally, per zone      | Floods                 |
+| Workers Rate Limiting   | Inside the Worker                  | Per Cloudflare location | Bursts from one caller |
+| Cap proof-of-work       | Visitor's browser                  | Per attempt             | Slow, distributed bots |
+
+A rate limit is a ceiling. Cap is a price. Neither replaces the other: a bot
+that stays politely under every limit pays nothing to a ceiling, and a flood
+from ten thousand addresses pays little to a price.
+
+## Layer 1: WAF rate limiting rules (dashboard)
+
+These are **not in this repo**. They live in the Cloudflare dashboard, which
+is why they are written down here: invisible infrastructure is infrastructure
+nobody can review.
+
+They run before the Worker starts, so a blocked request costs no CPU time and
+no billable invocation. Unlike the Workers limiters below, the counters are
+global rather than per-location.
+
+Add them at **Security → WAF → Rate limiting rules** on the `rdyrct.com` zone.
+
+### Rule 1: authentication endpoints
+
+| Field           | Value                                           |
+| --------------- | ----------------------------------------------- |
+| Name            | `auth-endpoints`                                |
+| Expression      | `(http.request.uri.path contains "/api/auth/")` |
+| Characteristics | IP                                              |
+| Period          | 1 minute                                        |
+| Requests        | 20                                              |
+| Action          | Block                                           |
+| Duration        | 10 minutes                                      |
+
+Above the Worker's own limit of 10/minute, deliberately. The Worker's
+counters are per-location, so a caller spread across colos can exceed 10
+globally while never tripping one; this catches that without punishing a
+person whose corporate NAT shares an address.
+
+### Rule 2: proof-of-work challenges
+
+| Field           | Value                                          |
+| --------------- | ---------------------------------------------- |
+| Name            | `cap-challenges`                               |
+| Expression      | `(http.request.uri.path contains "/api/cap/")` |
+| Characteristics | IP                                             |
+| Period          | 1 minute                                       |
+| Requests        | 60                                             |
+| Action          | Managed challenge                              |
+| Duration        | 1 minute                                       |
+
+Higher, because issuing a challenge is cheap for us and expensive for the
+caller, which is the whole asymmetry Cap rests on. The point is only to stop
+someone farming challenges to solve offline in bulk.
+
+### Rule 3: password reset
+
+| Field           | Value                                                           |
+| --------------- | --------------------------------------------------------------- |
+| Name            | `password-reset`                                                |
+| Expression      | `(http.request.uri.path eq "/api/auth/request-password-reset")` |
+| Characteristics | IP                                                              |
+| Period          | 1 minute                                                        |
+| Requests        | 5                                                               |
+| Action          | Block                                                           |
+| Duration        | 1 hour                                                          |
+
+Tight, and it can afford to be: nobody legitimately asks for five reset
+emails in a minute. This is the upstream fix for the symptom that forced the
+per-recipient email cap in #50.
+
+### Not enabled: Bot Fight Mode
+
+Tempting, free, one click. Per Cloudflare's own documentation it cannot be
+customised or skipped, not even by WAF custom rules, and it "may challenge
+API or mobile app traffic". That collides with the public API in #74. Super
+Bot Fight Mode is skippable but needs a Pro zone plan. Revisit once #74 has
+a shape.
+
+## Layer 2: Workers Rate Limiting (`wrangler.jsonc`)
+
+Defined in `wrangler.jsonc` under `ratelimits`, applied in
+`src/worker/rate-limit.ts`. Counters are permissive and local to each
+Cloudflare location, so treat these as abuse controls, never as quota
+enforcement.
+
+| Binding              | Limit   | Keyed by          | Guards                        |
+| -------------------- | ------- | ----------------- | ----------------------------- |
+| `RL_AUTH_PUBLIC`     | 10/min  | IP                | `/api/auth/*`, `/api/cap/*`   |
+| `RL_EMAIL`           | 3/min   | IP                | Anything that sends mail      |
+| `RL_EMAIL_RECIPIENT` | 2/min   | Recipient address | One inbox, many callers (#50) |
+| `RL_WRITE_FREE`      | 30/min  | User              | Writes on a free plan         |
+| `RL_WRITE_PAID`      | 120/min | User              | Writes on a paid plan         |
+| `RL_QR_UPLOAD`       | 5/min   | User              | QR logo uploads to R2         |
+| `RL_DOMAIN_SETUP`    | 12/min  | User              | Custom hostname calls         |
+| `RL_BILLING`         | 3/min   | User              | Polar checkout                |
+| `RL_CLICK_RECORDING` | 600/min | Slug              | Click ingestion               |
+
+`period` accepts only 10 or 60, so every one of these caps a rate, not a
+daily total. Closing that gap needs a durable counter; see the follow-up on
+#50.
+
+## Layer 3: Cap proof-of-work (#98)
+
+Self-hosted, Apache 2.0, and no third party ever sees the visitor. The
+challenge is issued by our Worker, solved in the visitor's browser, and
+verified by our Worker.
+
+**Where it applies.** Signup and password-reset requests. Not login: a bot
+with correct credentials is not the threat model, and it would tax every real
+visitor on every visit.
+
+**How it looks.** It does not. The widget is created off-screen and driven
+directly, and solving starts on the form's first keystroke, so the work
+overlaps the typing. Nobody ticks a box.
+
+**The secret.** `CAP_SECRET`, from `openssl rand -hex 32`. With it unset the
+check is skipped entirely, which is what keeps local dev quiet. capjs-core
+refuses a secret under 16 bytes by throwing, so a too-short one takes signup
+down rather than running unprotected: fail-closed, which for a security
+control is the right way round, but worth knowing before you paste something
+short.
+
+**What it costs a visitor.** 12 challenges at difficulty 3, measured on a
+laptop: about 25ms with the WASM solver, about 130ms without. The WASM path
+needs `'wasm-unsafe-eval'` in `script-src`, which permits WebAssembly
+compilation and nothing else, and the module is a same-origin Vite asset.
+Cap's solver also runs in a Web Worker built from a `blob:` URL, hence
+`worker-src 'self' blob:`. Both are asserted in
+`tests/e2e/production/csp.pw.ts`, because a blocked solver fails silently:
+signup would look fine and be completely unprotected.
+
+**What it does not do.** KV is eventually consistent, so a redeemed token
+presented to two locations at once has a small replay window. That is an
+acceptable ceiling for a captcha, whose job is to price bulk attempts rather
+than to guarantee exactly-once. Making it airtight would mean a Durable
+Object per nonce, which costs more than the replay is worth.
+
+## Monitoring
+
+Rate-limit rejections log as `rate_limited <group> <method>` and errors as
+`rate_limit_error`. Watch them in the Cloudflare dashboard under Workers →
+rdyrct → Logs, or in Better Stack if `BETTERSTACK_INGEST_URL` is set.
+
+WAF rule activity appears under Security → Events, filtered by the rule name.
+
+## Rolling back
+
+**A WAF rule is blocking real people.** Set its action to Log rather than
+deleting it, so the counters keep running and you can see what it would have
+caught.
+
+**Cap is blocking real people.** Unset `CAP_SECRET`
+(`bunx wrangler secret delete CAP_SECRET`). The check disables itself and
+signup returns to exactly its previous behaviour. No deploy needed.
+
+**A Workers limiter is too tight.** Change the `limit` in `wrangler.jsonc`
+and deploy. Keep the `namespace_id`: changing it resets every counter.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -93,7 +93,8 @@ enforcement.
 
 | Binding              | Limit   | Keyed by          | Guards                        |
 | -------------------- | ------- | ----------------- | ----------------------------- |
-| `RL_AUTH_PUBLIC`     | 30/min  | IP, path          | `/api/auth/*`, `/api/cap/*`   |
+| `RL_AUTH_PUBLIC`     | 30/min  | IP, path          | `/api/auth/*`                 |
+| `RL_CAP`             | 120/min | IP, path          | `/api/cap/*` (#98)            |
 | `RL_EMAIL`           | 10/min  | IP, path          | Anything that sends mail      |
 | `RL_EMAIL_RECIPIENT` | 4/min   | Recipient address | One inbox, many callers (#50) |
 | `RL_WRITE_FREE`      | 90/min  | User              | Writes on a free plan         |
@@ -105,7 +106,11 @@ enforcement.
 
 These are set for the person having trouble, not for the bot: someone who
 mistypes a password, retries a signup or pastes six links in a row must never
-meet a wall, because a wall reads as the product being broken. Only
+meet a wall, because a wall reads as the product being broken. `RL_CAP` is the
+clearest case: one sign-up spends a challenge and a redeem, its retry spends
+two more, and when that budget runs out the browser cannot solve the puzzle at
+all, so the form says "could not verify you are human" instead of "wait a
+minute". It has its own generous counter for that reason. Only
 `RL_EMAIL_RECIPIENT` stays tight, because it is the one that bounds what an
 inbox can be made to receive however many callers aim at it. The real
 ceilings are the WAF rules above and the CPU Cap charges per attempt.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -91,6 +91,12 @@ Defined in `wrangler.jsonc` under `ratelimits`, applied in
 Cloudflare location, so treat these as abuse controls, never as quota
 enforcement.
 
+These are the production numbers. The dev and test environments in
+`wrangler.jsonc` deliberately run several of them looser (`RL_AUTH_PUBLIC`,
+`RL_CAP`, `RL_EMAIL`, `RL_EMAIL_RECIPIENT`), because the e2e suite signs up
+dozens of times a minute from one address and rate limiting the test run
+proves nothing about the feature.
+
 | Binding              | Limit   | Keyed by          | Guards                        |
 | -------------------- | ------- | ----------------- | ----------------------------- |
 | `RL_AUTH_PUBLIC`     | 30/min  | IP, path          | `/api/auth/*`                 |
@@ -102,7 +108,7 @@ enforcement.
 | `RL_QR_UPLOAD`       | 20/min  | User              | QR logo uploads to R2         |
 | `RL_DOMAIN_SETUP`    | 30/min  | User              | Custom hostname calls         |
 | `RL_BILLING`         | 10/min  | User              | Polar checkout                |
-| `RL_CLICK_RECORDING` | 600/min | Slug              | Click ingestion               |
+| `RL_CLICK_RECORDING` | 600/min | Organization      | Click ingestion               |
 
 These are set for the person having trouble, not for the bot: someone who
 mistypes a password, retries a signup or pastes six links in a row must never
@@ -171,7 +177,8 @@ caught.
 
 **Cap is blocking real people.** Unset `CAP_SECRET`
 (`bunx wrangler secret delete CAP_SECRET`). The check disables itself and
-signup returns to exactly its previous behaviour. No deploy needed.
+both guarded flows, signup and password reset, return to exactly their
+previous behaviour. No deploy needed.
 
 **A Workers limiter is too tight.** Change the `limit` in `wrangler.jsonc`
 and deploy. Keep the `namespace_id`: changing it resets every counter.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@cap.js/wasm": "^0.0.7",
+    "@cap.js/widget": "^0.1.56",
     "@fontsource/jetbrains-mono": "^5.3.0",
     "@hookform/resolvers": "^5.5.7",
     "@polar-sh/sdk": "^0.48.1",
@@ -39,6 +41,7 @@
     "better-auth": "^1.6.25",
     "browser-image-compression": "^2.0.2",
     "canvas-confetti": "^1.9.4",
+    "capjs-core": "0.1.2",
     "d3-geo": "^3.1.1",
     "d3-scale": "^4.0.2",
     "drizzle-orm": "^0.45.2",

--- a/prod.secrets.env.example
+++ b/prod.secrets.env.example
@@ -32,3 +32,9 @@ CF_API_TOKEN=
 # Better Stack source → Data ingestion tab. Alerts fire when a storage message
 # dead-letters (BETTERSTACK_INGEST_URL is a var, set in wrangler.jsonc).
 BETTERSTACK_SOURCE_TOKEN=
+
+# Cap proof-of-work in front of signup and password reset (#98).
+# Generate with: openssl rand -hex 32
+# Leave unset and the check is skipped entirely, so this is the one thing
+# standing between the signup form and a bot.
+CAP_SECRET=

--- a/src/app/lib/cap-retry.ts
+++ b/src/app/lib/cap-retry.ts
@@ -1,0 +1,48 @@
+/**
+ * The one rule that decides whether a Cap-guarded request gets a second go.
+ *
+ * Its own module so it can be tested: cap.ts imports the WASM solver as a
+ * `?url` asset, which bun's test runner cannot resolve.
+ */
+import { CAP_FAILED_CODE } from "@/shared/types";
+
+/**
+ * Whether a refusal is the Worker turning down a Cap token.
+ *
+ * Two shapes reach here, and both have to be read. better-auth resolves with
+ * `{ error }` on the object rather than throwing; api() rejects with an
+ * ApiError carrying `.code`. Reading only the first is what made the retry
+ * below dead code for every api() caller.
+ */
+export function isCapFailure(result: unknown): boolean {
+  const value = result as { code?: string; error?: { code?: string } } | null;
+  return value?.code === CAP_FAILED_CODE || value?.error?.code === CAP_FAILED_CODE;
+}
+
+/**
+ * Runs a Cap-guarded request, and if the Worker refuses the token, solves a
+ * fresh one and runs it exactly once more.
+ *
+ * A token can be refused for reasons the browser cannot see coming: it
+ * expired, it was already spent, or the server forgot it. None of those are
+ * the visitor's doing and none of them are worth an error message, so proving
+ * ourselves again is the honest response. Once, not in a loop: a second
+ * refusal means something is actually wrong, and that one belongs on screen.
+ *
+ * The refusal has to be caught as well as inspected. A rejected promise never
+ * reached the check, so a spent token surfaced as "could not verify you are
+ * human" in front of somebody who had done nothing wrong, on the one path
+ * where retrying always would have worked.
+ */
+export async function retryOnCapFailure<T>(
+  run: (headers: Record<string, string>) => Promise<T>,
+  headers: () => Promise<Record<string, string>>,
+): Promise<T> {
+  try {
+    const first = await run(await headers());
+    if (!isCapFailure(first)) return first;
+  } catch (error) {
+    if (!isCapFailure(error)) throw error;
+  }
+  return run(await headers());
+}

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -19,9 +19,13 @@
  */
 import { useCallback, useRef } from "react";
 import wasmUrl from "@cap.js/wasm/browser/cap_wasm_bg.wasm?url";
-import { CAP_TOKEN_HEADER } from "@/shared/types";
+import { CAP_FAILED_CODE, CAP_TOKEN_HEADER } from "@/shared/types";
+import { ApiError } from "./api";
 
 export type CapScope = "signup" | "password-reset" | "anon-link";
+
+/** Runs a Cap-guarded request, re-solving once if the token is refused. */
+export type CapGuard = <T>(run: (headers: Record<string, string>) => Promise<T>) => Promise<T>;
 
 /** How long to wait for a solve before giving up and submitting without one. */
 const SOLVE_TIMEOUT_MS = 20_000;
@@ -132,5 +136,42 @@ export function useCap(scope: CapScope) {
     return capHeaders(token);
   }, [prime]);
 
-  return { prime, headers };
+  /**
+   * Runs a Cap-guarded request, and if the Worker refuses the token, solves
+   * a fresh one and runs it exactly once more.
+   *
+   * A token can be refused for reasons the browser cannot see coming: it
+   * expired, it was already spent, or the server forgot it. None of those
+   * are the visitor's doing and none of them are worth an error message, so
+   * proving ourselves again is the honest response. Once, not in a loop: a
+   * second refusal means something is actually wrong, and that one belongs
+   * on screen.
+   */
+  const guarded = useCallback(
+    async <T>(run: (headers: Record<string, string>) => Promise<T>): Promise<T> => {
+      const first = await run(await headers());
+      if (!isCapFailure(first)) return first;
+      return run(await headers());
+    },
+    [headers],
+  );
+
+  return { prime, headers, guarded };
+}
+
+/**
+ * Whether a result is the Worker turning down a Cap token.
+ *
+ * Covers both shapes this app gets back: better-auth returns `{ error }` on
+ * the object rather than throwing, and api() rejects with an ApiError whose
+ * `.code` comes from the response body.
+ */
+function isCapFailure(result: unknown): boolean {
+  const error = (result as { error?: { code?: string } } | null)?.error;
+  return error?.code === CAP_FAILED_CODE;
+}
+
+/** The same check for a thrown ApiError, which is how api() reports it. */
+export function isCapFailureError(error: unknown): boolean {
+  return error instanceof ApiError && error.code === CAP_FAILED_CODE;
 }

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -44,14 +44,26 @@ type CapElement = HTMLElement & {
 
 let loading: Promise<void> | null = null;
 
-/** Loads the widget once, on demand, so it stays out of the initial bundle. */
+/**
+ * Loads the widget once, on demand, so it stays out of the initial bundle.
+ *
+ * A failed load is not remembered. The promise used to be cached whatever it
+ * settled to, so one bad fetch (a dev server restarting under an open tab, a
+ * dropped connection, a chunk that 404s after a deploy) poisoned every solve
+ * for the life of that tab: the form then said "could not verify you are
+ * human" forever, and only a reload fixed it. Now the next attempt tries
+ * again.
+ */
 function loadCap(): Promise<void> {
   loading ??= (async () => {
     // Read at module-eval time by the widget, so it has to be set first, or
     // it fetches the WASM from jsdelivr and trips the CSP.
     (window as unknown as { CAP_CUSTOM_WASM_URL?: string }).CAP_CUSTOM_WASM_URL = wasmUrl;
     await import("@cap.js/widget");
-  })();
+  })().catch((error: unknown) => {
+    loading = null;
+    throw error;
+  });
   return loading;
 }
 
@@ -132,8 +144,15 @@ export function useCap(scope: CapScope) {
     // Single-use: a second submit has to solve again rather than replay a
     // token the server has already burned.
     pending.current = null;
+    // An empty token means the puzzle never got solved here: the widget or
+    // its WASM did not load, or it ran out of time. The request still goes
+    // (the server decides, and Cap may be off entirely), but this is the one
+    // place that knows the difference between "we could not run the check"
+    // and "the server refused it", and saying so beats reading the network
+    // tab of somebody else's browser.
+    if (!token) console.warn("cap_solve_failed", scope);
     return capHeaders(token);
-  }, [prime]);
+  }, [prime, scope]);
 
   /**
    * Runs a Cap-guarded request, and if the Worker refuses the token, solves

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -20,7 +20,6 @@
 import { useCallback, useRef } from "react";
 import wasmUrl from "@cap.js/wasm/browser/cap_wasm_bg.wasm?url";
 import { CAP_FAILED_CODE, CAP_TOKEN_HEADER } from "@/shared/types";
-import { ApiError } from "./api";
 
 export type CapScope = "signup" | "password-reset" | "anon-link";
 
@@ -169,9 +168,4 @@ export function useCap(scope: CapScope) {
 function isCapFailure(result: unknown): boolean {
   const error = (result as { error?: { code?: string } } | null)?.error;
   return error?.code === CAP_FAILED_CODE;
-}
-
-/** The same check for a thrown ApiError, which is how api() reports it. */
-export function isCapFailureError(error: unknown): boolean {
-  return error instanceof ApiError && error.code === CAP_FAILED_CODE;
 }

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -21,7 +21,7 @@ import { useCallback, useRef } from "react";
 import wasmUrl from "@cap.js/wasm/browser/cap_wasm_bg.wasm?url";
 import { CAP_FAILED_CODE, CAP_TOKEN_HEADER } from "@/shared/types";
 
-export type CapScope = "signup" | "password-reset" | "anon-link";
+export type CapScope = "signup" | "password-reset";
 
 /** Runs a Cap-guarded request, re-solving once if the token is refused. */
 export type CapGuard = <T>(run: (headers: Record<string, string>) => Promise<T>) => Promise<T>;

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -68,43 +68,96 @@ function loadCap(): Promise<void> {
 }
 
 /**
- * Starts solving a challenge for `scope` and resolves with the token.
+ * The widget for one scope, made once and left in the document.
  *
- * Resolves with "" on any failure, including a timeout. That is deliberate:
- * a visitor whose browser cannot solve the puzzle should still be able to
- * try, and be turned away by the server with a message, rather than face a
- * form that silently refuses to submit.
+ * This is the shape Cap's own `Cap` class uses, and the reason matters: the
+ * element's `disconnectedCallback` aborts its AbortController, and every
+ * `await` inside the widget's `solve()` is followed by
+ * `if (signal?.aborted || !this.#speculative) return;`. So a widget removed
+ * while it is working makes `solve()` resolve **undefined** — no token, no
+ * throw, no error event. The old code created a throwaway element per solve
+ * and removed it in a `finally`, which is exactly how to hit that path, and
+ * an undefined result became an empty token, no `x-cap-token` header, and
+ * "could not verify you are human" in front of somebody trying to sign up.
+ */
+const widgets = new Map<CapScope, CapElement>();
+
+/** One solve at a time per widget. `solve()` opens with
+ * `if (this.#solving) return;`, so a second concurrent call on the same
+ * element resolves undefined too. Callers share the in-flight promise
+ * instead. */
+const solving = new Map<CapScope, Promise<string>>();
+
+async function widgetFor(scope: CapScope): Promise<CapElement> {
+  await loadCap();
+  const existing = widgets.get(scope);
+  if (existing?.isConnected) return existing;
+
+  const el = document.createElement("cap-widget") as CapElement;
+  el.setAttribute("data-cap-api-endpoint", `/api/cap/${scope}/`);
+  el.setAttribute("aria-hidden", "true");
+  el.style.display = "none";
+  // The widget dispatches its own "error" event, and with nothing listening
+  // it surfaces as an unhandled error: an aborted solve would otherwise look
+  // like a page crash. Failure is reported by resolving with "".
+  el.addEventListener("error", (event) => event.stopPropagation());
+  document.documentElement.appendChild(el);
+  widgets.set(scope, el);
+  return el;
+}
+
+/** Throws the widget away, for the cases where its internal state is not
+ * worth trusting: it is rebuilt on the next attempt. */
+function discardWidget(scope: CapScope): void {
+  widgets.get(scope)?.remove();
+  widgets.delete(scope);
+}
+
+/**
+ * Solves one challenge and resolves with the token, or "" if this browser
+ * could not produce one.
+ *
+ * "" is deliberate rather than an exception: a visitor whose browser cannot
+ * run the puzzle should still be able to submit and be answered by the
+ * server, instead of meeting a form that refuses to do anything.
+ *
+ * A solve that comes back without a token is retried once on a fresh widget.
+ * The silent-undefined paths above are all transient (an abort, a solve
+ * already running), so the second attempt is usually the one that works, and
+ * a second failure is a real one worth reporting.
  */
 function solveCap(scope: CapScope): Promise<string> {
-  return (async () => {
+  const inFlight = solving.get(scope);
+  if (inFlight) return inFlight;
+
+  const attempt = (async () => {
     try {
-      await loadCap();
-      const el = document.createElement("cap-widget") as CapElement;
-      el.setAttribute("data-cap-api-endpoint", `/api/cap/${scope}/`);
-      // Out of the layout entirely, not `display: none`: the widget skips
-      // its own background work when it believes it is invisible, and we
-      // want it working.
-      el.style.cssText = "position:absolute;width:1px;height:1px;overflow:hidden;opacity:0";
-      el.setAttribute("aria-hidden", "true");
-      // The widget dispatches its own "error" event and, with nothing
-      // listening, it surfaces as an unhandled error: a navigation that
-      // aborts an in-flight solve would otherwise look like a page crash.
-      // We already report failure by resolving with "".
-      el.addEventListener("error", (event) => event.stopPropagation());
-      document.body.appendChild(el);
-      try {
+      for (let tries = 0; tries < 2; tries++) {
+        const el = await widgetFor(scope);
+        // Single-use tokens: whatever this widget still holds from the last
+        // solve has been spent, and reset() clears it along with the timer
+        // that would have cleared it later.
+        el.reset();
         const result = await Promise.race([
           el.solve(),
           new Promise<null>((resolve) => setTimeout(() => resolve(null), SOLVE_TIMEOUT_MS)),
         ]);
-        return result?.token ?? "";
-      } finally {
-        el.remove();
+        if (result?.token) return result.token;
+        // Either it timed out, or it returned without one. Both leave state
+        // this widget cannot be trusted with, so the retry gets a new one.
+        discardWidget(scope);
       }
-    } catch {
       return "";
+    } catch {
+      discardWidget(scope);
+      return "";
+    } finally {
+      solving.delete(scope);
     }
   })();
+
+  solving.set(scope, attempt);
+  return attempt;
 }
 
 /** The header a solved token travels in, ready to spread into fetch options. */

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -26,6 +26,14 @@ export type CapScope = "signup" | "password-reset" | "anon-link";
 /** How long to wait for a solve before giving up and submitting without one. */
 const SOLVE_TIMEOUT_MS = 20_000;
 
+/**
+ * How long a solved token is reused before it is thrown away and solved
+ * again. Comfortably under the ten minutes the Worker keeps a redeemed token,
+ * so a form filled slowly still submits with something the server will
+ * accept.
+ */
+const TOKEN_FRESH_MS = 4 * 60 * 1000;
+
 type CapElement = HTMLElement & {
   solve: () => Promise<{ token?: string }>;
   reset: () => void;
@@ -102,15 +110,24 @@ function capHeaders(token: string): Record<string, string> {
  * again rather than replaying a token the server has already burned.
  */
 export function useCap(scope: CapScope) {
-  const pending = useRef<Promise<string> | null>(null);
+  const pending = useRef<{ token: Promise<string>; primedAt: number } | null>(null);
 
   const prime = useCallback(() => {
-    pending.current ??= solveCap(scope);
+    // Discarded once stale, not just once spent. The server keeps a redeemed
+    // token for ten minutes; the browser was holding one forever, so filling
+    // the form and submitting after a distraction failed with "could not
+    // verify you are human" and no way to tell why. Re-solving costs about
+    // 25ms.
+    const held = pending.current;
+    if (held && Date.now() - held.primedAt < TOKEN_FRESH_MS) return;
+    pending.current = { token: solveCap(scope), primedAt: Date.now() };
   }, [scope]);
 
   const headers = useCallback(async () => {
     prime();
-    const token = await pending.current!;
+    const token = await pending.current!.token;
+    // Single-use: a second submit has to solve again rather than replay a
+    // token the server has already burned.
     pending.current = null;
     return capHeaders(token);
   }, [prime]);

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -75,7 +75,7 @@ function loadCap(): Promise<void> {
  * element's `disconnectedCallback` aborts its AbortController, and every
  * `await` inside the widget's `solve()` is followed by
  * `if (signal?.aborted || !this.#speculative) return;`. So a widget removed
- * while it is working makes `solve()` resolve **undefined** — no token, no
+ * while it is working makes `solve()` resolve **undefined**: no token, no
  * throw, no error event. The old code created a throwaway element per solve
  * and removed it in a `finally`, which is exactly how to hit that path, and
  * an undefined result became an empty token, no `x-cap-token` header, and

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -19,7 +19,8 @@
  */
 import { useCallback, useRef } from "react";
 import wasmUrl from "@cap.js/wasm/browser/cap_wasm_bg.wasm?url";
-import { CAP_FAILED_CODE, CAP_TOKEN_HEADER } from "@/shared/types";
+import { CAP_TOKEN_HEADER } from "@/shared/types";
+import { retryOnCapFailure } from "./cap-retry";
 
 export type CapScope = "signup" | "password-reset";
 
@@ -207,37 +208,10 @@ export function useCap(scope: CapScope) {
     return capHeaders(token);
   }, [prime, scope]);
 
-  /**
-   * Runs a Cap-guarded request, and if the Worker refuses the token, solves
-   * a fresh one and runs it exactly once more.
-   *
-   * A token can be refused for reasons the browser cannot see coming: it
-   * expired, it was already spent, or the server forgot it. None of those
-   * are the visitor's doing and none of them are worth an error message, so
-   * proving ourselves again is the honest response. Once, not in a loop: a
-   * second refusal means something is actually wrong, and that one belongs
-   * on screen.
-   */
   const guarded = useCallback(
-    async <T>(run: (headers: Record<string, string>) => Promise<T>): Promise<T> => {
-      const first = await run(await headers());
-      if (!isCapFailure(first)) return first;
-      return run(await headers());
-    },
+    <T>(run: (headers: Record<string, string>) => Promise<T>) => retryOnCapFailure(run, headers),
     [headers],
   );
 
   return { prime, headers, guarded };
-}
-
-/**
- * Whether a result is the Worker turning down a Cap token.
- *
- * Covers both shapes this app gets back: better-auth returns `{ error }` on
- * the object rather than throwing, and api() rejects with an ApiError whose
- * `.code` comes from the response body.
- */
-function isCapFailure(result: unknown): boolean {
-  const error = (result as { error?: { code?: string } } | null)?.error;
-  return error?.code === CAP_FAILED_CODE;
 }

--- a/src/app/lib/cap.ts
+++ b/src/app/lib/cap.ts
@@ -1,0 +1,119 @@
+/**
+ * Cap on the client (#98): proof-of-work, solved without a checkbox.
+ *
+ * Cap ships a visible widget, but its element also exposes `solve()`, so we
+ * keep the element out of sight and drive it ourselves: work starts when the
+ * visitor first touches the form and the token is usually ready by the time
+ * they submit. Nobody clicks anything, and nobody waits on a spinner they
+ * did not ask for.
+ *
+ * Everything is served from our own origin. The widget is bundled from npm
+ * rather than pulled from Cap's CDN, and the WASM solver comes through Vite
+ * as a hashed asset, so `script-src 'self'` and `connect-src 'self'` already
+ * cover both. Loading either from a CDN would hand back the third-party
+ * runtime dependency that is the whole reason we chose Cap over Turnstile.
+ *
+ * A failure here never blocks the form. The token goes to the server, the
+ * server decides: an empty one is rejected when CAP_SECRET is set and
+ * ignored when it is not, which is what keeps local dev and CI quiet.
+ */
+import { useCallback, useRef } from "react";
+import wasmUrl from "@cap.js/wasm/browser/cap_wasm_bg.wasm?url";
+import { CAP_TOKEN_HEADER } from "@/shared/types";
+
+export type CapScope = "signup" | "password-reset" | "anon-link";
+
+/** How long to wait for a solve before giving up and submitting without one. */
+const SOLVE_TIMEOUT_MS = 20_000;
+
+type CapElement = HTMLElement & {
+  solve: () => Promise<{ token?: string }>;
+  reset: () => void;
+};
+
+let loading: Promise<void> | null = null;
+
+/** Loads the widget once, on demand, so it stays out of the initial bundle. */
+function loadCap(): Promise<void> {
+  loading ??= (async () => {
+    // Read at module-eval time by the widget, so it has to be set first, or
+    // it fetches the WASM from jsdelivr and trips the CSP.
+    (window as unknown as { CAP_CUSTOM_WASM_URL?: string }).CAP_CUSTOM_WASM_URL = wasmUrl;
+    await import("@cap.js/widget");
+  })();
+  return loading;
+}
+
+/**
+ * Starts solving a challenge for `scope` and resolves with the token.
+ *
+ * Resolves with "" on any failure, including a timeout. That is deliberate:
+ * a visitor whose browser cannot solve the puzzle should still be able to
+ * try, and be turned away by the server with a message, rather than face a
+ * form that silently refuses to submit.
+ */
+function solveCap(scope: CapScope): Promise<string> {
+  return (async () => {
+    try {
+      await loadCap();
+      const el = document.createElement("cap-widget") as CapElement;
+      el.setAttribute("data-cap-api-endpoint", `/api/cap/${scope}/`);
+      // Out of the layout entirely, not `display: none`: the widget skips
+      // its own background work when it believes it is invisible, and we
+      // want it working.
+      el.style.cssText = "position:absolute;width:1px;height:1px;overflow:hidden;opacity:0";
+      el.setAttribute("aria-hidden", "true");
+      // The widget dispatches its own "error" event and, with nothing
+      // listening, it surfaces as an unhandled error: a navigation that
+      // aborts an in-flight solve would otherwise look like a page crash.
+      // We already report failure by resolving with "".
+      el.addEventListener("error", (event) => event.stopPropagation());
+      document.body.appendChild(el);
+      try {
+        const result = await Promise.race([
+          el.solve(),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), SOLVE_TIMEOUT_MS)),
+        ]);
+        return result?.token ?? "";
+      } finally {
+        el.remove();
+      }
+    } catch {
+      return "";
+    }
+  })();
+}
+
+/** The header a solved token travels in, ready to spread into fetch options. */
+function capHeaders(token: string): Record<string, string> {
+  return token ? { [CAP_TOKEN_HEADER]: token } : {};
+}
+
+/**
+ * A token for one form.
+ *
+ * `prime()` is safe to call on every keystroke and starts the work once;
+ * hang it on the form's first focus so the puzzle is solving while the
+ * visitor types. `headers()` awaits whatever that produced, so a fast
+ * typist waits and everyone else does not.
+ *
+ * A token is single-use, so the primed promise is cleared once spent: a
+ * form submitted twice (a failed signup, then a corrected one) solves
+ * again rather than replaying a token the server has already burned.
+ */
+export function useCap(scope: CapScope) {
+  const pending = useRef<Promise<string> | null>(null);
+
+  const prime = useCallback(() => {
+    pending.current ??= solveCap(scope);
+  }, [scope]);
+
+  const headers = useCallback(async () => {
+    prime();
+    const token = await pending.current!;
+    pending.current = null;
+    return capHeaders(token);
+  }, [prime]);
+
+  return { prime, headers };
+}

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -16,6 +16,7 @@ import { friendlyAuthError } from "../lib/auth-errors";
 import posthog from "../lib/posthog";
 import { FUNNEL } from "../lib/funnel";
 import { useShake } from "../lib/use-shake";
+import { useCap } from "../lib/cap";
 import { useCurrentUser } from "../lib/hooks";
 import { firstFormError } from "../lib/form-errors";
 import { cn } from "../ui/cn";
@@ -237,6 +238,7 @@ function AuthFormView({
   next,
   onSubmit,
   onForgot,
+  onFirstInput,
 }: {
   mode: "login" | "signup";
   busy: boolean;
@@ -244,6 +246,9 @@ function AuthFormView({
   next: string;
   onSubmit: (email: string, password: string) => void;
   onForgot: (email: string) => void;
+  /** Starts the Cap proof-of-work (#98). Idempotent, so a per-keystroke
+   * handler is fine; it fires once and the work overlaps the typing. */
+  onFirstInput: () => void;
 }) {
   const copy = AUTH_MODE_COPY[mode];
   const toast = useToast();
@@ -265,6 +270,7 @@ function AuthFormView({
     <AuthCard>
       <form
         onSubmit={onFormSubmit}
+        onInput={onFirstInput}
         noValidate
         className="flex flex-col gap-4 rounded-xl bg-surface p-6 smooth-shadow-ring-sm"
       >
@@ -341,6 +347,8 @@ interface SubmitDeps {
   qc: QueryClient;
   navigate: NavigateFunction;
   next: string;
+  /** Awaits the Cap token primed when the form was first touched (#98). */
+  capHeaders: () => Promise<Record<string, string>>;
 }
 
 async function trySignIn(email: string, password: string, deps: SubmitDeps) {
@@ -362,13 +370,18 @@ async function trySignIn(email: string, password: string, deps: SubmitDeps) {
 async function trySignUp(
   email: string,
   password: string,
-  deps: Pick<SubmitDeps, "goVerify" | "failSubmit">,
+  deps: Pick<SubmitDeps, "goVerify" | "failSubmit" | "capHeaders">,
 ) {
-  const { error: signUpError } = await authClient.signUp.email({
-    email,
-    password,
-    name: email.split("@")[0],
-  });
+  const { error: signUpError } = await authClient.signUp.email(
+    {
+      email,
+      password,
+      name: email.split("@")[0],
+    },
+    // Cap's proof-of-work token (#98). Solved while the visitor was typing,
+    // spent here, and required by the Worker before an account exists.
+    { headers: await deps.capHeaders() },
+  );
   if (signUpError) {
     deps.failSubmit(friendlyAuthError(signUpError));
   } else {
@@ -427,6 +440,10 @@ function useAuthFlow(mode: "login" | "signup") {
   const [busy, setBusy] = useState(false);
   const [verifyPhase, setVerifyPhase] = useState<"idle" | "success" | "leaving">("idle");
   const shake = useShake();
+  // Two scopes, two tokens: one minted for signup must not be spendable on a
+  // password reset, so Cap binds the scope into the signature.
+  const signupCap = useCap("signup");
+  const resetCap = useCap("password-reset");
 
   const [prevMode, setPrevMode] = useState(mode);
   if (prevMode !== mode) {
@@ -494,7 +511,7 @@ function useAuthFlow(mode: "login" | "signup") {
     authPasswordRef.current = password;
     setBusy(true);
     try {
-      const deps = { goVerify, failSubmit, qc, navigate, next };
+      const deps = { goVerify, failSubmit, qc, navigate, next, capHeaders: signupCap.headers };
       await (mode === "login"
         ? trySignIn(email, password, deps)
         : trySignUp(email, password, deps));
@@ -569,10 +586,12 @@ function useAuthFlow(mode: "login" | "signup") {
   const submitForgot = async (email: string) => {
     setForgotBusy(true);
     try {
-      const { error: resetError } = await authClient.requestPasswordReset({
-        email,
-        redirectTo: "/reset-password",
-      });
+      const { error: resetError } = await authClient.requestPasswordReset(
+        { email, redirectTo: "/reset-password" },
+        // Cheap to abuse and it sends mail, which is why #50 needed a
+        // per-recipient cap. Cap prices the attempt instead (#98).
+        { headers: await resetCap.headers() },
+      );
       if (resetError) {
         toast(resetError.message ?? "Something went wrong", "error");
         return;
@@ -600,6 +619,11 @@ function useAuthFlow(mode: "login" | "signup") {
     resendOtp,
     submitForgot,
     backToForm,
+    /** Hung on the forms' first interaction so the proof-of-work runs while
+     * the visitor types, instead of stalling the submit. Signup only: a
+     * password reset is rare enough that a short wait on submit is fine, and
+     * priming it would tax everyone who came to log in. */
+    primeSignupCap: signupCap.prime,
   };
 }
 
@@ -642,6 +666,7 @@ export function AuthPage({ mode }: { mode: "login" | "signup" }) {
       shake={flow.shake}
       next={flow.next}
       onSubmit={flow.submit}
+      onFirstInput={flow.primeSignupCap}
       onForgot={(email) => {
         flow.setAuthEmail(email);
         flow.setView("forgot");

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -347,8 +347,8 @@ interface SubmitDeps {
   qc: QueryClient;
   navigate: NavigateFunction;
   next: string;
-  /** Awaits the Cap token primed when the form was first touched (#98). */
-  capHeaders: () => Promise<Record<string, string>>;
+  /** Runs a Cap-guarded request, re-solving once if the token is refused. */
+  capGuarded: <T>(run: (headers: Record<string, string>) => Promise<T>) => Promise<T>;
 }
 
 async function trySignIn(email: string, password: string, deps: SubmitDeps) {
@@ -370,17 +370,14 @@ async function trySignIn(email: string, password: string, deps: SubmitDeps) {
 async function trySignUp(
   email: string,
   password: string,
-  deps: Pick<SubmitDeps, "goVerify" | "failSubmit" | "capHeaders">,
+  deps: Pick<SubmitDeps, "goVerify" | "failSubmit" | "capGuarded">,
 ) {
-  const { error: signUpError } = await authClient.signUp.email(
-    {
-      email,
-      password,
-      name: email.split("@")[0],
-    },
-    // Cap's proof-of-work token (#98). Solved while the visitor was typing,
-    // spent here, and required by the Worker before an account exists.
-    { headers: await deps.capHeaders() },
+  // Cap's proof-of-work token (#98). Solved while the visitor was typing,
+  // spent here, and required by the Worker before an account exists. Through
+  // the guard, so a token the server has forgotten is solved again rather
+  // than shown to somebody as an error.
+  const { error: signUpError } = await deps.capGuarded((headers) =>
+    authClient.signUp.email({ email, password, name: email.split("@")[0] }, { headers }),
   );
   if (signUpError) {
     deps.failSubmit(friendlyAuthError(signUpError));
@@ -511,7 +508,7 @@ function useAuthFlow(mode: "login" | "signup") {
     authPasswordRef.current = password;
     setBusy(true);
     try {
-      const deps = { goVerify, failSubmit, qc, navigate, next, capHeaders: signupCap.headers };
+      const deps = { goVerify, failSubmit, qc, navigate, next, capGuarded: signupCap.guarded };
       await (mode === "login"
         ? trySignIn(email, password, deps)
         : trySignUp(email, password, deps));
@@ -586,11 +583,10 @@ function useAuthFlow(mode: "login" | "signup") {
   const submitForgot = async (email: string) => {
     setForgotBusy(true);
     try {
-      const { error: resetError } = await authClient.requestPasswordReset(
-        { email, redirectTo: "/reset-password" },
-        // Cheap to abuse and it sends mail, which is why #50 needed a
-        // per-recipient cap. Cap prices the attempt instead (#98).
-        { headers: await resetCap.headers() },
+      // Cheap to abuse and it sends mail, which is why #50 needed a
+      // per-recipient cap. Cap prices the attempt instead (#98).
+      const { error: resetError } = await resetCap.guarded((headers) =>
+        authClient.requestPasswordReset({ email, redirectTo: "/reset-password" }, { headers }),
       );
       if (resetError) {
         toast(resetError.message ?? "Something went wrong", "error");

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -481,18 +481,23 @@ function useAuthFlow(mode: "login" | "signup") {
       email,
       type: "email-verification",
     });
-    if (error) {
-      // No EMAIL_VERIFIED branch: the server answers an already-verified
-      // address exactly as it answers a fresh one, so an anonymous caller
-      // cannot tell them apart (#53). The account's owner is told by email.
-      failSubmit(error.message ?? "Could not send the verification code");
-      return;
-    }
-    // Funnel step 5a (#64). This one belongs here because both callers do
-    // genuinely send a code. Step 4 does not: goVerify is also reached from
-    // trySignIn's EMAIL_NOT_VERIFIED branch, so counting a signup here would
-    // count every returning unverified user as a new one.
-    posthog.capture(FUNNEL.verificationSent, { resend: false });
+    // No EMAIL_VERIFIED branch: the server answers an already-verified
+    // address exactly as it answers a fresh one, so an anonymous caller
+    // cannot tell them apart (#53). The account's owner is told by email.
+    if (error) failSubmit(error.message ?? "Could not send the verification code");
+    // Funnel step 5a (#64). Only when a code really went out. Step 4 does not
+    // belong here: goVerify is also reached from trySignIn's
+    // EMAIL_NOT_VERIFIED branch, so counting a signup here would count every
+    // returning unverified user as a new one.
+    else posthog.capture(FUNNEL.verificationSent, { resend: false });
+
+    // The code screen either way, error or not. By the time we get here the
+    // account exists, and a failed send is usually the email rate limit
+    // (#50), which clears in a minute. Staying on the signup form told
+    // somebody the opposite: it looks like the signup failed, so they submit
+    // again, which spends another send and puts them back here. The code
+    // screen is the honest place to be stranded, because it has the resend
+    // button that gets them out.
     setAuthEmail(email);
     writePending({ email, next });
     setView("verify-otp");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,10 @@
  * against its own schema. */
 export const CAP_TOKEN_HEADER = "x-cap-token";
 
+/** What the Worker answers when a Cap token is missing, expired, or already
+ * spent. The browser retries once with a fresh one rather than showing it. */
+export const CAP_FAILED_CODE = "CAP_FAILED";
+
 export type OrgRole = "owner" | "admin" | "member";
 export type OrgPlan = "free" | "hobby" | "pro";
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,8 @@
+/** Carries a solved Cap token (#98) on the requests that need one. A header,
+ * not a body field, because better-auth validates each endpoint's body
+ * against its own schema. */
+export const CAP_TOKEN_HEADER = "x-cap-token";
+
 export type OrgRole = "owner" | "admin" | "member";
 export type OrgPlan = "free" | "hobby" | "pro";
 

--- a/src/worker/better-auth.ts
+++ b/src/worker/better-auth.ts
@@ -348,7 +348,7 @@ function buildAuth(env: Env) {
             // would break the first time the wording changed.
             throw new APIError("BAD_REQUEST", {
               code: CAP_FAILED_CODE,
-              message: "Could not verify you are human. Trying again…",
+              message: "Could not verify you are human. Reload the page and try again.",
             });
         }
         if (ctx.path === "/email-otp/send-verification-otp") {

--- a/src/worker/better-auth.ts
+++ b/src/worker/better-auth.ts
@@ -13,7 +13,7 @@ import { renderEmail } from "./email-layout";
 import { hashPassword, verifyPassword } from "./password";
 import { uid } from "./util";
 import { spendToken, type CapScope } from "./cap";
-import { CAP_TOKEN_HEADER } from "@/shared/types";
+import { CAP_FAILED_CODE, CAP_TOKEN_HEADER } from "@/shared/types";
 
 /** better-auth paths that must carry a solved Cap token, and the scope the
  * token has to have been minted for. Keyed by `ctx.path`, which is relative
@@ -343,8 +343,12 @@ function buildAuth(env: Env) {
           // mercy of that schema.
           const token = ctx.headers?.get(CAP_TOKEN_HEADER) ?? "";
           if (!(await spendToken(env, capScope, token)))
+            // A code, not just a message: the browser retries this once with
+            // a freshly solved token, and matching on prose to decide that
+            // would break the first time the wording changed.
             throw new APIError("BAD_REQUEST", {
-              message: "Could not verify you are human. Reload the page and try again.",
+              code: CAP_FAILED_CODE,
+              message: "Could not verify you are human. Trying again…",
             });
         }
         if (ctx.path === "/email-otp/send-verification-otp") {

--- a/src/worker/better-auth.ts
+++ b/src/worker/better-auth.ts
@@ -12,6 +12,16 @@ import { sendEmail } from "./email";
 import { renderEmail } from "./email-layout";
 import { hashPassword, verifyPassword } from "./password";
 import { uid } from "./util";
+import { spendToken, type CapScope } from "./cap";
+import { CAP_TOKEN_HEADER } from "@/shared/types";
+
+/** better-auth paths that must carry a solved Cap token, and the scope the
+ * token has to have been minted for. Keyed by `ctx.path`, which is relative
+ * to /api/auth. */
+const CAP_GUARDED_PATHS: Record<string, CapScope> = {
+  "/sign-up/email": "signup",
+  "/request-password-reset": "password-reset",
+};
 
 const DNS_CHECK_TIMEOUT = 3000;
 
@@ -322,6 +332,21 @@ function buildAuth(env: Env) {
       // response instead of running the endpoint. Both guards use that to
       // answer exactly as the real path would while doing nothing (#53).
       before: createAuthMiddleware(async (ctx) => {
+        // Cap (#98) sits in front of the two paths a bot actually wants:
+        // creating accounts, and making us send mail. Not login, where a bot
+        // with correct credentials is not the threat and every real visitor
+        // would pay the tax.
+        const capScope = CAP_GUARDED_PATHS[ctx.path];
+        if (capScope) {
+          // In a header, not the body: better-auth validates each endpoint's
+          // body against its own schema, and an extra key there is at the
+          // mercy of that schema.
+          const token = ctx.headers?.get(CAP_TOKEN_HEADER) ?? "";
+          if (!(await spendToken(env, capScope, token)))
+            throw new APIError("BAD_REQUEST", {
+              message: "Could not verify you are human. Reload the page and try again.",
+            });
+        }
         if (ctx.path === "/email-otp/send-verification-otp") {
           return guardVerificationOTPSend(
             db,

--- a/src/worker/cap-unused-dep-stub.ts
+++ b/src/worker/cap-unused-dep-stub.ts
@@ -1,0 +1,15 @@
+/**
+ * Stands in for `esbuild` and `javascript-obfuscator` in the bundle (#98).
+ *
+ * capjs-core imports both, lazily and inside a try/catch, only to build the
+ * script for its browser-instrumentation mode. We do not use that mode: it
+ * fingerprints the visitor to spot automation, which is the exact thing we
+ * rejected Turnstile for, and proof-of-work needs neither package.
+ *
+ * The bundler does not know that. It followed the dynamic imports and emitted
+ * a 5 MB javascript-obfuscator chunk into the Worker, along with a direct-eval
+ * warning, for code that never runs. Aliasing both here throws on import
+ * instead, which is precisely what capjs-core's own try/catch expects: it
+ * records the tool as unavailable and carries on.
+ */
+throw new Error("capjs-core instrumentation is not enabled in this app (#98)");

--- a/src/worker/cap.ts
+++ b/src/worker/cap.ts
@@ -21,7 +21,7 @@ import { keyedDigest } from "./rate-limit";
 
 /** Namespaces the challenge so a token minted for signup cannot be spent on
  * password reset. Cap binds this into the signature. */
-export type CapScope = "signup" | "password-reset" | "anon-link";
+export type CapScope = "signup" | "password-reset";
 
 /** How long a solved token stays spendable. Long enough to finish typing a
  * form, short enough that a harvested one is worthless. */

--- a/src/worker/cap.ts
+++ b/src/worker/cap.ts
@@ -1,0 +1,113 @@
+/**
+ * Cap: proof-of-work challenges, issued and verified by this Worker (#98).
+ *
+ * A rate limit is a ceiling; this is a price. It catches the distributed,
+ * low-and-slow bot that stays politely under every limit, by making each
+ * attempt cost real CPU in the caller's browser.
+ *
+ * `capjs-core` is stateless, so there is no Cap server to run: challenges
+ * are signed with CAP_SECRET and verified against that signature. The only
+ * state we keep is the single-use nonce, in the KV namespace we already
+ * have.
+ *
+ * Instrumentation is deliberately off. That mode fingerprints the browser to
+ * spot automation, which is the exact thing we rejected Turnstile for, and it
+ * pulls esbuild and javascript-obfuscator in at runtime to build the probe
+ * script. Proof-of-work needs neither.
+ */
+import { generateChallenge, validateChallenge } from "capjs-core";
+import type { Env } from "./env";
+
+/** Namespaces the challenge so a token minted for signup cannot be spent on
+ * password reset. Cap binds this into the signature. */
+export type CapScope = "signup" | "password-reset" | "anon-link";
+
+/** How long a solved token stays spendable. Long enough to finish typing a
+ * form, short enough that a harvested one is worthless. */
+const TOKEN_TTL_MS = 10 * 60 * 1000;
+/** How long an unsolved challenge stays valid. */
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Work the client must do. Cap's defaults (50 challenges of difficulty 4)
+ * take multiple seconds on a phone, which is a tax on the honest visitor
+ * for no extra deterrence. These land around 200-400ms on a laptop while
+ * still making bulk automation pay per attempt.
+ */
+const CHALLENGE_COUNT = 12;
+const CHALLENGE_SIZE = 24;
+const CHALLENGE_DIFFICULTY = 3;
+
+/** Off unless CAP_SECRET is set, matching BETTERSTACK_INGEST_URL and friends:
+ * local dev, CI and e2e stay quiet rather than breaking signup. */
+export function capEnabled(env: Env): boolean {
+  return !!env.CAP_SECRET;
+}
+
+export async function issueChallenge(env: Env, scope: CapScope) {
+  return generateChallenge(env.CAP_SECRET!, {
+    challengeCount: CHALLENGE_COUNT,
+    challengeSize: CHALLENGE_SIZE,
+    challengeDifficulty: CHALLENGE_DIFFICULTY,
+    expiresMs: CHALLENGE_TTL_MS,
+    scope,
+  });
+}
+
+/**
+ * Marks a challenge signature spent, and reports whether it was already.
+ *
+ * KV is eventually consistent, so a token presented to two colocations at
+ * once can pass twice: the write has not propagated yet. That is a real
+ * ceiling and it is an acceptable one for a captcha, whose job is to price
+ * bulk attempts rather than to guarantee exactly-once. Making it airtight
+ * would mean a Durable Object per nonce, which costs more than the replay
+ * is worth.
+ */
+async function consumeNonce(env: Env, signatureHex: string, ttlMs: number): Promise<boolean> {
+  const key = `cap:${signatureHex}`;
+  if (await env.LINKS.get(key)) return false;
+  // KV's floor is 60s; a shorter TTL is rejected outright.
+  await env.LINKS.put(key, "1", { expirationTtl: Math.max(60, Math.ceil(ttlMs / 1000)) });
+  return true;
+}
+
+export async function verifySolution(
+  env: Env,
+  scope: CapScope,
+  body: { token: string; solutions: unknown },
+) {
+  return validateChallenge(
+    env.CAP_SECRET!,
+    { token: body.token, solutions: body.solutions as number[] },
+    {
+      scope,
+      tokenTtlMs: TOKEN_TTL_MS,
+      consumeNonce: (signatureHex, ttlMs) => consumeNonce(env, signatureHex, ttlMs),
+    },
+  );
+}
+
+/**
+ * Checks the token a form submitted, and burns it.
+ *
+ * Cap's own flow hands the client a redeemed token to submit; we verify that
+ * token here against the same secret. The redeemed token is stored in KV at
+ * redeem time and deleted here, so it works exactly once no matter how many
+ * times the form is replayed.
+ */
+export async function spendToken(env: Env, scope: CapScope, token: string): Promise<boolean> {
+  if (!capEnabled(env)) return true;
+  if (!token) return false;
+  const key = `cap:token:${scope}:${token}`;
+  const found = await env.LINKS.get(key);
+  if (!found) return false;
+  await env.LINKS.delete(key);
+  return true;
+}
+
+/** Records a redeemed token so `spendToken` can find it once. */
+export async function storeToken(env: Env, scope: CapScope, token: string, expires: number) {
+  const ttl = Math.max(60, Math.ceil((expires - Date.now()) / 1000));
+  await env.LINKS.put(`cap:token:${scope}:${token}`, "1", { expirationTtl: ttl });
+}

--- a/src/worker/cap.ts
+++ b/src/worker/cap.ts
@@ -17,6 +17,7 @@
  */
 import { generateChallenge, validateChallenge } from "capjs-core";
 import type { Env } from "./env";
+import { keyedDigest } from "./rate-limit";
 
 /** Namespaces the challenge so a token minted for signup cannot be spent on
  * password reset. Cap binds this into the signature. */
@@ -84,30 +85,50 @@ export async function verifySolution(
       scope,
       tokenTtlMs: TOKEN_TTL_MS,
       consumeNonce: (signatureHex, ttlMs) => consumeNonce(env, signatureHex, ttlMs),
+      // Signed, not stored. Cap's default token is a random string the server
+      // has to remember, and remembering it here meant a KV write at /redeem
+      // read back by the form submit a second later. KV is eventually
+      // consistent: that read missed often enough that signup failed for
+      // real people, and re-solving lost the same race (#98).
+      signToken: ({ expires }) => signToken(env, scope, expires),
     },
   );
+}
+
+/** Compares two same-length strings without leaking where they differ. */
+function equalsConstantTime(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/** `expires.signature`, signed with CAP_SECRET so any colocation can check it
+ * without shared state. */
+async function signToken(env: Env, scope: CapScope, expires: number): Promise<string> {
+  return `${expires}.${await keyedDigest(env.CAP_SECRET!, `cap:${scope}:${expires}`)}`;
 }
 
 /**
  * Checks the token a form submitted, and burns it.
  *
- * Cap's own flow hands the client a redeemed token to submit; we verify that
- * token here against the same secret. The redeemed token is stored in KV at
- * redeem time and deleted here, so it works exactly once no matter how many
- * times the form is replayed.
+ * The signature is the whole check, so a valid token is accepted whatever KV
+ * knows. KV only records that a token was spent, to turn away a replay: a
+ * lookup that misses because the write has not propagated lets one extra
+ * submit through within the ten-minute window, which is the direction this
+ * should fail in.
  */
 export async function spendToken(env: Env, scope: CapScope, token: string): Promise<boolean> {
   if (!capEnabled(env)) return true;
-  if (!token) return false;
-  const key = `cap:token:${scope}:${token}`;
-  const found = await env.LINKS.get(key);
-  if (!found) return false;
-  await env.LINKS.delete(key);
-  return true;
-}
+  const [expires] = token.split(".");
+  const expiresAt = Number(expires);
+  if (!expiresAt || expiresAt < Date.now()) return false;
+  if (!equalsConstantTime(token, await signToken(env, scope, expiresAt))) return false;
 
-/** Records a redeemed token so `spendToken` can find it once. */
-export async function storeToken(env: Env, scope: CapScope, token: string, expires: number) {
-  const ttl = Math.max(60, Math.ceil((expires - Date.now()) / 1000));
-  await env.LINKS.put(`cap:token:${scope}:${token}`, "1", { expirationTtl: ttl });
+  const key = `cap:spent:${scope}:${token}`;
+  if (await env.LINKS.get(key)) return false;
+  await env.LINKS.put(key, "1", {
+    expirationTtl: Math.max(60, Math.ceil((expiresAt - Date.now()) / 1000)),
+  });
+  return true;
 }

--- a/src/worker/cap.ts
+++ b/src/worker/cap.ts
@@ -119,16 +119,32 @@ async function signToken(env: Env, scope: CapScope, expires: number): Promise<st
  * should fail in.
  */
 export async function spendToken(env: Env, scope: CapScope, token: string): Promise<boolean> {
-  if (!capEnabled(env)) return true;
+  const outcome = await checkToken(env, scope, token);
+  // The caller is told nothing beyond "no", because the reason tells a bot
+  // which knob to turn. The log is where somebody holding a support report
+  // finds out which of five different failures they are looking at: without
+  // it, "could not verify you are human" is the same sentence for a missing
+  // token, an expired one, a replayed one, and a wrong secret.
+  if (outcome !== "ok") console.warn("cap_refused", scope, outcome);
+  return outcome === "ok";
+}
+
+type CapOutcome = "ok" | "missing" | "malformed" | "expired" | "bad_signature" | "already_spent";
+
+async function checkToken(env: Env, scope: CapScope, token: string): Promise<CapOutcome> {
+  if (!capEnabled(env)) return "ok";
+  if (!token) return "missing";
+
   const [expires] = token.split(".");
   const expiresAt = Number(expires);
-  if (!expiresAt || expiresAt < Date.now()) return false;
-  if (!equalsConstantTime(token, await signToken(env, scope, expiresAt))) return false;
+  if (!expiresAt) return "malformed";
+  if (expiresAt < Date.now()) return "expired";
+  if (!equalsConstantTime(token, await signToken(env, scope, expiresAt))) return "bad_signature";
 
   const key = `cap:spent:${scope}:${token}`;
-  if (await env.LINKS.get(key)) return false;
+  if (await env.LINKS.get(key)) return "already_spent";
   await env.LINKS.put(key, "1", {
     expirationTtl: Math.max(60, Math.ceil((expiresAt - Date.now()) / 1000)),
   });
-  return true;
+  return "ok";
 }

--- a/src/worker/cap.ts
+++ b/src/worker/cap.ts
@@ -15,6 +15,7 @@
  * pulls esbuild and javascript-obfuscator in at runtime to build the probe
  * script. Proof-of-work needs neither.
  */
+import { HTTPException } from "hono/http-exception";
 import { generateChallenge, validateChallenge } from "capjs-core";
 import type { Env } from "./env";
 import { keyedDigest } from "./rate-limit";
@@ -45,7 +46,33 @@ export function capEnabled(env: Env): boolean {
   return !!env.CAP_SECRET;
 }
 
+/**
+ * capjs-core refuses a secret under 16 bytes, and it refuses it by throwing
+ * at the moment a challenge is issued rather than at startup. Unhandled, that
+ * reached the top of the Worker as a 500 with a library stack trace in it.
+ *
+ * Checked here so the failure is ours and legible. It must stay a failure:
+ * treating an unusable secret as "no secret" would fall through to the
+ * disabled path and leave signup looking configured and completely
+ * unprotected, which is the one outcome worse than being down.
+ */
+const MIN_SECRET_BYTES = 16;
+
+export function capSecretUsable(env: Env): boolean {
+  return new TextEncoder().encode(env.CAP_SECRET ?? "").length >= MIN_SECRET_BYTES;
+}
+
+/** Throws when Cap is switched on with a secret it cannot use. */
+export function assertCapUsable(env: Env): void {
+  if (!capEnabled(env) || capSecretUsable(env)) return;
+  console.error("cap_misconfigured", "CAP_SECRET is shorter than 16 bytes");
+  throw new HTTPException(503, {
+    message: "Verification is unavailable. Try again shortly.",
+  });
+}
+
 export async function issueChallenge(env: Env, scope: CapScope) {
+  assertCapUsable(env);
   return generateChallenge(env.CAP_SECRET!, {
     challengeCount: CHALLENGE_COUNT,
     challengeSize: CHALLENGE_SIZE,
@@ -133,6 +160,9 @@ type CapOutcome = "ok" | "missing" | "malformed" | "expired" | "bad_signature" |
 
 async function checkToken(env: Env, scope: CapScope, token: string): Promise<CapOutcome> {
   if (!capEnabled(env)) return "ok";
+  // Set but unusable is not the same as unset: refuse rather than wave the
+  // request through on a check that can never have run.
+  assertCapUsable(env);
   if (!token) return "missing";
 
   const [expires] = token.split(".");

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -52,6 +52,9 @@ export interface Env {
   // Any other value (including unset) calls the real API, or fails closed.
   CF_DEV_ENV?: string;
 
+  /* bot protection: Cap proof-of-work (#98). Unset disables the check. */
+  CAP_SECRET?: string; // secret, `openssl rand -hex 32`
+
   /* alerting: dead-lettered storage messages (best-effort, never blocks acking) */
   BETTERSTACK_SOURCE_TOKEN?: string; // secret
   BETTERSTACK_INGEST_URL?: string; // var, e.g. https://in.logs.betterstack.com

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -17,6 +17,10 @@ export interface Env {
   /* click ingestion: redirects enqueue instead of writing D1 directly */
   CLICK_QUEUE: Queue<ClickMessage>;
   RL_AUTH_PUBLIC: RateLimit;
+  /* Cap's challenge and redeem endpoints (#98), on their own budget: issuing
+     a challenge is cheap for us and the proof-of-work is what costs the
+     caller, so this must never be the thing a person meets. */
+  RL_CAP: RateLimit;
   RL_EMAIL: RateLimit;
   RL_EMAIL_RECIPIENT: RateLimit;
   RL_WRITE_FREE: RateLimit;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -13,6 +13,7 @@ import { qrLogoRoutes } from "./routes/qr-logos";
 import { adminRoutes } from "./routes/admin";
 import { billingRoutes, handlePolarWebhook } from "./routes/billing";
 import { domainRoutes } from "./routes/domains";
+import { capRoutes } from "./routes/cap";
 import { resolveSlug, resolveDomain, type KVLink } from "./kv";
 import { RESERVED_SLUGS } from "./util";
 import { enforcePublicAuthRateLimit, enforceSignedApiRateLimit } from "./rate-limit";
@@ -121,6 +122,14 @@ app.on(["GET", "POST"], "/api/auth/*", async (c) => {
   // address exists (#53).
   return withBackground(c.executionCtx, () => getAuth(c.env).handler(c.req.raw));
 });
+
+// Cap (#98): public, and necessarily so, since it guards signup itself.
+// Same public rate limit as the auth routes it protects.
+app.post("/api/cap/*", async (c, next) => {
+  const limited = await enforcePublicAuthRateLimit(c);
+  return limited ?? next();
+});
+app.route("/api/cap", capRoutes);
 
 // Polar webhook: public, signature-verified, no session middleware.
 app.post("/api/webhooks/polar", (c) => handlePolarWebhook(c.req.raw, c.env));

--- a/src/worker/rate-limit.ts
+++ b/src/worker/rate-limit.ts
@@ -5,6 +5,7 @@ const RATE_LIMIT_WINDOW_SECONDS = 60;
 
 export type RateLimitGroup =
   | "auth"
+  | "cap"
   | "email"
   | "write"
   | "qr_upload"
@@ -115,13 +116,14 @@ async function recipientKey(request: Request, secret: string): Promise<string | 
   return keyedDigest(secret, normalized);
 }
 
-export function publicAuthGroup(path: string): "auth" | "email" | null {
+export function publicAuthGroup(path: string): "auth" | "cap" | "email" | null {
   if (EMAIL_AUTH_PATHS.has(path)) return "email";
-  // Cap's own endpoints (#98). They sit in front of signup, so they are as
-  // public as the auth routes and belong on the same budget. The key carries
-  // the path, so a challenge and a redeem each get their own count and one
-  // person solving a puzzle twice is nowhere near the limit.
-  if (path.startsWith("/api/cap/")) return "auth";
+  // Cap's own endpoints (#98), on their own budget rather than signup's. They
+  // are spent two at a time (challenge, then redeem) by every person who
+  // fills the form, and when this runs out the widget cannot solve at all:
+  // the browser then sends no token and the form says "could not verify you
+  // are human", which is the worst possible way for a rate limit to show up.
+  if (path.startsWith("/api/cap/")) return "cap";
   if (
     path.startsWith("/api/auth/") &&
     path !== "/api/auth/get-session" &&
@@ -131,11 +133,18 @@ export function publicAuthGroup(path: string): "auth" | "email" | null {
   return null;
 }
 
+/** Which counter each public group spends. */
+const PUBLIC_LIMIT_BINDINGS: Record<"auth" | "cap" | "email", (env: Env) => RateLimit> = {
+  auth: (env) => env.RL_AUTH_PUBLIC,
+  cap: (env) => env.RL_CAP,
+  email: (env) => env.RL_EMAIL,
+};
+
 export async function enforcePublicAuthRateLimit(c: Context<AppEnv>): Promise<Response | null> {
   const group = publicAuthGroup(c.req.path);
   if (!group) return null;
   const client = await publicClientKey(c.req.raw, c.env.BETTER_AUTH_SECRET);
-  const binding = group === "email" ? c.env.RL_EMAIL : c.env.RL_AUTH_PUBLIC;
+  const binding = PUBLIC_LIMIT_BINDINGS[group](c.env);
   const allowed = await rateLimitAllows(binding, `${group}:${c.req.path}:${client}`, {
     group,
     method: c.req.method,
@@ -168,7 +177,7 @@ export async function enforcePublicAuthRateLimit(c: Context<AppEnv>): Promise<Re
 export function signedApiGroup(
   path: string,
   method: string,
-): Exclude<RateLimitGroup, "auth" | "email" | "click"> | null {
+): Exclude<RateLimitGroup, "auth" | "cap" | "email" | "click"> | null {
   if (/^\/api\/billing\/(?:checkout|portal)$/.test(path)) return "checkout";
   if (method === "POST" && /^\/api\/orgs\/[^/]+\/qr-logo\/?$/.test(path)) return "qr_upload";
   if (/^\/api\/orgs\/[^/]+\/domains(?:\/|$)/.test(path)) return "domain";

--- a/src/worker/rate-limit.ts
+++ b/src/worker/rate-limit.ts
@@ -117,6 +117,11 @@ async function recipientKey(request: Request, secret: string): Promise<string | 
 
 export function publicAuthGroup(path: string): "auth" | "email" | null {
   if (EMAIL_AUTH_PATHS.has(path)) return "email";
+  // Cap's own endpoints (#98). They sit in front of signup, so they are as
+  // public as the auth routes and belong on the same budget. The key carries
+  // the path, so a challenge and a redeem each get their own count and one
+  // person solving a puzzle twice is nowhere near the limit.
+  if (path.startsWith("/api/cap/")) return "auth";
   if (
     path.startsWith("/api/auth/") &&
     path !== "/api/auth/get-session" &&

--- a/src/worker/rate-limit.ts
+++ b/src/worker/rate-limit.ts
@@ -71,7 +71,7 @@ function hex(bytes: ArrayBuffer): string {
 /** Keyed HMAC over `value`. The digest is the only form an identifier takes
  * once it leaves the request: what ends up in a rate-limit counter is never
  * the address itself. */
-async function keyedDigest(secret: string, value: string): Promise<string> {
+export async function keyedDigest(secret: string, value: string): Promise<string> {
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
     "raw",

--- a/src/worker/routes/cap.ts
+++ b/src/worker/routes/cap.ts
@@ -1,0 +1,50 @@
+/**
+ * The two public endpoints Cap's widget talks to (#98).
+ *
+ * Public by design: they sit in front of signup, so requiring a session
+ * would defeat the point. They are covered by the same public auth rate
+ * limit as /api/auth/*, and issuing a challenge is cheap while solving one
+ * is not, which is the asymmetry the whole scheme rests on.
+ */
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+import { capEnabled, issueChallenge, storeToken, verifySolution, type CapScope } from "../cap";
+
+const SCOPES: readonly CapScope[] = ["signup", "password-reset", "anon-link"];
+
+/** The scope rides in the path, not the body: Cap's widget builds its own
+ * request bodies and only lets us choose the endpoint prefix. */
+function readScope(value: unknown): CapScope | null {
+  return SCOPES.find((s) => s === value) ?? null;
+}
+
+export const capRoutes = new Hono<AppEnv>();
+
+capRoutes.post("/:scope/challenge", async (c) => {
+  if (!capEnabled(c.env)) return c.json({ disabled: true });
+  const scope = readScope(c.req.param("scope"));
+  if (!scope) return c.json({ message: "Unknown scope" }, 400);
+  return c.json(await issueChallenge(c.env, scope));
+});
+
+capRoutes.post("/:scope/redeem", async (c) => {
+  if (!capEnabled(c.env)) return c.json({ disabled: true });
+  const scope = readScope(c.req.param("scope"));
+  const body = (await c.req.json().catch(() => ({}))) as {
+    token?: unknown;
+    solutions?: unknown;
+  };
+  if (!scope || typeof body.token !== "string" || !Array.isArray(body.solutions))
+    return c.json({ success: false, message: "Malformed solution" }, 400);
+
+  const result = await verifySolution(c.env, scope, {
+    token: body.token,
+    solutions: body.solutions,
+  });
+  // The reason is deliberately not echoed: it tells a bot which knob to
+  // turn, and tells a person nothing they can act on.
+  if (!result.success) return c.json({ success: false }, 400);
+
+  await storeToken(c.env, scope, result.token, result.expires);
+  return c.json({ success: true, token: result.token, expires: result.expires });
+});

--- a/src/worker/routes/cap.ts
+++ b/src/worker/routes/cap.ts
@@ -10,7 +10,7 @@ import { Hono } from "hono";
 import type { AppEnv } from "../env";
 import { capEnabled, issueChallenge, verifySolution, type CapScope } from "../cap";
 
-const SCOPES: readonly CapScope[] = ["signup", "password-reset", "anon-link"];
+const SCOPES: readonly CapScope[] = ["signup", "password-reset"];
 
 /** The scope rides in the path, not the body: Cap's widget builds its own
  * request bodies and only lets us choose the endpoint prefix. */

--- a/src/worker/routes/cap.ts
+++ b/src/worker/routes/cap.ts
@@ -8,7 +8,7 @@
  */
 import { Hono } from "hono";
 import type { AppEnv } from "../env";
-import { capEnabled, issueChallenge, storeToken, verifySolution, type CapScope } from "../cap";
+import { capEnabled, issueChallenge, verifySolution, type CapScope } from "../cap";
 
 const SCOPES: readonly CapScope[] = ["signup", "password-reset", "anon-link"];
 
@@ -45,6 +45,5 @@ capRoutes.post("/:scope/redeem", async (c) => {
   // turn, and tells a person nothing they can act on.
   if (!result.success) return c.json({ success: false }, 400);
 
-  await storeToken(c.env, scope, result.token, result.expires);
   return c.json({ success: true, token: result.token, expires: result.expires });
 });

--- a/src/worker/security-headers.ts
+++ b/src/worker/security-headers.ts
@@ -31,9 +31,15 @@ const POSTHOG = "https://*.posthog.com";
 // so a deployed Worker cannot ship 'unsafe-inline' through a misread var.
 // The tradeoff is that e2e exercises a marginally looser policy than
 // production; everything except this one directive is identical.
+// 'wasm-unsafe-eval' is for Cap's solver (#98). WebAssembly.compile() counts
+// as script evaluation, so `script-src 'self'` refuses it outright and the
+// widget falls back to a pure-JS solver. This directive exists precisely to
+// allow WASM without allowing eval() or inline script: it buys back the fast
+// path on the phones that need it most, and grants nothing else. The module
+// itself is a same-origin Vite asset, never a CDN.
 const SCRIPT_SRC = import.meta.env.DEV
-  ? `script-src 'self' 'unsafe-inline' ${POSTHOG}`
-  : `script-src 'self' ${POSTHOG}`;
+  ? `script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' ${POSTHOG}`
+  : `script-src 'self' 'wasm-unsafe-eval' ${POSTHOG}`;
 
 const CSP = [
   "default-src 'self'",
@@ -41,6 +47,14 @@ const CSP = [
   "style-src 'self' 'unsafe-inline'",
   `img-src 'self' data: ${POSTHOG}`,
   "font-src 'self'",
+  // Cap (#98) solves its proof-of-work in a Web Worker built from a Blob
+  // URL, and with no worker-src the browser falls through child-src to
+  // default-src 'self', which refuses blob:. Everything else about Cap is
+  // same-origin: the widget is bundled from npm and its WASM ships as a
+  // Vite asset, so nothing here opens a door to a third party. The cost is
+  // that a script which already ran could spawn a worker from a string it
+  // built, which script-src 'self' still gates on getting there first.
+  "worker-src 'self' blob:",
   `connect-src 'self' ${POSTHOG}`,
   "object-src 'none'",
   "base-uri 'self'",

--- a/tests/cap-loader.test.ts
+++ b/tests/cap-loader.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * The widget loader's caching rule, which is the whole bug this file exists
+ * for: a load that fails must not be remembered.
+ *
+ * `loading ??= makePromise()` kept whatever the first attempt settled to. One
+ * bad fetch (a dev server restarting under an open tab, a chunk that 404s
+ * after a deploy, a dropped connection) therefore poisoned every later solve
+ * in that tab: the form said "could not verify you are human" on every
+ * attempt from then on, and nothing but a reload cleared it.
+ *
+ * The loader itself imports the widget and a WASM asset, so this tests the
+ * caching rule against the same shape rather than the module: bun's test
+ * runner cannot resolve `?url` asset imports.
+ */
+function makeLoader(load: () => Promise<void>) {
+  let loading: Promise<void> | null = null;
+  return () => {
+    loading ??= load().catch((error: unknown) => {
+      loading = null;
+      throw error;
+    });
+    return loading;
+  };
+}
+
+describe("loading the proof-of-work widget", () => {
+  test("loads once and reuses it", async () => {
+    let calls = 0;
+    const loadCap = makeLoader(async () => {
+      calls++;
+    });
+
+    await loadCap();
+    await loadCap();
+    await loadCap();
+
+    expect(calls).toBe(1);
+  });
+
+  test("tries again after a failure instead of failing forever", async () => {
+    let calls = 0;
+    const loadCap = makeLoader(async () => {
+      calls++;
+      if (calls === 1) throw new Error("chunk 404");
+    });
+
+    await expect(loadCap()).rejects.toThrow("chunk 404");
+    // The attempt that used to inherit the first one's failure for the life
+    // of the tab.
+    await loadCap();
+
+    expect(calls).toBe(2);
+  });
+
+  test("goes back to reusing one load once it succeeds", async () => {
+    let calls = 0;
+    const loadCap = makeLoader(async () => {
+      calls++;
+      if (calls === 1) throw new Error("offline");
+    });
+
+    await expect(loadCap()).rejects.toThrow("offline");
+    await loadCap();
+    await loadCap();
+
+    expect(calls).toBe(2);
+  });
+});

--- a/tests/cap-loader.test.ts
+++ b/tests/cap-loader.test.ts
@@ -68,3 +68,77 @@ describe("loading the proof-of-work widget", () => {
     expect(calls).toBe(2);
   });
 });
+
+/**
+ * The two rules that keep a solve from silently producing nothing.
+ *
+ * Cap's widget resolves `solve()` with `undefined` in two cases, both proven
+ * in a browser against the real widget: a second concurrent `solve()` on the
+ * same element (it opens with `if (this.#solving) return;`), and an element
+ * removed while solving (`disconnectedCallback` aborts, and every `await`
+ * inside `solve()` is followed by `if (signal?.aborted) return;`). Neither
+ * throws and neither fires an error event, so an undefined result became an
+ * empty token, no `x-cap-token` header, and "could not verify you are human"
+ * in front of somebody trying to sign up.
+ *
+ * The lifecycle is DOM-bound, so what is asserted here is the policy around
+ * it: callers share one in-flight solve, and a solve that yields no token is
+ * retried once on a fresh widget.
+ */
+function makeSolver(solve: (attempt: number) => Promise<{ token?: string } | null>) {
+  let inFlight: Promise<string> | null = null;
+  let built = 0;
+  const run = () => {
+    inFlight ??= (async () => {
+      try {
+        for (let tries = 0; tries < 2; tries++) {
+          built++;
+          const result = await solve(built);
+          if (result?.token) return result.token;
+        }
+        return "";
+      } finally {
+        inFlight = null;
+      }
+    })();
+    return inFlight;
+  };
+  return { run, widgets: () => built };
+}
+
+describe("solving a challenge", () => {
+  test("two callers at once share one solve rather than racing the widget", async () => {
+    const solver = makeSolver(async () => ({ token: "t" }));
+
+    const [a, b] = await Promise.all([solver.run(), solver.run()]);
+
+    expect([a, b]).toEqual(["t", "t"]);
+    // The second call must not have started its own: that is the concurrent
+    // solve() the widget answers with undefined.
+    expect(solver.widgets()).toBe(1);
+  });
+
+  test("retries once on a fresh widget when a solve comes back empty", async () => {
+    // What an aborted solve looks like from here: no token, no error.
+    const solver = makeSolver(async (attempt) => (attempt === 1 ? undefined : { token: "t" }));
+
+    expect(await solver.run()).toBe("t");
+    expect(solver.widgets()).toBe(2);
+  });
+
+  test("gives up after the second empty solve instead of looping", async () => {
+    const solver = makeSolver(async () => undefined);
+
+    expect(await solver.run()).toBe("");
+    expect(solver.widgets()).toBe(2);
+  });
+
+  test("a later solve starts fresh once the first has settled", async () => {
+    const solver = makeSolver(async () => ({ token: "t" }));
+
+    await solver.run();
+    await solver.run();
+
+    expect(solver.widgets()).toBe(2);
+  });
+});

--- a/tests/cap-retry.test.ts
+++ b/tests/cap-retry.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { CAP_FAILED_CODE } from "@/shared/types";
+import { isCapFailure, retryOnCapFailure } from "@/app/lib/cap-retry";
+
+/**
+ * The second go at a refused Cap token (#98).
+ *
+ * A token is single use and short lived, so a refusal is routine: it expired,
+ * the server already burned it, or it forgot it. The visitor did none of that
+ * and should never read about it, so the request re-solves and runs once more.
+ *
+ * The bug this covers: the check only ever read a *returned* `{ error }`,
+ * which is better-auth's shape. api() rejects instead, so the retry was dead
+ * code on every route that used it, and the anonymous shortener showed "could
+ * not verify you are human" to somebody shortening a second link.
+ */
+
+class ApiError extends Error {
+  constructor(readonly code: string) {
+    super(code);
+  }
+}
+
+function refusals(...results: unknown[]) {
+  const sent: string[] = [];
+  let call = 0;
+  const run = async (headers: Record<string, string>) => {
+    sent.push(headers["x-cap-token"] ?? "");
+    const result = results[call++];
+    if (result instanceof Error) throw result;
+    return result;
+  };
+  let token = 0;
+  const headers = async () => ({ "x-cap-token": `token-${++token}` });
+  return { run, headers, sent };
+}
+
+describe("recognizing a refused token", () => {
+  test("reads better-auth's returned error", () => {
+    expect(isCapFailure({ error: { code: CAP_FAILED_CODE } })).toBe(true);
+  });
+
+  test("reads the thrown ApiError", () => {
+    expect(isCapFailure(new ApiError(CAP_FAILED_CODE))).toBe(true);
+  });
+
+  test("leaves anything else alone", () => {
+    expect(isCapFailure(new ApiError("slug_taken"))).toBe(false);
+    expect(isCapFailure({ error: { code: "rate_limited" } })).toBe(false);
+    expect(isCapFailure({ slug: "abc" })).toBe(false);
+    expect(isCapFailure(null)).toBe(false);
+  });
+});
+
+describe("running a Cap-guarded request", () => {
+  test("passes the first answer through, with one token", async () => {
+    const { run, headers, sent } = refusals({ slug: "abc" });
+
+    expect(await retryOnCapFailure(run, headers)).toEqual({ slug: "abc" });
+    expect(sent).toEqual(["token-1"]);
+  });
+
+  test("solves again when the token comes back thrown", async () => {
+    const { run, headers, sent } = refusals(new ApiError(CAP_FAILED_CODE), { slug: "abc" });
+
+    expect(await retryOnCapFailure(run, headers)).toEqual({ slug: "abc" });
+    // A fresh token, not the one the server already spent.
+    expect(sent).toEqual(["token-1", "token-2"]);
+  });
+
+  test("solves again when the token comes back returned", async () => {
+    const { run, headers, sent } = refusals({ error: { code: CAP_FAILED_CODE } }, { slug: "abc" });
+
+    expect(await retryOnCapFailure(run, headers)).toEqual({ slug: "abc" });
+    expect(sent).toEqual(["token-1", "token-2"]);
+  });
+
+  test("raises anything that is not about the token, without a second attempt", async () => {
+    const { run, headers, sent } = refusals(new ApiError("slug_taken"), { slug: "abc" });
+
+    await expect(retryOnCapFailure(run, headers)).rejects.toThrow("slug_taken");
+    expect(sent).toEqual(["token-1"]);
+  });
+
+  test("stops at two, so a real refusal reaches the screen", async () => {
+    const refused = new ApiError(CAP_FAILED_CODE);
+    const { run, headers, sent } = refusals(refused, refused, { slug: "abc" });
+
+    await expect(retryOnCapFailure(run, headers)).rejects.toThrow(CAP_FAILED_CODE);
+    expect(sent).toEqual(["token-1", "token-2"]);
+  });
+});

--- a/tests/e2e/privacy-and-email-abuse.pw.ts
+++ b/tests/e2e/privacy-and-email-abuse.pw.ts
@@ -2,7 +2,6 @@ import { expect, test, type Page } from "@playwright/test";
 import { appUrl } from "./environment";
 import { queryRows } from "./db";
 import { signUpAndVerify } from "./resend";
-import { createOrg } from "./orgs";
 
 const password = "test-password-123";
 
@@ -29,7 +28,6 @@ async function createQuickLink(page: Page): Promise<string> {
 test("a click records the referring host, never the URL it came from (#20)", async ({ page }) => {
   const email = `referrer-${Date.now()}@gmail.com`;
   await signUpAndVerify(page, email, password);
-  await createOrg(page, "Referrer Org");
   const slug = await createQuickLink(page);
 
   // A real referring URL: the path and query are the parts that carry other
@@ -87,7 +85,7 @@ test("one address cannot be mailed without limit by many callers (#50)", async (
   // what refuses, and without a recipient-keyed limit every one of these
   // would be accepted.
   const statuses: number[] = [];
-  for (let attempt = 0; attempt < 6; attempt++) {
+  for (let attempt = 0; attempt < 8; attempt++) {
     const response = await page.request.post(
       `${appUrl}/api/auth/email-otp/request-password-reset`,
       {
@@ -103,9 +101,40 @@ test("one address cannot be mailed without limit by many callers (#50)", async (
     if (response.status() === 429) break;
   }
 
-  // Refused on the fourth, not merely somewhere: RL_EMAIL_RECIPIENT allows 3
+  // Refused on the sixth, not merely somewhere: RL_EMAIL_RECIPIENT allows 5
   // a minute in this environment, so the position of the 429 is what names
   // which budget ran out. Anything later would mean the recipient limit let
-  // a fourth send through.
-  expect(statuses.indexOf(429)).toBe(3);
+  // a sixth send through.
+  expect(statuses.indexOf(429)).toBe(5);
+});
+
+test("a throttled verification email still lands on the code screen (#50)", async ({ page }) => {
+  const email = `throttled-${Date.now()}@gmail.com`;
+
+  // The send refused, the account made anyway. That is what the email rate
+  // limit looks like from the browser, and the app used to answer it by
+  // leaving the person on the signup form: it reads as "signup failed", so
+  // they submit again, spend another send, and get the same nothing.
+  await page.route("**/api/auth/email-otp/send-verification-otp", (route) =>
+    route.fulfill({
+      status: 429,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "Too many requests. Try again shortly." }),
+    }),
+  );
+
+  await page.goto("/signup");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Sign up" }).click();
+
+  // The toast shows for 3.25s, and a sign-up under a loaded suite can take
+  // longer than the default 5s to answer at all: this waits for the whole
+  // round trip, not just for the toast's own life.
+  await expect(page.getByText("Too many requests. Try again shortly.")).toBeVisible({
+    timeout: 20_000,
+  });
+  // The code screen, which is where the resend button is, not back at the form.
+  await expect(page.getByRole("heading", { name: "Enter your code" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Resend code" })).toBeVisible();
 });

--- a/tests/e2e/privacy-and-email-abuse.pw.ts
+++ b/tests/e2e/privacy-and-email-abuse.pw.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 import { appUrl } from "./environment";
 import { queryRows } from "./db";
 import { signUpAndVerify } from "./resend";
+import { createOrg } from "./orgs";
 
 const password = "test-password-123";
 
@@ -28,6 +29,7 @@ async function createQuickLink(page: Page): Promise<string> {
 test("a click records the referring host, never the URL it came from (#20)", async ({ page }) => {
   const email = `referrer-${Date.now()}@gmail.com`;
   await signUpAndVerify(page, email, password);
+  await createOrg(page, "Referrer Org");
   const slug = await createQuickLink(page);
 
   // A real referring URL: the path and query are the parts that carry other

--- a/tests/e2e/production/csp.pw.ts
+++ b/tests/e2e/production/csp.pw.ts
@@ -26,7 +26,45 @@ test("the built worker serves the production CSP", async ({ page }) => {
   // style-src carries 'unsafe-inline' by design (React inline `style`), so the
   // check that matters is script-src alone, read as its own directive.
   const scriptSrc = csp?.split(";").find((part) => part.trim().startsWith("script-src"));
-  expect(scriptSrc?.trim()).toBe("script-src 'self' https://*.posthog.com");
+  expect(scriptSrc?.trim()).toBe("script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com");
+});
+
+/**
+ * Cap's proof-of-work (#98) is the part of this app most likely to be
+ * strangled by our own policy, and it fails quietly: the widget catches its
+ * own errors, so a blocked Worker or a refused WebAssembly.compile() would
+ * leave signup apparently fine and completely unprotected.
+ *
+ * So this asserts the mechanism, not just the absence of complaints. The
+ * solver runs in a Worker built from a blob: URL (worker-src) and compiles a
+ * same-origin WASM module (script-src 'wasm-unsafe-eval'). Both were blocked
+ * by the policy as it stood before this feature; the measured cost of losing
+ * the WASM path is roughly 5x on solve time.
+ */
+test("Cap solves a challenge under the production CSP", async ({ page }) => {
+  await page.goto("/signup");
+
+  // The widget only loads once the visitor touches the form, which is the
+  // whole point: no cost to anyone who does not sign up.
+  await page.getByRole("textbox").first().fill("csp-probe@example.com");
+  await page.waitForFunction(() => !!customElements.get("cap-widget"), null, { timeout: 15_000 });
+
+  const solved = await page.evaluate(async () => {
+    const el = document.createElement("cap-widget") as HTMLElement & {
+      solve: () => Promise<{ token?: string }>;
+    };
+    el.setAttribute("data-cap-api-endpoint", "/api/cap/signup/");
+    el.style.cssText = "position:absolute;width:1px;height:1px;opacity:0";
+    document.body.appendChild(el);
+    try {
+      return (await el.solve())?.token ?? "";
+    } finally {
+      el.remove();
+    }
+  });
+
+  expect(solved).not.toBe("");
+  expect(await cspViolations(page)).toEqual([]);
 });
 
 test("the landing page renders under the production CSP without violations", async ({ page }) => {

--- a/tests/worker/cap-disabled.worker.ts
+++ b/tests/worker/cap-disabled.worker.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, it } from "vitest";
 import { reset } from "cloudflare:test";
 import { applyTestMigrations, captureEmails, fetchWorker, overrideEnv } from "./support";
+import { spendToken } from "../../src/worker/cap";
 
 /**
  * Cap with no CAP_SECRET set (#98): the gate is off and signup works exactly
@@ -33,4 +34,32 @@ it("lets signup through untouched when no secret is configured", async () => {
     overrideEnv({ BETTER_AUTH_SECRET: "test-secret", CAP_SECRET: undefined }),
   );
   expect(res.status).toBe(200);
+});
+
+it("refuses a challenge when the secret is too short to use", async () => {
+  // capjs-core refuses a secret under 16 bytes by throwing, and it throws
+  // when a challenge is issued rather than at startup. Which way that falls
+  // is the point: a secret that is set but unusable must take the Cap route
+  // down, never fall through to the disabled path and leave signup looking
+  // configured and completely unprotected. `capEnabled` only asks whether
+  // the secret is set, so "set but unusable" is exactly the gap between the
+  // two, and it is answered by us rather than by a library stack trace
+  // reaching the top of the Worker.
+  const res = await fetchWorker(
+    new Request("http://localhost/api/cap/signup/challenge", { method: "POST" }),
+    overrideEnv({ BETTER_AUTH_SECRET: "test-secret", CAP_SECRET: "tooshort" }),
+  );
+
+  expect(res.status).toBe(503);
+});
+
+it("refuses to spend a token when the secret is too short to use", async () => {
+  // The other half: the check that decides whether a signup is let through
+  // must not answer "ok" on a secret no challenge could have been signed
+  // with. Called directly rather than through signup, because getAuth()
+  // memoizes one auth instance per isolate (see above) and the first test in
+  // this file already built one with Cap disabled.
+  await expect(
+    spendToken(overrideEnv({ CAP_SECRET: "tooshort" }), "signup", "1.deadbeef"),
+  ).rejects.toThrow();
 });

--- a/tests/worker/cap-disabled.worker.ts
+++ b/tests/worker/cap-disabled.worker.ts
@@ -1,0 +1,36 @@
+import { beforeEach, expect, it } from "vitest";
+import { reset } from "cloudflare:test";
+import { applyTestMigrations, captureEmails, fetchWorker, overrideEnv } from "./support";
+
+/**
+ * Cap with no CAP_SECRET set (#98): the gate is off and signup works exactly
+ * as it did before, which is what keeps local dev, CI and the e2e run from
+ * needing a secret.
+ *
+ * Its own file because getAuth() memoizes one auth instance per isolate, and
+ * that instance closes over the env that built it. A test sharing a file with
+ * the enabled cases would inherit the enabled hook no matter which env it
+ * passed. Bindings are stable in production, so nothing here is a product
+ * defect: it is the cost of that cache, paid in test layout.
+ */
+beforeEach(async () => {
+  reset();
+  await applyTestMigrations();
+  captureEmails({ mx: "deliverable" });
+});
+
+it("lets signup through untouched when no secret is configured", async () => {
+  const res = await fetchWorker(
+    new Request("http://localhost/api/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "nosecret@example.com",
+        password: "a-good-password-1",
+        name: "probe",
+      }),
+    }),
+    overrideEnv({ BETTER_AUTH_SECRET: "test-secret", CAP_SECRET: undefined }),
+  );
+  expect(res.status).toBe(200);
+});

--- a/tests/worker/cap-rate-limit.worker.ts
+++ b/tests/worker/cap-rate-limit.worker.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../../src/worker";
+import type { Env } from "../../src/worker/env";
+import {
+  applyTestMigrations,
+  exhaustedLimit,
+  openLimit,
+  overrideEnv,
+  recordingLimit,
+} from "./support";
+
+/**
+ * Cap's endpoints spend their own budget, not signup's (#98).
+ *
+ * They were briefly counted against RL_AUTH_PUBLIC, which is the worst place
+ * for them: a person fills the form, the widget asks for a challenge, the
+ * counter is out, and the browser can produce no token at all. What they then
+ * see is "could not verify you are human", which reads as an accusation
+ * rather than as "wait a minute" — and the built-in retry spends two more
+ * requests against the same exhausted budget, so it never helps.
+ *
+ * The counters are asserted through stub bindings rather than by spending
+ * real ones: Cloudflare's per-location counters do not reset between cases.
+ */
+
+async function post(testEnv: Env, path: string, body: unknown = {}): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.7" },
+      body: JSON.stringify(body),
+    }),
+    testEnv,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+const CAP_ON = (overrides: Partial<Env>) =>
+  overrideEnv({
+    BETTER_AUTH_SECRET: "test-secret",
+    CAP_SECRET: "cap-test-secret-long-enough-to-be-accepted",
+    ...overrides,
+  });
+
+beforeEach(applyTestMigrations);
+afterEach(reset);
+
+describe("the budget Cap spends", () => {
+  it("keeps issuing challenges when the signup budget is gone", async () => {
+    // The case that took signup down: somebody who has been trying to log in
+    // must still be able to prove they are human.
+    const res = await post(
+      CAP_ON({ RL_AUTH_PUBLIC: exhaustedLimit(), RL_CAP: openLimit() }),
+      "/api/cap/signup/challenge",
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("refuses when its own budget is gone", async () => {
+    const res = await post(
+      CAP_ON({ RL_AUTH_PUBLIC: openLimit(), RL_CAP: exhaustedLimit() }),
+      "/api/cap/signup/challenge",
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("x-ratelimit-group")).toBe("cap");
+  });
+
+  it("counts a challenge and a redeem separately, per caller", async () => {
+    const keys: string[] = [];
+    const env = CAP_ON({ RL_AUTH_PUBLIC: openLimit(), RL_CAP: recordingLimit(keys) });
+
+    await post(env, "/api/cap/signup/challenge");
+    await post(env, "/api/cap/signup/redeem", { token: "x", solutions: [] });
+
+    expect(keys).toHaveLength(2);
+    expect(new Set(keys).size).toBe(2);
+    // The caller is a keyed digest, never the address itself.
+    for (const key of keys) {
+      expect(key.startsWith("cap:")).toBe(true);
+      expect(key).not.toContain("203.0.113.7");
+    }
+  });
+
+  it("leaves the auth routes on the auth budget", async () => {
+    // Sign-up is not the example here: it sends mail, so it spends the email
+    // budget. Sign-in is the plain auth case.
+    const res = await post(
+      CAP_ON({ RL_AUTH_PUBLIC: exhaustedLimit(), RL_CAP: openLimit() }),
+      "/api/auth/sign-in/email",
+      { email: "someone@example.com", password: "a-good-password-1" },
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("x-ratelimit-group")).toBe("auth");
+  });
+});

--- a/tests/worker/cap.worker.ts
+++ b/tests/worker/cap.worker.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { reset } from "cloudflare:test";
+import { applyTestMigrations, captureEmails, fetchWorker, overrideEnv } from "./support";
+
+/**
+ * Cap, the proof-of-work gate in front of signup and password reset (#98).
+ *
+ * The browser side (widget, Web Worker, WASM, CSP) is asserted in
+ * tests/e2e/production/csp.pw.ts and exercised by every signup scenario,
+ * because CAP_SECRET is set in .dev.vars.example. What is left for here is
+ * the part a browser cannot show: that a forged, reused, or absent token is
+ * refused, and that an unset secret disables the gate instead of breaking
+ * the form.
+ */
+
+// capjs-core refuses a secret under 16 bytes, and refuses it by throwing
+// inside the challenge route. That is fail-closed, which is the right way
+// round for a security control, but it does mean a too-short CAP_SECRET
+// takes signup down rather than quietly running unprotected.
+const CAP_ON = () =>
+  overrideEnv({
+    BETTER_AUTH_SECRET: "test-secret",
+    CAP_SECRET: "cap-test-secret-long-enough-to-be-accepted",
+  });
+
+function capPost(path: string, body: unknown, testEnv = CAP_ON()) {
+  return fetchWorker(
+    new Request(`http://localhost/api/cap/${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    testEnv,
+  );
+}
+
+/** Brute-forces one Cap challenge the way the browser's worker does: find a
+ * nonce whose sha256(salt + nonce) starts with the target prefix. */
+async function solve(salt: string, target: string): Promise<number> {
+  for (let nonce = 0; ; nonce++) {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(salt + nonce));
+    const hex = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+    if (hex.startsWith(target)) return nonce;
+  }
+}
+
+/**
+ * Cap's salt/target derivation, copied because the package does not export
+ * it. Salts are never sent: both sides derive them from the token, so a test
+ * that wants to solve a real challenge has to derive them too.
+ *
+ * Copying it does couple this test to Cap's internals, which is why it is
+ * only here and not in src: if they change the PRNG, redeem starts returning
+ * 400 and these tests fail loudly rather than quietly testing nothing.
+ */
+function prng(seed: string, length: number): string {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+  let state = hash >>> 0;
+  let result = "";
+  while (result.length < length) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    result += state.toString(16).padStart(8, "0");
+  }
+  return result.substring(0, length);
+}
+
+async function solveAll(token: string, spec: { c: number; s: number; d: number }) {
+  const solutions: number[] = [];
+  for (let i = 1; i <= spec.c; i++) {
+    solutions.push(await solve(prng(`${token}${i}`, spec.s), prng(`${token}${i}d`, spec.d)));
+  }
+  return solutions;
+}
+
+function signUp(email: string, headers: Record<string, string> = {}, testEnv = CAP_ON()) {
+  return fetchWorker(
+    new Request("http://localhost/api/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify({ email, password: "a-good-password-1", name: "probe" }),
+    }),
+    testEnv,
+  );
+}
+
+beforeEach(async () => {
+  reset();
+  await applyTestMigrations();
+  captureEmails({ mx: "deliverable" });
+});
+
+describe("issuing and redeeming", () => {
+  it("mints a challenge, and redeems a correct solution for a token", async () => {
+    const challenge = (await (await capPost("signup/challenge", {})).json()) as {
+      token: string;
+      challenge: { c: number; s: number; d: number };
+    };
+    expect(challenge.challenge.c).toBeGreaterThan(0);
+
+    const redeemed = (await (
+      await capPost("signup/redeem", {
+        token: challenge.token,
+        solutions: await solveAll(challenge.token, challenge.challenge),
+      })
+    ).json()) as { success: boolean; token?: string };
+
+    expect(redeemed.success).toBe(true);
+    expect(redeemed.token).toBeTruthy();
+  });
+
+  it("refuses a wrong solution", async () => {
+    const challenge = (await (await capPost("signup/challenge", {})).json()) as {
+      token: string;
+      challenge: { c: number };
+    };
+    const res = await capPost("signup/redeem", {
+      token: challenge.token,
+      solutions: Array.from({ length: challenge.challenge?.c ?? 12 }, () => 1),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("refuses a scope nobody offers", async () => {
+    expect((await capPost("admin/challenge", {})).status).toBe(400);
+  });
+});
+
+describe("spending a token at signup", () => {
+  async function mintToken(scope = "signup") {
+    const challenge = (await (await capPost(`${scope}/challenge`, {})).json()) as {
+      token: string;
+      challenge: { c: number; s: number; d: number };
+    };
+    const redeemed = (await (
+      await capPost(`${scope}/redeem`, {
+        token: challenge.token,
+        solutions: await solveAll(challenge.token, challenge.challenge),
+      })
+    ).json()) as { token: string };
+    return redeemed.token;
+  }
+
+  it("accepts a freshly redeemed token", async () => {
+    const res = await signUp("fresh@example.com", { "x-cap-token": await mintToken() });
+    expect(res.status).toBe(200);
+  });
+
+  it("refuses the same token twice, so a harvested one is worth one attempt", async () => {
+    const token = await mintToken();
+    expect((await signUp("first@example.com", { "x-cap-token": token })).status).toBe(200);
+
+    const replay = await signUp("second@example.com", { "x-cap-token": token });
+    expect(replay.status).toBe(400);
+    // And the second account was never created.
+    const { results } = await env.DB.prepare("select email from user").all();
+    expect(results.map((r) => r.email)).not.toContain("second@example.com");
+  });
+
+  it("refuses a missing token", async () => {
+    expect((await signUp("notoken@example.com")).status).toBe(400);
+  });
+
+  it("refuses a forged token", async () => {
+    const res = await signUp("forged@example.com", { "x-cap-token": "deadbeef:cafe" });
+    expect(res.status).toBe(400);
+  });
+
+  it("refuses a token minted for another scope", async () => {
+    // The whole point of binding a scope into the signature: a token earned
+    // on the password-reset form must not open the signup door.
+    const res = await signUp("crossed@example.com", {
+      "x-cap-token": await mintToken("password-reset"),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("with no CAP_SECRET", () => {
+  // Explicitly cleared, not merely left out: the ambient binding is built
+  // from .dev.vars, which now sets CAP_SECRET so the browser tests run the
+  // real loop. Inheriting it here would test the enabled path twice and the
+  // disabled path never.
+  const CAP_OFF = () => overrideEnv({ BETTER_AUTH_SECRET: "test-secret", CAP_SECRET: undefined });
+
+  // The matching signup case lives in cap-disabled.worker.ts: getAuth()
+  // caches its instance per isolate, so the hook closes over whichever env
+  // built it first. Harmless in production, where bindings never change,
+  // but it means the disabled path needs a file of its own to be tested.
+
+  it("reports the challenge endpoint as disabled rather than erroring", async () => {
+    const res = await capPost("signup/challenge", {}, CAP_OFF());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ disabled: true });
+  });
+});

--- a/tests/worker/cap.worker.ts
+++ b/tests/worker/cap.worker.ts
@@ -164,6 +164,17 @@ describe("spending a token at signup", () => {
     expect(results.map((r) => r.email)).not.toContain("second@example.com");
   });
 
+  it("accepts a token KV has never heard of", async () => {
+    // The regression this guards: the redeemed token used to be a random
+    // string written to KV at redeem and read back here. KV is eventually
+    // consistent, so that read missed and real signups were told to prove
+    // they were human again, forever. Emptying KV stands in for a write that
+    // has not propagated; a signed token does not care.
+    const token = await mintToken();
+    for (const key of (await env.LINKS.list()).keys) await env.LINKS.delete(key.name);
+    expect((await signUp("unpropagated@example.com", { "x-cap-token": token })).status).toBe(200);
+  });
+
   it("refuses a missing token", async () => {
     expect((await signUp("notoken@example.com")).status).toBe(400);
   });

--- a/tests/worker/email-recipient-limit.worker.ts
+++ b/tests/worker/email-recipient-limit.worker.ts
@@ -2,34 +2,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
 import worker from "../../src/worker";
 import type { Env } from "../../src/worker/env";
-import { applyTestMigrations, authEnv, overrideEnv } from "./support";
+import {
+  applyTestMigrations,
+  authEnv,
+  exhaustedLimit,
+  openLimit,
+  overrideEnv,
+  recordingLimit,
+} from "./support";
 
 const RESET_PATH = "/api/auth/email-otp/request-password-reset";
-
-/**
- * A rate-limit binding that always refuses, so a route's behaviour once a
- * budget is gone can be asserted without spending real tokens against
- * Cloudflare's per-location counters (which the test runner does not reset
- * between cases).
- */
-function exhaustedLimit(): RateLimit {
-  return { limit: async () => ({ success: false }) } as unknown as RateLimit;
-}
-
-/** A binding that always allows, isolating which of the two budgets is
- * under test. */
-function openLimit(): RateLimit {
-  return { limit: async () => ({ success: true }) } as unknown as RateLimit;
-}
-
-function recordingLimit(keys: string[]): RateLimit {
-  return {
-    limit: async ({ key }: { key: string }) => {
-      keys.push(key);
-      return { success: true };
-    },
-  } as unknown as RateLimit;
-}
 
 /**
  * One password-reset request. `callerIp` fills cf-connecting-ip, which is

--- a/tests/worker/support.ts
+++ b/tests/worker/support.ts
@@ -368,3 +368,29 @@ export function batchOf<Body>(queueName: string, bodies: Body[], attempts = 1) {
   const ctx = createExecutionContext();
   return { batch, ctx };
 }
+
+/**
+ * Stub rate-limit bindings.
+ *
+ * Cloudflare's per-location counters do not reset between test cases, so a
+ * test that wants "this budget is gone" says so with a binding rather than by
+ * spending a real one.
+ */
+export function exhaustedLimit(): RateLimit {
+  return { limit: async () => ({ success: false }) } as unknown as RateLimit;
+}
+
+/** Always allows, isolating which of several budgets is under test. */
+export function openLimit(): RateLimit {
+  return { limit: async () => ({ success: true }) } as unknown as RateLimit;
+}
+
+/** Allows, and records the key each call was counted against. */
+export function recordingLimit(keys: string[]): RateLimit {
+  return {
+    limit: async ({ key }: { key: string }) => {
+      keys.push(key);
+      return { success: true };
+    },
+  } as unknown as RateLimit;
+}

--- a/tests/worker/support.ts
+++ b/tests/worker/support.ts
@@ -43,7 +43,19 @@ export function captureClickQueue(): { env: Env; sent: ClickMessage[] } {
 
 // Env with a non-empty auth secret, independent of the ambient .dev.vars, so
 // sign-in's rate-limit key derivation has a key to HMAC with.
-export const authEnv = () => overrideEnv({ BETTER_AUTH_SECRET: "test-secret" });
+/**
+ * The default binding for worker tests: a known BETTER_AUTH_SECRET, and Cap
+ * explicitly off.
+ *
+ * Cap has to be cleared rather than merely unmentioned, because the ambient
+ * binding is built from .dev.vars, which sets CAP_SECRET so the browser tests
+ * exercise the real proof-of-work loop (#98). Inheriting it here would make
+ * every signup in every worker test fail the Cap check first and report 400,
+ * hiding whatever that test was actually about. Tests that want Cap on say so:
+ * see cap.worker.ts.
+ */
+export const authEnv = () =>
+  overrideEnv({ BETTER_AUTH_SECRET: "test-secret", CAP_SECRET: undefined });
 
 /**
  * Drive one request through the real worker and wait for anything it

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,7 +95,17 @@ export default defineConfig(async () => ({
   ],
   resolve: {
     // mirror the tsconfig "@/*" path for runtime imports (app and worker)
-    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+      // capjs-core reaches for these two only in its instrumentation mode,
+      // which we do not use. Left alone, the bundler follows the dynamic
+      // imports and ships a 5 MB javascript-obfuscator chunk in the Worker.
+      // See src/worker/cap-unused-dep-stub.ts.
+      esbuild: fileURLToPath(new URL("./src/worker/cap-unused-dep-stub.ts", import.meta.url)),
+      "javascript-obfuscator": fileURLToPath(
+        new URL("./src/worker/cap-unused-dep-stub.ts", import.meta.url),
+      ),
+    },
   },
   // dev-only: let curl -H "Host: linker.example.com" exercise the
   // custom-domain hot path locally

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -145,12 +145,25 @@
   // front of all of it.
   "ratelimits": [
     {
-      // Per caller, per path: login, signup and each Cap endpoint count
-      // separately, so this is 30 tries at one door, not 30 across all of them.
+      // Per caller, per path: login and signup count separately, so this is
+      // 30 tries at one door, not 30 across all of them.
       "name": "RL_AUTH_PUBLIC",
       "namespace_id": "14001",
       "simple": {
         "limit": 30,
+        "period": 60,
+      },
+    },
+    // Cap's own endpoints (#98). Separate from RL_AUTH_PUBLIC and much
+    // higher: one sign-up spends a challenge and a redeem, its retry spends
+    // two more, and several people behind one office address are ordinary.
+    // The proof-of-work prices these, not this counter, which is only here so
+    // a script cannot farm challenges to solve offline in bulk.
+    {
+      "name": "RL_CAP",
+      "namespace_id": "14011",
+      "simple": {
+        "limit": 120,
         "period": 60,
       },
     },
@@ -344,6 +357,17 @@
           "namespace_id": "24001",
           "simple": {
             "limit": 40,
+            "period": 60,
+          },
+        },
+        {
+          // Higher again than production's: local dev and the e2e run have no
+          // cf-connecting-ip, so every caller on the machine shares one key
+          // and one budget.
+          "name": "RL_CAP",
+          "namespace_id": "24011",
+          "simple": {
+            "limit": 600,
             "period": 60,
           },
         },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -135,20 +135,34 @@
   // Cloudflare Workers Rate Limiting counters. Namespace IDs are unique within
   // this account. Counters are permissive and local to each Cloudflare location,
   // so these are abuse controls, not billing or exact quota enforcement.
+  //
+  // Set for the person who is having trouble, not for the bot. Somebody who
+  // mistypes a password, retries a signup, or pastes six links in a row must
+  // never meet a wall, because they read it as the product being broken and
+  // they are right. The ceilings that matter for abuse are elsewhere: Cap
+  // charges CPU per attempt (#98), RL_EMAIL_RECIPIENT bounds what one inbox
+  // can be made to receive, and the WAF rules in docs/rate-limiting.md sit in
+  // front of all of it.
   "ratelimits": [
     {
+      // Per caller, per path: login, signup and each Cap endpoint count
+      // separately, so this is 30 tries at one door, not 30 across all of them.
       "name": "RL_AUTH_PUBLIC",
       "namespace_id": "14001",
       "simple": {
-        "limit": 10,
+        "limit": 30,
         "period": 60,
       },
     },
     {
+      // Per caller, per path. Raised from 3: a signup that goes wrong costs
+      // a send each time somebody retries, and three of those inside a minute
+      // is a person having a bad day, not a bot. Cap already prices each
+      // attempt in CPU (#98), so this does not have to be the tight one.
       "name": "RL_EMAIL",
       "namespace_id": "14002",
       "simple": {
-        "limit": 3,
+        "limit": 10,
         "period": 60,
       },
     },
@@ -156,7 +170,7 @@
       "name": "RL_WRITE_FREE",
       "namespace_id": "14003",
       "simple": {
-        "limit": 30,
+        "limit": 90,
         "period": 60,
       },
     },
@@ -164,7 +178,7 @@
       "name": "RL_WRITE_PAID",
       "namespace_id": "14004",
       "simple": {
-        "limit": 120,
+        "limit": 300,
         "period": 60,
       },
     },
@@ -172,7 +186,7 @@
       "name": "RL_QR_UPLOAD",
       "namespace_id": "14005",
       "simple": {
-        "limit": 5,
+        "limit": 20,
         "period": 60,
       },
     },
@@ -180,7 +194,7 @@
       "name": "RL_DOMAIN_SETUP",
       "namespace_id": "14006",
       "simple": {
-        "limit": 12,
+        "limit": 30,
         "period": 60,
       },
     },
@@ -188,7 +202,7 @@
       "name": "RL_BILLING",
       "namespace_id": "14007",
       "simple": {
-        "limit": 3,
+        "limit": 10,
         "period": 60,
       },
     },
@@ -202,8 +216,9 @@
     },
     // Keyed by the recipient address rather than the caller, so many callers
     // cannot each stay under RL_EMAIL while all aiming at one inbox (#50).
-    // Tighter than RL_EMAIL's 3: one address has no legitimate reason to
-    // want a second code in the same minute, let alone a third.
+    // Still the tight one, and it is the limit that matters: it bounds what
+    // an inbox can be made to receive however many callers aim at it. Four a
+    // minute covers a signup plus a couple of impatient resends.
     //
     // `period` only accepts 10 or 60, so this caps the rate, not the daily
     // total. Closing that needs a durable counter rather than Cloudflare's
@@ -212,7 +227,7 @@
       "name": "RL_EMAIL_RECIPIENT",
       "namespace_id": "14009",
       "simple": {
-        "limit": 2,
+        "limit": 4,
         "period": 60,
       },
     },
@@ -328,7 +343,7 @@
           "name": "RL_AUTH_PUBLIC",
           "namespace_id": "24001",
           "simple": {
-            "limit": 10,
+            "limit": 40,
             "period": 60,
           },
         },
@@ -336,10 +351,10 @@
           "name": "RL_EMAIL",
           "namespace_id": "24002",
           "simple": {
-            // Higher than production's (3): the e2e suite's real sign-ups
+            // Higher than production's (10): the e2e suite's real sign-ups
             // and password-reset sends across files share this one budget,
             // and production's abuse-control number is too tight for that.
-            "limit": 20,
+            "limit": 30,
             "period": 60,
           },
         },
@@ -347,7 +362,7 @@
           "name": "RL_WRITE_FREE",
           "namespace_id": "24003",
           "simple": {
-            "limit": 30,
+            "limit": 90,
             "period": 60,
           },
         },
@@ -355,7 +370,7 @@
           "name": "RL_WRITE_PAID",
           "namespace_id": "24004",
           "simple": {
-            "limit": 120,
+            "limit": 300,
             "period": 60,
           },
         },
@@ -363,7 +378,7 @@
           "name": "RL_QR_UPLOAD",
           "namespace_id": "24005",
           "simple": {
-            "limit": 5,
+            "limit": 20,
             "period": 60,
           },
         },
@@ -371,7 +386,7 @@
           "name": "RL_DOMAIN_SETUP",
           "namespace_id": "24006",
           "simple": {
-            "limit": 12,
+            "limit": 30,
             "period": 60,
           },
         },
@@ -379,7 +394,7 @@
           "name": "RL_BILLING",
           "namespace_id": "24007",
           "simple": {
-            "limit": 3,
+            "limit": 10,
             "period": 60,
           },
         },
@@ -395,12 +410,12 @@
           "name": "RL_EMAIL_RECIPIENT",
           "namespace_id": "24009",
           "simple": {
-            // One above production's (2), leaving the two sends a sign-up
+            // One above production's (4), leaving the two sends a sign-up
             // costs (submit, then the resend on the code screen's reload)
             // some headroom. Every test mints its own
             // `something-${Date.now()}@gmail.com`, so no other address is
             // near this; the e2e scenario trips it deliberately.
-            "limit": 3,
+            "limit": 5,
             "period": 60,
           },
         },


### PR DESCRIPTION
Closes #98.

Cap proof-of-work guards signup and password reset. `capjs-core` runs in this
Worker, the widget is bundled from npm, and the WASM solver is a same-origin
Vite asset, so no third party ever sees the visitor. Nobody clicks a checkbox:
the puzzle solves while they type and the token rides in `x-cap-token`.

Tokens are signed, not stored. A redeemed token used to be a random string
written to KV and read back a second later; KV is eventually consistent, so
that read missed often enough to tell real people to prove they were human
again, and trying harder could not help. `expires.hmac(CAP_SECRET,
scope:expires)` needs no shared state. KV is still written, but only to catch a
replay.

Getting the widget right took four attempts and only the last one was the bug.
`solve()` resolves **undefined** if a second solve starts while one is in
flight, or if the element is removed mid-solve: no token, no throw, no error
event. The page was building and binning a widget per attempt, which is exactly
how to hit that. One widget per scope, kept, fixes it.

Also here: a refused token now gets its second go on every route. The guard
only read a returned `{ error }`, which is better-auth's shape, while `api()`
rejects with an ApiError, so the retry was dead code for every `api()` caller.
That is what made the anonymous shortener's e2e fail about one run in three
with `already_spent`. The rule moved into `cap-retry.ts` with a test, because
`cap.ts` imports the WASM solver as a `?url` asset and bun's test runner cannot
resolve it.

The limits are set for the person having trouble, not for the bot, and Cap has
its own rate-limit budget rather than borrowing signup's, which is what made
every local visitor share one bucket and 429 each other. `docs/rate-limiting.md`
covers all three layers and the dashboard rules to apply by hand.

Part of splitting #105 up. Based on #108.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proof-of-work protection for signup and password-reset requests.
  * Added challenge solving, token validation, replay prevention, and automatic retry handling.
  * Added dedicated rate limiting for proof-of-work challenges and redemption.

* **Bug Fixes**
  * Verification-code flows now remain usable with clear feedback when email delivery is throttled.

* **Documentation**
  * Added setup, configuration, monitoring, rollback, and licensing documentation for bot protection and rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

Replaces #109, which GitHub closed when its base branch merged and would not let reopen after the rebase.
