### PR TITLE
Fix trailing-slash redirects and return link quota usage from mutations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,13 @@ jobs:
   static:
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 gives fallow the full git history it needs to diff
+      # against origin/main (see the fallow step below); a shallow checkout
+      # has no origin/main ref to compare against.
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.4
@@ -35,6 +39,11 @@ jobs:
           bun run check
           bunx tsc -p tsconfig.worker.json --noEmit
           bunx tsc -p tests/worker/tsconfig.json --noEmit
+      # Scoped to what this branch changed, gated against
+      # fallow-baselines/health.json: fails only on findings the branch
+      # introduced, not inherited debt. See AGENTS.md.
+      - name: Fallow audit
+        run: bun run fallow
 
   unit:
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
         "@vitejs/plugin-react": "^6.0.5",
         "bun-types": "^1.3.14",
         "drizzle-kit": "^0.31.10",
-        "fallow": "^3.16.0",
+        "fallow": "3.17.0",
         "jsqr": "^1.4.0",
         "lefthook": "^2.1.10",
         "oxfmt": "^0.63.0",
@@ -246,21 +246,21 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
-    "@fallow-cli/darwin-arm64": ["@fallow-cli/darwin-arm64@3.16.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-y3reFgZ/d8JOsCJyBtyi94mOVwxnfNNtEvQuxr3OyrjTGXk8efs4ww1wKg3NS3ZrfWUCt24bAl2Jx355NcRlQQ=="],
+    "@fallow-cli/darwin-arm64": ["@fallow-cli/darwin-arm64@3.17.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u9O4aQaTSdaZaa4MAVEZEiwOx6QQzChymyQPrxV6KvDcVbcl0oYSekJKdvN4gEqUY8ClMze9gWS1tbn/W3N4dQ=="],
 
-    "@fallow-cli/darwin-x64": ["@fallow-cli/darwin-x64@3.16.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+0ch/wroWhCUoa426CRAtRZknD/vWa2vy8KsXkffWEUh4U3WQ4klIilGQvGTtRMO3C7qOp7ARLT9CPfCKgFTYw=="],
+    "@fallow-cli/darwin-x64": ["@fallow-cli/darwin-x64@3.17.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-l3tZJovnCa8j+im4qTl4GVSfrx4gisJYeHDwb5TbcdTGaWYz42gHriAaz5MhOR8S24q3xRegX8QrI8PA4XXU4g=="],
 
-    "@fallow-cli/linux-arm64-gnu": ["@fallow-cli/linux-arm64-gnu@3.16.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-GdQWKYDu1/iIXKFJ+0dQs3Ro515FXKq3MhqAB0bzuYS7DiehiIXQ0+NgaWt4B/yo5MmckhdjrKzhE9jJLDVU8A=="],
+    "@fallow-cli/linux-arm64-gnu": ["@fallow-cli/linux-arm64-gnu@3.17.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-IAjS6qR4tHcRo1y5lzYT6mktN/ATPyPNrJ6yjwTORwwQV1YfMO58A5zGBfJlPBY+lUmaMZ9w37ftvH9a2AS4dQ=="],
 
-    "@fallow-cli/linux-arm64-musl": ["@fallow-cli/linux-arm64-musl@3.16.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Iejp/ZugU2es7v4pZQw4/8+mqZCfhw3WWUns4pjhyXcXrggnS1kbnaSfS1jwZKDqlAKmTVS+oPJqIHg0pIj/Yg=="],
+    "@fallow-cli/linux-arm64-musl": ["@fallow-cli/linux-arm64-musl@3.17.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Oe1dvk5Wt5Bmnxfc6HufJTaFY9SEwDVrZpnSdVQlv+nvz7DzrTK1r91cR3Ip477ANSLa9XD/MHPMpfqqo0dlZg=="],
 
-    "@fallow-cli/linux-x64-gnu": ["@fallow-cli/linux-x64-gnu@3.16.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sqov+wY5FmUNfXZufqLEEThFISNU1G2xUIZ+no1aT5TwFVNJ22uXaLidB5VMnxWugLx6yzXvIuwqs6PJ0b+FDA=="],
+    "@fallow-cli/linux-x64-gnu": ["@fallow-cli/linux-x64-gnu@3.17.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XgLU2a51zuky7gifjVDHuiJGToAReDsVCDcyDF84TQz/h3bqO0iRkpDL8dh7+HODku84+EffpK5ZHY19n6Ij0w=="],
 
-    "@fallow-cli/linux-x64-musl": ["@fallow-cli/linux-x64-musl@3.16.0", "", { "os": "linux", "cpu": "x64" }, "sha512-JZSDV8yYyXc0Dl/mWtGDPlng+wMpdd8P+nj7YEwyc8+9DYHDdk6xbSqT2KwSzI4pP57FcSuF4KuxM9W9BBZZhw=="],
+    "@fallow-cli/linux-x64-musl": ["@fallow-cli/linux-x64-musl@3.17.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GnDZx2kbLKKdYAp05NSKv6CZHgzEKvhRd0btCKFMMpUEhdzmr4uh2Qb4UzKDBg/q2r1EhkzN4b/qC+tbFCmtwA=="],
 
-    "@fallow-cli/win32-arm64-msvc": ["@fallow-cli/win32-arm64-msvc@3.16.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Nsmh9UlduwNqqM88brJKPs1honCv5wxqWSoQg2SRZdFxCf5D0HI912hfgj9YHhVVVfFZ3yqSOOqTMpyw+Djrrw=="],
+    "@fallow-cli/win32-arm64-msvc": ["@fallow-cli/win32-arm64-msvc@3.17.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-u9n5WzPuKuC1PKegKQknWtngAUJ2szQaRXsbY54s7UMqeFNyC+W04LV5D+sEZywU7L0kzL+Kck9LxFLXBQcgvA=="],
 
-    "@fallow-cli/win32-x64-msvc": ["@fallow-cli/win32-x64-msvc@3.16.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ugyhSEEcyIHJOtQRAkJabd+/xlyHSkfd8uOxJCLnpt/i6h5Z27msbNh+m0S+QDIJ1eMAuBEWo66js/1rcJD8TQ=="],
+    "@fallow-cli/win32-x64-msvc": ["@fallow-cli/win32-x64-msvc@3.17.0", "", { "os": "win32", "cpu": "x64" }, "sha512-/OcyxHuCKabzQ9hKIjM/CFJ9fr30n0Mw5MK6nzi5rn26mbYUgh073UZq4FONOpPJ/FqHtC726rxpgBtR4qS+gg=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
 
@@ -1018,9 +1018,9 @@
 
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
-    "fallow": ["fallow@3.16.0", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@fallow-cli/darwin-arm64": "3.16.0", "@fallow-cli/darwin-x64": "3.16.0", "@fallow-cli/linux-arm64-gnu": "3.16.0", "@fallow-cli/linux-arm64-musl": "3.16.0", "@fallow-cli/linux-x64-gnu": "3.16.0", "@fallow-cli/linux-x64-musl": "3.16.0", "@fallow-cli/win32-arm64-msvc": "3.16.0", "@fallow-cli/win32-x64-msvc": "3.16.0", "fallow-type-aware": "3.16.0" }, "bin": { "fallow": "bin/fallow", "fallow-lsp": "bin/fallow-lsp", "fallow-mcp": "bin/fallow-mcp" } }, "sha512-JzwjtBpd9t2kKtZnYyJ3VU8DSNFqgqSpsJ6bCtE/fKlZ343DpWCvhuVqE58bvmh79WbxEvvJswwErd1lVJgYfg=="],
+    "fallow": ["fallow@3.17.0", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@fallow-cli/darwin-arm64": "3.17.0", "@fallow-cli/darwin-x64": "3.17.0", "@fallow-cli/linux-arm64-gnu": "3.17.0", "@fallow-cli/linux-arm64-musl": "3.17.0", "@fallow-cli/linux-x64-gnu": "3.17.0", "@fallow-cli/linux-x64-musl": "3.17.0", "@fallow-cli/win32-arm64-msvc": "3.17.0", "@fallow-cli/win32-x64-msvc": "3.17.0", "fallow-type-aware": "3.17.0" }, "bin": { "fallow": "bin/fallow", "fallow-lsp": "bin/fallow-lsp", "fallow-mcp": "bin/fallow-mcp" } }, "sha512-tbLuvsPq3I2CzpoF/9MgSQ7hWzOqlj3avFUAmCr1J9OERE6z714SlDmA38NVvNy/zuK/70utXB3/b33xC9z29g=="],
 
-    "fallow-type-aware": ["fallow-type-aware@3.16.0", "", { "dependencies": { "typescript": "7.0.2" }, "bin": { "fallow-type-aware": "fallow-type-aware.mjs" } }, "sha512-y/1p6K9Opr308vs1n88umLTMsVyhR6cLe3V7+6UI3xKHj7gcAYSH3l65XqjVNaCDhSFRLHiqG2WukrEs106d7A=="],
+    "fallow-type-aware": ["fallow-type-aware@3.17.0", "", { "dependencies": { "typescript": "7.0.2" }, "bin": { "fallow-type-aware": "fallow-type-aware.mjs" } }, "sha512-DFtZUK5oqP56tSsrBWPzjrTIwPPxwlBV8QoSaGghMru347Nqj8ZBY6u9HFa/TIPcxvFU/zIZMRF8xS/XAWQTzg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "bun-types": "^1.3.14",
     "drizzle-kit": "^0.31.10",
-    "fallow": "^3.16.0",
+    "fallow": "3.17.0",
     "jsqr": "^1.4.0",
     "lefthook": "^2.1.10",
     "oxfmt": "^0.63.0",

--- a/src/app/components/qr-color-field.tsx
+++ b/src/app/components/qr-color-field.tsx
@@ -97,7 +97,7 @@ export function QrColorField({
                 prefixed
                 color={color}
                 onChange={onChange}
-                className="mt-2 h-8 w-full rounded-md border border-border bg-bg px-2 text-center text-xs text-text uppercase focus:border-accent focus:outline-none"
+                className="mt-2 h-8 w-full rounded-md border border-border bg-bg px-2 text-center text-xs text-text uppercase focus-visible:border-accent focus-visible:outline-none"
               />
             </Popover.Popup>
           </Popover.Positioner>

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -24,6 +24,7 @@ import type {
   AdminLinkRow,
   AdminAnonLinkRow,
   AdminActionRow,
+  QuotaUsage,
   WithQuotaUsage,
 } from "@/shared/types";
 
@@ -142,24 +143,40 @@ function linkQueryString(query: LinkQuery): string {
   return params.toString();
 }
 
+interface CachedQuotaUsage {
+  count: number;
+  at: number;
+}
+
 /** Links used against the plan's `links` cap: a link plus its kept-forever
  * aliases each count (a rename's automatic 48h temp_alias never does), so
  * this can run ahead of `useLinks(...).data.length`. */
 export const useLinkQuotaUsage = (orgId: string) =>
-  useQuery<{ count: number }>({
+  useQuery<CachedQuotaUsage>({
     queryKey: ["linkQuotaUsage", orgId],
     queryFn: () => api(`/orgs/${orgId}/links/quota-usage`),
     enabled: !!orgId,
   });
 
+/** Seeds the quota cache from a mutation response instead of a follow-up GET
+ * /links/quota-usage (#100), guarded by when the count was read: two
+ * mutations racing can have their responses arrive in the opposite order
+ * from the writes that produced them, so a response older than what's
+ * already cached is dropped instead of clobbering a fresher count. */
+function applyQuotaUsage(qc: ReturnType<typeof useQueryClient>, orgId: string, quota: QuotaUsage) {
+  qc.setQueryData<CachedQuotaUsage>(["linkQuotaUsage", orgId], (prev) =>
+    prev && prev.at > quota.quotaUsageAt
+      ? prev
+      : { count: quota.quotaUsage, at: quota.quotaUsageAt },
+  );
+}
+
 export function useLinkMutations(orgId: string) {
   const qc = useQueryClient();
-  const invalidate = (quotaUsage: number) => {
+  const invalidate = (quota: QuotaUsage) => {
     qc.invalidateQueries({ queryKey: ["links", orgId] });
     qc.invalidateQueries({ queryKey: ["stats", orgId] });
-    // The write already knows its own effect on the count, so seed the cache
-    // with it instead of a follow-up GET /links/quota-usage (#100).
-    qc.setQueryData(["linkQuotaUsage", orgId], { count: quotaUsage });
+    applyQuotaUsage(qc, orgId, quota);
     // A rename can leave the old slug behind as a temp alias: refetch any
     // addresses list already open for this org's links, not just on remount.
     qc.invalidateQueries({ queryKey: ["addresses", orgId] });
@@ -168,7 +185,7 @@ export function useLinkMutations(orgId: string) {
     mutationFn: (body: LinkInput) =>
       api<WithQuotaUsage<LinkDTO>>(`/orgs/${orgId}/links`, { method: "POST", body }),
     onSuccess: (link) => {
-      invalidate(link.quotaUsage);
+      invalidate(link);
       // Funnel step 7, the activation event (#64). On the hook rather than
       // the call sites, so the dashboard's quick-create and the links page
       // both count and neither can be forgotten.
@@ -178,12 +195,12 @@ export function useLinkMutations(orgId: string) {
   const update = useMutation({
     mutationFn: ({ id, ...body }: LinkInput & { id: string }) =>
       api<WithQuotaUsage<LinkDTO>>(`/orgs/${orgId}/links/${id}`, { method: "PATCH", body }),
-    onSuccess: (link) => invalidate(link.quotaUsage),
+    onSuccess: invalidate,
   });
   const remove = useMutation({
     mutationFn: (id: string) =>
       api<WithQuotaUsage<{ ok: true }>>(`/orgs/${orgId}/links/${id}`, { method: "DELETE" }),
-    onSuccess: (res) => invalidate(res.quotaUsage),
+    onSuccess: invalidate,
   });
   return { create, update, remove };
 }
@@ -223,11 +240,11 @@ export const useAddresses = (orgId: string, linkId: string | null) =>
 
 export function useAddressMutations(orgId: string, linkId: string) {
   const qc = useQueryClient();
-  const invalidate = (quotaUsage: number) => {
+  const invalidate = (quota: QuotaUsage) => {
     qc.invalidateQueries({ queryKey: ["addresses", orgId, linkId] });
     qc.invalidateQueries({ queryKey: ["links", orgId] });
     qc.invalidateQueries({ queryKey: ["linkStats", orgId] });
-    qc.setQueryData(["linkQuotaUsage", orgId], { count: quotaUsage });
+    applyQuotaUsage(qc, orgId, quota);
   };
   const keepForever = useMutation({
     mutationFn: (addressId: string) =>
@@ -235,7 +252,7 @@ export function useAddressMutations(orgId: string, linkId: string) {
         `/orgs/${orgId}/links/${linkId}/addresses/${addressId}/keep-forever`,
         { method: "POST" },
       ),
-    onSuccess: (res) => invalidate(res.quotaUsage),
+    onSuccess: invalidate,
   });
   const remove = useMutation({
     mutationFn: (addressId: string) =>
@@ -243,7 +260,7 @@ export function useAddressMutations(orgId: string, linkId: string) {
         `/orgs/${orgId}/links/${linkId}/addresses/${addressId}/remove`,
         { method: "POST", body: { confirm: true } },
       ),
-    onSuccess: (res) => invalidate(res.quotaUsage),
+    onSuccess: invalidate,
   });
   const promote = useMutation({
     mutationFn: (addressId: string) =>
@@ -253,7 +270,7 @@ export function useAddressMutations(orgId: string, linkId: string) {
           method: "POST",
         },
       ),
-    onSuccess: (link) => invalidate(link.quotaUsage),
+    onSuccess: invalidate,
   });
   const create = useMutation({
     mutationFn: (body: { slug?: string }) =>
@@ -261,7 +278,7 @@ export function useAddressMutations(orgId: string, linkId: string) {
         method: "POST",
         body,
       }),
-    onSuccess: (link) => invalidate(link.quotaUsage),
+    onSuccess: invalidate,
   });
   return { keepForever, remove, promote, create };
 }

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -24,6 +24,7 @@ import type {
   AdminLinkRow,
   AdminAnonLinkRow,
   AdminActionRow,
+  WithQuotaUsage,
 } from "@/shared/types";
 
 export function useCurrentUser() {
@@ -153,18 +154,21 @@ export const useLinkQuotaUsage = (orgId: string) =>
 
 export function useLinkMutations(orgId: string) {
   const qc = useQueryClient();
-  const invalidate = () => {
+  const invalidate = (quotaUsage: number) => {
     qc.invalidateQueries({ queryKey: ["links", orgId] });
     qc.invalidateQueries({ queryKey: ["stats", orgId] });
-    qc.invalidateQueries({ queryKey: ["linkQuotaUsage", orgId] });
+    // The write already knows its own effect on the count, so seed the cache
+    // with it instead of a follow-up GET /links/quota-usage (#100).
+    qc.setQueryData(["linkQuotaUsage", orgId], { count: quotaUsage });
     // A rename can leave the old slug behind as a temp alias: refetch any
     // addresses list already open for this org's links, not just on remount.
     qc.invalidateQueries({ queryKey: ["addresses", orgId] });
   };
   const create = useMutation({
-    mutationFn: (body: LinkInput) => api<LinkDTO>(`/orgs/${orgId}/links`, { method: "POST", body }),
+    mutationFn: (body: LinkInput) =>
+      api<WithQuotaUsage<LinkDTO>>(`/orgs/${orgId}/links`, { method: "POST", body }),
     onSuccess: (link) => {
-      invalidate();
+      invalidate(link.quotaUsage);
       // Funnel step 7, the activation event (#64). On the hook rather than
       // the call sites, so the dashboard's quick-create and the links page
       // both count and neither can be forgotten.
@@ -173,12 +177,13 @@ export function useLinkMutations(orgId: string) {
   });
   const update = useMutation({
     mutationFn: ({ id, ...body }: LinkInput & { id: string }) =>
-      api<LinkDTO>(`/orgs/${orgId}/links/${id}`, { method: "PATCH", body }),
-    onSuccess: invalidate,
+      api<WithQuotaUsage<LinkDTO>>(`/orgs/${orgId}/links/${id}`, { method: "PATCH", body }),
+    onSuccess: (link) => invalidate(link.quotaUsage),
   });
   const remove = useMutation({
-    mutationFn: (id: string) => api(`/orgs/${orgId}/links/${id}`, { method: "DELETE" }),
-    onSuccess: invalidate,
+    mutationFn: (id: string) =>
+      api<WithQuotaUsage<{ ok: true }>>(`/orgs/${orgId}/links/${id}`, { method: "DELETE" }),
+    onSuccess: (res) => invalidate(res.quotaUsage),
   });
   return { create, update, remove };
 }
@@ -218,36 +223,45 @@ export const useAddresses = (orgId: string, linkId: string | null) =>
 
 export function useAddressMutations(orgId: string, linkId: string) {
   const qc = useQueryClient();
-  const invalidate = () => {
+  const invalidate = (quotaUsage: number) => {
     qc.invalidateQueries({ queryKey: ["addresses", orgId, linkId] });
     qc.invalidateQueries({ queryKey: ["links", orgId] });
     qc.invalidateQueries({ queryKey: ["linkStats", orgId] });
-    qc.invalidateQueries({ queryKey: ["linkQuotaUsage", orgId] });
+    qc.setQueryData(["linkQuotaUsage", orgId], { count: quotaUsage });
   };
   const keepForever = useMutation({
     mutationFn: (addressId: string) =>
-      api(`/orgs/${orgId}/links/${linkId}/addresses/${addressId}/keep-forever`, { method: "POST" }),
-    onSuccess: invalidate,
+      api<WithQuotaUsage<{ ok: true }>>(
+        `/orgs/${orgId}/links/${linkId}/addresses/${addressId}/keep-forever`,
+        { method: "POST" },
+      ),
+    onSuccess: (res) => invalidate(res.quotaUsage),
   });
   const remove = useMutation({
     mutationFn: (addressId: string) =>
-      api(`/orgs/${orgId}/links/${linkId}/addresses/${addressId}/remove`, {
-        method: "POST",
-        body: { confirm: true },
-      }),
-    onSuccess: invalidate,
+      api<WithQuotaUsage<{ ok: true }>>(
+        `/orgs/${orgId}/links/${linkId}/addresses/${addressId}/remove`,
+        { method: "POST", body: { confirm: true } },
+      ),
+    onSuccess: (res) => invalidate(res.quotaUsage),
   });
   const promote = useMutation({
     mutationFn: (addressId: string) =>
-      api<LinkDTO>(`/orgs/${orgId}/links/${linkId}/addresses/${addressId}/promote`, {
-        method: "POST",
-      }),
-    onSuccess: invalidate,
+      api<WithQuotaUsage<LinkDTO>>(
+        `/orgs/${orgId}/links/${linkId}/addresses/${addressId}/promote`,
+        {
+          method: "POST",
+        },
+      ),
+    onSuccess: (link) => invalidate(link.quotaUsage),
   });
   const create = useMutation({
     mutationFn: (body: { slug?: string }) =>
-      api<LinkDTO>(`/orgs/${orgId}/links/${linkId}/addresses`, { method: "POST", body }),
-    onSuccess: invalidate,
+      api<WithQuotaUsage<LinkDTO>>(`/orgs/${orgId}/links/${linkId}/addresses`, {
+        method: "POST",
+        body,
+      }),
+    onSuccess: (link) => invalidate(link.quotaUsage),
   });
   return { keepForever, remove, promote, create };
 }

--- a/src/app/ui/field.tsx
+++ b/src/app/ui/field.tsx
@@ -9,7 +9,7 @@ import { cn } from "./cn";
 import { Tooltip } from "./tooltip";
 
 const inputClass =
-  "h-9 w-full rounded-md border border-border bg-bg px-3 text-sm text-text transition-colors placeholder:text-placeholder focus:border-accent focus:outline-none disabled:opacity-50";
+  "h-9 w-full rounded-md border border-border bg-bg px-3 text-sm text-text transition-colors placeholder:text-placeholder focus-visible:border-accent focus-visible:outline-none disabled:opacity-50";
 
 export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
   ({ className, ...props }, ref) => (

--- a/src/app/ui/otp.tsx
+++ b/src/app/ui/otp.tsx
@@ -103,7 +103,7 @@ export function OtpInput({
         <OTPField.Input
           key={i}
           autoFocus={autoFocus && i === 0}
-          className="h-11 w-full min-w-0 rounded-md border border-border bg-bg text-center text-lg text-text tabular-nums transition-colors focus:border-accent focus:outline-none disabled:opacity-50 data-[filled]:border-accent/60"
+          className="h-11 w-full min-w-0 rounded-md border border-border bg-bg text-center text-lg text-text tabular-nums transition-colors focus-visible:border-accent focus-visible:outline-none disabled:opacity-50 data-[filled]:border-accent/60"
         />
       ))}
     </OTPField.Root>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -203,10 +203,20 @@ export interface AppConfig {
   appHost: string;
 }
 
-/** A link/address mutation's response, plus the org's fresh link-quota usage
- * (see #100): the write that changed it already knows the new count, so the
- * client can skip the follow-up GET /links/quota-usage. */
-export type WithQuotaUsage<T> = T & { quotaUsage: number };
+/** The org's fresh link-quota count, plus when it was read. The timestamp
+ * lets the client drop an out-of-order mutation response instead of
+ * overwriting a newer cached count with a stale one: two mutations racing
+ * can have their HTTP responses arrive in the opposite order from the D1
+ * writes that produced them. */
+export interface QuotaUsage {
+  quotaUsage: number;
+  quotaUsageAt: number;
+}
+
+/** A link/address mutation's response, plus its fresh QuotaUsage (see #100):
+ * the write that changed the count already knows it, so the client can skip
+ * the follow-up GET /links/quota-usage. */
+export type WithQuotaUsage<T> = T & QuotaUsage;
 
 export interface LinkDTO extends QrOverrides {
   id: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -203,6 +203,11 @@ export interface AppConfig {
   appHost: string;
 }
 
+/** A link/address mutation's response, plus the org's fresh link-quota usage
+ * (see #100): the write that changed it already knows the new count, so the
+ * client can skip the follow-up GET /links/quota-usage. */
+export type WithQuotaUsage<T> = T & { quotaUsage: number };
+
 export interface LinkDTO extends QrOverrides {
   id: string;
   domainId: string | null;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -4,6 +4,7 @@ import type { JsonValue } from "../shared/types";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { methodNotAllowed } from "hono/method-not-allowed";
+import { trimTrailingSlash } from "hono/trailing-slash";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AppEnv, Env } from "./env";
 import { withSession } from "./session";
@@ -142,6 +143,13 @@ app.use("*", async (c, next) => {
   if (domain.rootRedirect) return c.redirect(domain.rootRedirect, 302);
   return c.text("Not found", 404);
 });
+
+// A trailing slash on a GET (`/abc/`) fell through every route below,
+// including custom-domain and shared-domain slug matching, straight to the
+// SPA shell under a 200. This normalizes it to the slash-free path with a
+// redirect, after the custom-domain middleware so a redirected request comes
+// back through it and still resolves as that domain's own slug.
+app.use("*", trimTrailingSlash({ alwaysRedirect: true }));
 
 /* ---------------- API ---------------- */
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -134,7 +134,11 @@ app.use("*", async (c, next) => {
   if (!domain) return next();
 
   const path = new URL(c.req.url).pathname;
-  const slug = path.slice(1);
+  // This middleware is a dead end for a host it owns: it never calls next(),
+  // so trimTrailingSlash below never gets a turn at a custom domain's own
+  // path. A trailing slash has to be stripped right here or "/abc/" reads as
+  // a miss and falls all the way through to the domain's root redirect.
+  const slug = path.slice(1).replace(/\/+$/, "");
   if (slug && !slug.includes("/")) {
     const hit = await resolveSlug(c.env, slug, host);
     if (hit && isLive(hit)) return redirectWithClick(c, hit);
@@ -144,11 +148,10 @@ app.use("*", async (c, next) => {
   return c.text("Not found", 404);
 });
 
-// A trailing slash on a GET (`/abc/`) fell through every route below,
-// including custom-domain and shared-domain slug matching, straight to the
-// SPA shell under a 200. This normalizes it to the slash-free path with a
-// redirect, after the custom-domain middleware so a redirected request comes
-// back through it and still resolves as that domain's own slug.
+// A trailing slash on a GET (`/abc/`) fell through the shared-domain slug
+// route below (hono's `/:slug` param match is exact, no trailing segment)
+// straight to the SPA shell under a 200. Custom domains handle their own
+// trailing slash above; this covers everything on the shared host.
 app.use("*", trimTrailingSlash({ alwaysRedirect: true }));
 
 /* ---------------- API ---------------- */

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -165,7 +165,11 @@ async function insertAddressAndRespond(
       cause: { code: "link_limit" },
     });
   await enqueueStorage(env, [syncLinkMsg(address.slug, hostname)]);
-  return { dto: await linkToDTO(db, orgId, link), status } as const;
+  const [dto, quotaUsage] = await Promise.all([
+    linkToDTO(db, orgId, link),
+    countActiveAddresses(db, orgId),
+  ]);
+  return { dto: { ...dto, quotaUsage }, status } as const;
 }
 
 /** Count active addresses for a single link, for call sites that don't
@@ -791,7 +795,8 @@ linkRoutes.post("/", requireOrgRole("member"), async (c) => {
   // Score the destination after the response (#68), the way clicks are
   // recorded: it scores, it never blocks, and nobody waits on it.
   c.executionCtx.waitUntil(scoreAndRecord(c.env.DB, link.id, link.destination));
-  return c.json(toDTO(link, 0, hostname, 1), 201);
+  const quotaUsage = await countActiveAddresses(db, orgId);
+  return c.json({ ...toDTO(link, 0, hostname, 1), quotaUsage }, 201);
 });
 
 /** Merges a PATCH body over the existing row: an unset field (undefined)
@@ -987,11 +992,15 @@ linkRoutes.patch("/:linkId", requireOrgRole("member"), async (c) => {
   if (updated.destination !== existing.destination)
     c.executionCtx.waitUntil(scoreAndRecord(c.env.DB, existing.id, updated.destination));
 
-  return c.json(await linkToDTO(db, orgId, updated));
+  const [dto, quotaUsage] = await Promise.all([
+    linkToDTO(db, orgId, updated),
+    countActiveAddresses(db, orgId),
+  ]);
+  return c.json({ ...dto, quotaUsage });
 });
 
 linkRoutes.delete("/:linkId", requireOrgRole("member"), async (c) => {
-  const { db, link } = await linkFromRequest(c);
+  const { db, orgId, link } = await linkFromRequest(c);
   // Gathered before the delete: every active address (primary + aliases) has
   // its own KV key, and the cascade only removes the D1 rows, not those keys.
   const addresses = await activeAddressesOf(db, link.id);
@@ -1001,7 +1010,8 @@ linkRoutes.delete("/:linkId", requireOrgRole("member"), async (c) => {
     ...addresses.map((a) => syncLinkMsg(a.slug, a.hostname)),
     deleteQrLogoMsg(link.qrLogo),
   ]);
-  return c.json({ ok: true });
+  const quotaUsage = await countActiveAddresses(db, orgId);
+  return c.json({ ok: true, quotaUsage });
 });
 
 /* ---------------- addresses (aliases + primary) ---------------- */
@@ -1106,7 +1116,8 @@ linkRoutes.post(
     // this as expired.
     const hostname = await domainHostname(db, orgId, address.domainId);
     await enqueueStorage(c.env, [syncLinkMsg(address.slug, hostname)]);
-    return c.json({ ok: true });
+    const quotaUsage = await countActiveAddresses(db, orgId);
+    return c.json({ ok: true, quotaUsage });
   },
 );
 
@@ -1132,12 +1143,19 @@ linkRoutes.post("/:linkId/addresses/:addressId/remove", requireOrgRole("member")
   // Re-publish now instead of waiting for the sweep: a removed address
   // should stop resolving immediately, not up to a day later.
   await enqueueStorage(c.env, [syncLinkMsg(address.slug, hostname)]);
-  return c.json({ ok: true });
+  const quotaUsage = await countActiveAddresses(db, orgId);
+  return c.json({ ok: true, quotaUsage });
 });
 
 linkRoutes.post("/:linkId/addresses/:addressId/promote", requireOrgRole("member"), async (c) => {
   const { db, orgId, link: existing, address } = await findLinkAndAddress(c);
-  if (address.kind === "primary") return c.json(await linkToDTO(db, orgId, existing));
+  if (address.kind === "primary") {
+    const [dto, quotaUsage] = await Promise.all([
+      linkToDTO(db, orgId, existing),
+      countActiveAddresses(db, orgId),
+    ]);
+    return c.json({ ...dto, quotaUsage });
+  }
   if (address.retiredAt !== null)
     throw new HTTPException(409, { message: "This address is no longer active" });
 
@@ -1205,5 +1223,9 @@ linkRoutes.post("/:linkId/addresses/:addressId/promote", requireOrgRole("member"
     syncLinkMsg(address.slug, hostname),
   ]);
 
-  return c.json(await linkToDTO(db, orgId, updated));
+  const [dto, quotaUsage] = await Promise.all([
+    linkToDTO(db, orgId, updated),
+    countActiveAddresses(db, orgId),
+  ]);
+  return c.json({ ...dto, quotaUsage });
 });

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -258,6 +258,12 @@ async function linkFromRequest(c: Context<AppEnv>) {
   return { db, orgId, link: await findLink(db, orgId, c.req.param("linkId")!) };
 }
 
+/** The `{ ok: true }` response shape once a mutation only changed which
+ * addresses are active, with the org's fresh quota count attached (#100). */
+async function okWithQuota(db: DB, orgId: string) {
+  return { ok: true as const, quotaUsage: await countActiveAddresses(db, orgId) };
+}
+
 async function findLinkAndAddress(c: Context<AppEnv>) {
   const db = c.var.db;
   const orgId = c.req.param("orgId")!;
@@ -1010,8 +1016,7 @@ linkRoutes.delete("/:linkId", requireOrgRole("member"), async (c) => {
     ...addresses.map((a) => syncLinkMsg(a.slug, a.hostname)),
     deleteQrLogoMsg(link.qrLogo),
   ]);
-  const quotaUsage = await countActiveAddresses(db, orgId);
-  return c.json({ ok: true, quotaUsage });
+  return c.json(await okWithQuota(db, orgId));
 });
 
 /* ---------------- addresses (aliases + primary) ---------------- */
@@ -1116,8 +1121,7 @@ linkRoutes.post(
     // this as expired.
     const hostname = await domainHostname(db, orgId, address.domainId);
     await enqueueStorage(c.env, [syncLinkMsg(address.slug, hostname)]);
-    const quotaUsage = await countActiveAddresses(db, orgId);
-    return c.json({ ok: true, quotaUsage });
+    return c.json(await okWithQuota(db, orgId));
   },
 );
 
@@ -1143,8 +1147,7 @@ linkRoutes.post("/:linkId/addresses/:addressId/remove", requireOrgRole("member")
   // Re-publish now instead of waiting for the sweep: a removed address
   // should stop resolving immediately, not up to a day later.
   await enqueueStorage(c.env, [syncLinkMsg(address.slug, hostname)]);
-  const quotaUsage = await countActiveAddresses(db, orgId);
-  return c.json({ ok: true, quotaUsage });
+  return c.json(await okWithQuota(db, orgId));
 });
 
 linkRoutes.post("/:linkId/addresses/:addressId/promote", requireOrgRole("member"), async (c) => {

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -32,7 +32,15 @@ import { jsonBodyLimit } from "../body-limit";
 import { scoreAndRecord } from "../risk";
 import { claimAnonLink } from "./shorten";
 import { cursorValueOf, linkPageQuery, readLinkPageParams, takePage } from "../links-page";
-import type { AddressDTO, LinkDTO, LinkInput, OrgPlan, PlanLimits, TopEntry } from "@/shared/types";
+import type {
+  AddressDTO,
+  LinkDTO,
+  LinkInput,
+  OrgPlan,
+  PlanLimits,
+  QuotaUsage,
+  TopEntry,
+} from "@/shared/types";
 
 const RECENT_CLICKS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 // Active aliases (temp + permanent) a single link may hold at once: keeps the
@@ -165,11 +173,8 @@ async function insertAddressAndRespond(
       cause: { code: "link_limit" },
     });
   await enqueueStorage(env, [syncLinkMsg(address.slug, hostname)]);
-  const [dto, quotaUsage] = await Promise.all([
-    linkToDTO(db, orgId, link),
-    countActiveAddresses(db, orgId),
-  ]);
-  return { dto: { ...dto, quotaUsage }, status } as const;
+  const [dto, quota] = await Promise.all([linkToDTO(db, orgId, link), quotaUsageFields(db, orgId)]);
+  return { dto: { ...dto, ...quota }, status } as const;
 }
 
 /** Count active addresses for a single link, for call sites that don't
@@ -258,10 +263,17 @@ async function linkFromRequest(c: Context<AppEnv>) {
   return { db, orgId, link: await findLink(db, orgId, c.req.param("linkId")!) };
 }
 
+/** The org's fresh link-quota count, timestamped at the read (see
+ * QuotaUsage): every mutation response spreads this in instead of the client
+ * making a follow-up GET /links/quota-usage (#100). */
+async function quotaUsageFields(db: DB, orgId: string): Promise<QuotaUsage> {
+  return { quotaUsage: await countActiveAddresses(db, orgId), quotaUsageAt: Date.now() };
+}
+
 /** The `{ ok: true }` response shape once a mutation only changed which
  * addresses are active, with the org's fresh quota count attached (#100). */
 async function okWithQuota(db: DB, orgId: string) {
-  return { ok: true as const, quotaUsage: await countActiveAddresses(db, orgId) };
+  return { ok: true as const, ...(await quotaUsageFields(db, orgId)) };
 }
 
 async function findLinkAndAddress(c: Context<AppEnv>) {
@@ -589,8 +601,8 @@ linkRoutes.post("/claim", requireOrgRole("member"), async (c) => {
 });
 
 linkRoutes.get("/quota-usage", requireOrgRole("member"), async (c) => {
-  const count = await countActiveAddresses(c.var.db, c.req.param("orgId")!);
-  return c.json({ count });
+  const { quotaUsage, quotaUsageAt } = await quotaUsageFields(c.var.db, c.req.param("orgId")!);
+  return c.json({ count: quotaUsage, at: quotaUsageAt });
 });
 
 /** Builds a new link row: unset appearance/UTM fields fall back to their
@@ -801,8 +813,7 @@ linkRoutes.post("/", requireOrgRole("member"), async (c) => {
   // Score the destination after the response (#68), the way clicks are
   // recorded: it scores, it never blocks, and nobody waits on it.
   c.executionCtx.waitUntil(scoreAndRecord(c.env.DB, link.id, link.destination));
-  const quotaUsage = await countActiveAddresses(db, orgId);
-  return c.json({ ...toDTO(link, 0, hostname, 1), quotaUsage }, 201);
+  return c.json({ ...toDTO(link, 0, hostname, 1), ...(await quotaUsageFields(db, orgId)) }, 201);
 });
 
 /** Merges a PATCH body over the existing row: an unset field (undefined)
@@ -998,11 +1009,11 @@ linkRoutes.patch("/:linkId", requireOrgRole("member"), async (c) => {
   if (updated.destination !== existing.destination)
     c.executionCtx.waitUntil(scoreAndRecord(c.env.DB, existing.id, updated.destination));
 
-  const [dto, quotaUsage] = await Promise.all([
+  const [dto, quota] = await Promise.all([
     linkToDTO(db, orgId, updated),
-    countActiveAddresses(db, orgId),
+    quotaUsageFields(db, orgId),
   ]);
-  return c.json({ ...dto, quotaUsage });
+  return c.json({ ...dto, ...quota });
 });
 
 linkRoutes.delete("/:linkId", requireOrgRole("member"), async (c) => {
@@ -1153,11 +1164,11 @@ linkRoutes.post("/:linkId/addresses/:addressId/remove", requireOrgRole("member")
 linkRoutes.post("/:linkId/addresses/:addressId/promote", requireOrgRole("member"), async (c) => {
   const { db, orgId, link: existing, address } = await findLinkAndAddress(c);
   if (address.kind === "primary") {
-    const [dto, quotaUsage] = await Promise.all([
+    const [dto, quota] = await Promise.all([
       linkToDTO(db, orgId, existing),
-      countActiveAddresses(db, orgId),
+      quotaUsageFields(db, orgId),
     ]);
-    return c.json({ ...dto, quotaUsage });
+    return c.json({ ...dto, ...quota });
   }
   if (address.retiredAt !== null)
     throw new HTTPException(409, { message: "This address is no longer active" });
@@ -1226,9 +1237,9 @@ linkRoutes.post("/:linkId/addresses/:addressId/promote", requireOrgRole("member"
     syncLinkMsg(address.slug, hostname),
   ]);
 
-  const [dto, quotaUsage] = await Promise.all([
+  const [dto, quota] = await Promise.all([
     linkToDTO(db, orgId, updated),
-    countActiveAddresses(db, orgId),
+    quotaUsageFields(db, orgId),
   ]);
-  return c.json({ ...dto, quotaUsage });
+  return c.json({ ...dto, ...quota });
 });

--- a/tests/worker/links.worker.ts
+++ b/tests/worker/links.worker.ts
@@ -74,3 +74,33 @@ describe("PATCH /orgs/:orgId/links/:linkId", () => {
     expect(updated.destination).toBe("https://example.com/original");
   });
 });
+
+describe("link quota usage returned by mutations (#100)", () => {
+  beforeEach(applyTestMigrations);
+  afterEach(reset);
+
+  it("create and delete each answer with the org's fresh count", async () => {
+    const cookie = await freeOwnerCookie();
+
+    const created = await postLink(cookie, { destination: "https://example.com/a" });
+    const link = await jsonBody<{ id: string; quotaUsage: number }>(created);
+    expect(link.quotaUsage).toBe(1);
+
+    const patched = await patchLink(cookie, link.id, { title: "Renamed" });
+    const updated = await jsonBody<{ quotaUsage: number }>(patched);
+    expect(updated.quotaUsage).toBe(1);
+
+    const ctx = createExecutionContext();
+    const deleted = await worker.fetch(
+      new Request(`http://localhost/api/orgs/org-1/links/${link.id}`, {
+        method: "DELETE",
+        headers: { cookie },
+      }),
+      authEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    const removed = await jsonBody<{ quotaUsage: number }>(deleted);
+    expect(removed.quotaUsage).toBe(0);
+  });
+});

--- a/tests/worker/links.worker.ts
+++ b/tests/worker/links.worker.ts
@@ -83,12 +83,17 @@ describe("link quota usage returned by mutations (#100)", () => {
     const cookie = await freeOwnerCookie();
 
     const created = await postLink(cookie, { destination: "https://example.com/a" });
-    const link = await jsonBody<{ id: string; quotaUsage: number }>(created);
+    const link = await jsonBody<{ id: string; quotaUsage: number; quotaUsageAt: number }>(created);
     expect(link.quotaUsage).toBe(1);
+    expect(link.quotaUsageAt).toBeGreaterThan(0);
 
     const patched = await patchLink(cookie, link.id, { title: "Renamed" });
-    const updated = await jsonBody<{ quotaUsage: number }>(patched);
+    const updated = await jsonBody<{ quotaUsage: number; quotaUsageAt: number }>(patched);
     expect(updated.quotaUsage).toBe(1);
+    // Each read is a fresh Date.now(), so a later mutation's response never
+    // carries an earlier timestamp: the client uses this to drop a stale,
+    // out-of-order response instead of clobbering a fresher one.
+    expect(updated.quotaUsageAt).toBeGreaterThanOrEqual(link.quotaUsageAt);
 
     const ctx = createExecutionContext();
     const deleted = await worker.fetch(
@@ -100,7 +105,8 @@ describe("link quota usage returned by mutations (#100)", () => {
       ctx,
     );
     await waitOnExecutionContext(ctx);
-    const removed = await jsonBody<{ quotaUsage: number }>(deleted);
+    const removed = await jsonBody<{ quotaUsage: number; quotaUsageAt: number }>(deleted);
     expect(removed.quotaUsage).toBe(0);
+    expect(removed.quotaUsageAt).toBeGreaterThanOrEqual(updated.quotaUsageAt);
   });
 });

--- a/tests/worker/redirects.worker.ts
+++ b/tests/worker/redirects.worker.ts
@@ -163,6 +163,18 @@ describe("redirect hot path", () => {
     expect(await res.text()).toContain('<div id="root">');
   });
 
+  it("redirects a trailing-slash slug to the slash-free path", async () => {
+    await env.LINKS.put(
+      "slug:summer",
+      JSON.stringify({ linkId: "link-1", orgId: "org-1", url: "https://example.com/sale" }),
+    );
+
+    const res = await fetchWorker(new Request("http://localhost/summer/", { redirect: "manual" }));
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("http://localhost/summer");
+  });
+
   it("leaves the app's own root keywords on 200", async () => {
     // The 404 above is decided one line below the RESERVED_SLUGS check, so the
     // way to get it wrong is to start 404ing the pages the SPA serves.

--- a/tests/worker/redirects.worker.ts
+++ b/tests/worker/redirects.worker.ts
@@ -39,6 +39,20 @@ beforeEach(async () => {
   ]);
 });
 
+/** The custom domain (go.example.com -> org-1) plus its one KV-published
+ * slug ("pricing" -> link-2), shared by every test that exercises
+ * custom-domain resolution. */
+async function putCustomDomainAndSlug(): Promise<void> {
+  await env.LINKS.put(
+    "domain:go.example.com",
+    JSON.stringify({ domainId: "domain-1", orgId: "org-1", rootRedirect: "https://example.com" }),
+  );
+  await env.LINKS.put(
+    "slug:go.example.com:pricing",
+    JSON.stringify({ linkId: "link-2", orgId: "org-1", url: "https://example.com/pricing" }),
+  );
+}
+
 describe("redirect hot path", () => {
   it("redirects a shared-host slug and enqueues a click after responding", async () => {
     await env.LINKS.put(
@@ -63,14 +77,7 @@ describe("redirect hot path", () => {
   });
 
   it("keeps custom-domain links separate from shared-host links", async () => {
-    await env.LINKS.put(
-      "domain:go.example.com",
-      JSON.stringify({ domainId: "domain-1", orgId: "org-1", rootRedirect: "https://example.com" }),
-    );
-    await env.LINKS.put(
-      "slug:go.example.com:pricing",
-      JSON.stringify({ linkId: "link-2", orgId: "org-1", url: "https://example.com/pricing" }),
-    );
+    await putCustomDomainAndSlug();
 
     const response = await fetchWorker(
       new Request("http://localhost/pricing", {
@@ -163,16 +170,55 @@ describe("redirect hot path", () => {
     expect(await res.text()).toContain('<div id="root">');
   });
 
-  it("redirects a trailing-slash slug to the slash-free path", async () => {
+  it("redirects a trailing-slash slug to the slash-free path, which then redirects and records a click", async () => {
     await env.LINKS.put(
       "slug:summer",
       JSON.stringify({ linkId: "link-1", orgId: "org-1", url: "https://example.com/sale" }),
     );
+    const { env: testEnv, sent } = captureClickQueue();
 
-    const res = await fetchWorker(new Request("http://localhost/summer/", { redirect: "manual" }));
+    const trimmed = await fetchWorker(
+      new Request("http://localhost/summer/", { redirect: "manual" }),
+      testEnv,
+    );
+    expect(trimmed.status).toBe(301);
+    const location = trimmed.headers.get("location");
+    expect(location).toBe("http://localhost/summer");
 
-    expect(res.status).toBe(301);
-    expect(res.headers.get("location")).toBe("http://localhost/summer");
+    const followed = await fetchWorker(new Request(location!, { redirect: "manual" }), testEnv);
+    expect(followed.status).toBe(302);
+    expect(followed.headers.get("location")).toBe("https://example.com/sale");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ linkId: "link-1", orgId: "org-1" });
+  });
+
+  it("resolves a trailing-slash slug on a custom domain without a detour through the SPA's redirect", async () => {
+    await putCustomDomainAndSlug();
+
+    // The custom-domain middleware is a dead end for its own host (it never
+    // calls next()), so it has to strip the trailing slash itself: it can't
+    // rely on the shared-domain trimTrailingSlash middleware registered
+    // after it.
+    const res = await fetchWorker(
+      new Request("http://localhost/pricing/", {
+        headers: { host: "go.example.com" },
+        redirect: "manual",
+      }),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://example.com/pricing");
+  });
+
+  it("still 404s a trailing-slash slug nobody registered, once trimmed", async () => {
+    const trimmed = await fetchWorker(
+      new Request("http://localhost/no-such-slug-xyz/", { redirect: "manual" }),
+    );
+    expect(trimmed.status).toBe(301);
+
+    const followed = await fetchWorker(
+      new Request(trimmed.headers.get("location")!, { redirect: "manual" }),
+    );
+    expect(followed.status).toBe(404);
   });
 
   it("leaves the app's own root keywords on 200", async () => {


### PR DESCRIPTION
## Summary
- `/:slug/` on the shared or a custom domain fell through to a 200 SPA shell instead of redirecting or 404ing. Adds `trimTrailingSlash({ alwaysRedirect: true })` after the custom-domain middleware so a trailing-slash request 301s to the slug-free path and resolves normally. Fixes #125.
- Creating, editing, or deleting a link (and the address mutations: add, keep-forever, remove, promote) cost an extra `GET /links/quota-usage` round trip. Each write already knows its effect on the org's link-quota count, so it now returns `quotaUsage` directly; the client seeds the query cache with it instead of invalidating. Fixes #100.

## Test plan
- [x] `bun run check` / worker tsc / worker-tests tsc all clean
- [x] `bun run lint`
- [x] `bun run test` (283 pass)
- [x] `bun run test:worker` (307 pass), including new cases in `tests/worker/redirects.worker.ts` and `tests/worker/links.worker.ts`
- [ ] full `verify:e2e` / CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VfyPU1UrdK8joAUPAzByL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation by showing focus styling only when focus is visibly required.
  * Trailing-slash links now redirect to their equivalent slash-free URLs.
  * Link quota usage now refreshes immediately after link and address changes, including creation, updates, deletion, and promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->