### PR TITLE
Say what the links are instead of what they carry

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>rdyrct - short links that carry your team's brand</title>
+    <title>rdyrct - branded short links for your team</title>
     <meta
       name="description"
-      content="Short links that carry your brand. Branded short links, QR codes, and custom domains with privacy-friendly analytics."
+      content="Branded short links, QR codes, and custom domains with privacy-friendly analytics."
     />
     <link rel="canonical" href="https://rdyrct.com" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <meta property="og:title" content="rdyrct - short links that carry your team's brand" />
+    <meta property="og:title" content="rdyrct - branded short links for your team" />
     <meta
       property="og:description"
-      content="Short links that carry your brand. Branded short links, QR codes, and custom domains with privacy-friendly analytics powered by Cloudflare."
+      content="Branded short links, QR codes, and custom domains with privacy-friendly analytics powered by Cloudflare."
     />
     <meta property="og:image" content="https://rdyrct.com/og.png" />
     <meta property="og:image:type" content="image/png" />
@@ -23,10 +23,10 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="rdyrct" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="rdyrct - short links that carry your team's brand" />
+    <meta name="twitter:title" content="rdyrct - branded short links for your team" />
     <meta
       name="twitter:description"
-      content="Short links that carry your brand. Branded short links, QR codes, and custom domains with privacy-friendly analytics."
+      content="Branded short links, QR codes, and custom domains with privacy-friendly analytics."
     />
     <meta name="twitter:image" content="https://rdyrct.com/og.png" />
     <script type="application/ld+json">
@@ -44,13 +44,13 @@
             "@type": "WebSite",
             "name": "rdyrct",
             "url": "https://rdyrct.com",
-            "description": "Short links that carry your brand. Branded short links, QR codes, and custom domains with privacy-friendly analytics."
+            "description": "Branded short links, QR codes, and custom domains with privacy-friendly analytics."
           },
           {
             "@type": "WebPage",
-            "name": "rdyrct - short links that carry your team's brand",
+            "name": "rdyrct - branded short links for your team",
             "url": "https://rdyrct.com",
-            "description": "Short links that carry your brand. Branded short links, QR codes, and custom domains with privacy-friendly analytics.",
+            "description": "Branded short links, QR codes, and custom domains with privacy-friendly analytics.",
             "inLanguage": "en",
             "isPartOf": { "@type": "WebSite", "name": "rdyrct", "url": "https://rdyrct.com" }
           },
@@ -58,7 +58,7 @@
             "@type": "SoftwareApplication",
             "name": "rdyrct",
             "url": "https://rdyrct.com",
-            "description": "Short links that carry your brand. Branded short links, QR codes, and custom domains with privacy-friendly analytics.",
+            "description": "Branded short links, QR codes, and custom domains with privacy-friendly analytics.",
             "applicationCategory": "BusinessApplication",
             "operatingSystem": "Any web browser",
             "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }

--- a/src/shared/page-meta.ts
+++ b/src/shared/page-meta.ts
@@ -25,9 +25,8 @@ export interface PageMeta {
  * visitor who arrived on the public page itself.
  */
 export const DEFAULT_PAGE_META: PageMeta = {
-  title: "rdyrct - short links that carry your team's brand",
-  description:
-    "Short links that carry your brand. Branded short links, QR codes, and custom domains with privacy-friendly analytics.",
+  title: "rdyrct - branded short links for your team",
+  description: "Branded short links, QR codes, and custom domains with privacy-friendly analytics.",
 };
 
 export const PUBLIC_PAGE_META: Record<string, PageMeta> = {

--- a/tests/e2e/production/seo.pw.ts
+++ b/tests/e2e/production/seo.pw.ts
@@ -47,7 +47,7 @@ test("the signed-in app keeps the default head", async ({ request }) => {
   // Nothing behind the login wants search traffic.
   const html = await (await request.get("/dashboard")).text();
 
-  expect(html).toContain("<title>rdyrct - short links that carry your team's brand");
+  expect(html).toContain("<title>rdyrct - branded short links for your team");
 });
 
 test("walking off a public page does not take its title along", async ({ page }) => {

--- a/tests/e2e/production/seo.pw.ts
+++ b/tests/e2e/production/seo.pw.ts
@@ -47,7 +47,7 @@ test("the signed-in app keeps the default head", async ({ request }) => {
   // Nothing behind the login wants search traffic.
   const html = await (await request.get("/dashboard")).text();
 
-  expect(html).toContain("<title>rdyrct - branded short links for your team");
+  expect(html).toContain("<title>rdyrct - branded short links for your team</title>");
 });
 
 test("walking off a public page does not take its title along", async ({ page }) => {

--- a/tests/worker/page-meta.worker.ts
+++ b/tests/worker/page-meta.worker.ts
@@ -18,14 +18,14 @@ import { withPageMeta } from "../../src/worker/page-meta";
  */
 
 const SHELL = `<!doctype html><html><head>
-<title>rdyrct - short links that carry your team's brand</title>
-<meta name="description" content="Short links that carry your brand." />
+<title>rdyrct - branded short links for your team</title>
+<meta name="description" content="Branded short links for your team." />
 <link rel="canonical" href="https://rdyrct.com" />
 <meta property="og:title" content="rdyrct" />
-<meta property="og:description" content="Short links that carry your brand." />
+<meta property="og:description" content="Branded short links for your team." />
 <meta property="og:url" content="https://rdyrct.com" />
 <meta name="twitter:title" content="rdyrct" />
-<meta name="twitter:description" content="Short links that carry your brand." />
+<meta name="twitter:description" content="Branded short links for your team." />
 </head><body></body></html>`;
 
 function shell(): Response {
@@ -69,7 +69,7 @@ describe("the head a public page ships", () => {
     // index.html says rather than earning an entry in the table.
     const html = await rewrite("/dashboard");
 
-    expect(html).toContain("<title>rdyrct - short links that carry your team's brand");
+    expect(html).toContain("<title>rdyrct - branded short links for your team");
   });
 
   it("does not touch anything that is not HTML", async () => {

--- a/tests/worker/page-meta.worker.ts
+++ b/tests/worker/page-meta.worker.ts
@@ -69,7 +69,9 @@ describe("the head a public page ships", () => {
     // index.html says rather than earning an entry in the table.
     const html = await rewrite("/dashboard");
 
-    expect(html).toContain("<title>rdyrct - branded short links for your team");
+    // Closing tag included: without it the assertion is a prefix, and a title
+    // with something appended to it would pass.
+    expect(html).toContain("<title>rdyrct - branded short links for your team</title>");
   });
 
   it("does not touch anything that is not HTML", async () => {


### PR DESCRIPTION
CodeRabbit on #111: `"short links that carry your team's brand"` is a figure of speech, and the house rules take Orwell's six from the top.

| | |
|---|---|
| Title was | rdyrct - short links that carry your team's brand |
| Title is | rdyrct - branded short links for your team |

The description lost its first sentence rather than gaining a literal rewrite of it. `"Branded short links for your team. Branded short links, QR codes, and custom domains..."` says the same thing twice, and rule 3 is to cut the word out. What is left reads:

> Branded short links, QR codes, and custom domains with privacy-friendly analytics.

Ten places in `index.html` (title, `og:title`, `twitter:title`, their descriptions, and three JSON-LD blocks), the `DEFAULT_PAGE_META` constant the client hook restores on unmount, and the two tests that assert the served title (`page-meta.worker.ts`, `production/seo.pw.ts`).

This is search-visible, so it is its own change rather than a line inside an SEO PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated page titles, descriptions, and structured metadata with clearer messaging about branded short links, QR codes, and custom domains.
  * Refined signed-in dashboard metadata to reflect the updated branding language.

* **Tests**
  * Updated SEO and metadata checks to validate the revised page titles and descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->