### PR TITLE
Parallelize and cache CI to cut wall-clock time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  static:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -22,11 +22,59 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.4
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('bun.lock') }}
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      # Before verify, not after: verify now ends with the browser smoke
-      # test, which needs these files to start the dev server.
-      #
+      - name: Format, lint, typecheck
+        run: |
+          bun run format:check
+          bun run lint
+          bun run check
+          bunx tsc -p tsconfig.worker.json --noEmit
+          bunx tsc -p tests/worker/tsconfig.json --noEmit
+
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Unit and worker tests
+        run: |
+          bun run test
+          bun run test:worker
+
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
       # Both of them. .env carries the VITE_PUBLIC_POSTHOG_* pair that
       # src/app/lib/posthog.ts reads, and CI used to run without it: the
       # analytics path was never exercised here, and in dev mode a missing
@@ -40,5 +88,5 @@ jobs:
         run: |
           cp .dev.vars.example .dev.vars
           cp .env.example .env
-      - name: Static checks, unit tests, and browser smoke test
-        run: bun run verify:e2e
+      - name: Browser smoke test (shard ${{ matrix.shard }}/3)
+        run: bunx playwright test --shard=${{ matrix.shard }}/3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,13 @@ jobs:
           key: node_modules-${{ runner.os }}-${{ hashFiles('bun.lock') }}
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      # Worker tests read secrets (BETTER_AUTH_SECRET, CAP_SECRET, ...) out of
+      # the ambient miniflare env, which wrangler builds from .dev.vars. Without
+      # it those bindings are empty, so auth/rate-limit code 500s instead of
+      # behaving: same reason the old single-job workflow copied this before
+      # running verify.
+      - name: Configure worker test environment
+        run: cp .dev.vars.example .dev.vars
       - name: Unit and worker tests
         run: |
           bun run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,9 @@ Workers globals in one directory, so they need untangling first.
 **Checks run in one place each.** The pre-commit hook only formats staged
 files, because that is the one job that repairs instead of complaining.
 Everything that reports runs in CI, where nobody can pass `--no-verify`:
-`.github/workflows/test.yml` runs `bun run verify:e2e`, and
+`.github/workflows/test.yml` runs the same checks as `bun run verify:e2e`,
+split across parallel jobs (static checks, unit/worker tests, and a 3-way
+sharded e2e run) to cut wall-clock time, and
 `.github/workflows/react-doctor.yml` blocks on any new react-doctor finding
 (changed files, against the merge base) for PRs and main.
 


### PR DESCRIPTION
## Summary
- Split the single serial `Tests` job into three parallel jobs: `static` (format/lint/typecheck), `unit` (bun test + worker tests), and `e2e` (3-way sharded Playwright run).
- Cache `node_modules` on `bun.lock` hash in each job to remove the redundant cold `bun install`.
- No test was removed or weakened; e2e alone was ~5.2m of a ~7.4m run, so sharding it is where the real time goes.

## Test plan
- [ ] CI run on this PR shows the three jobs (`static`, `unit`, `e2e` x3 shards) running in parallel and all green
- [ ] Compare total PR wall-clock against a recent `main` run for the before/after

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01UPW8HLHQyr6VN1RWwL5Lt5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated verification by separating formatting, linting, type checks, unit tests, and end-to-end tests into dedicated jobs.
  * Added parallelized, sharded browser smoke tests to reduce overall validation time.

* **Documentation**
  * Updated CI guidance to reflect the new parallel verification workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->