### PR TITLE
Stop repeating what Cloudflare's managed robots.txt already says

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,17 @@
-# search=yes: crawl and index normally. ai-train=no: do not use this site to
-# train a model. use=reference: an AI system may read and cite it, the way
-# llms.txt already asks.
-Content-Signal: search=yes,ai-train=no,use=reference
+# Cloudflare merges this file with its own managed block, which it puts
+# above everything here (see the zone's "Set your preference to block
+# training in robots.txt" setting). That block carries the Content Signals
+# policy, `Content-Signal: search=yes,ai-train=no,use=reference`, and a
+# list of AI training crawlers refused by name that Cloudflare keeps up to
+# date. So none of that belongs here: a second copy is one more thing to
+# forget, and it would go stale the week a new crawler appears.
+#
+# What is left is the part only this repo knows: which paths are worth
+# crawling, and where the sitemaps are. Fetch https://rdyrct.com/robots.txt
+# to read the merged result rather than this file alone.
+#
+# See also /llms.txt and /llms-full.txt (what this site is, for an
+# assistant to read and cite) and /ai.txt.
 
 User-agent: *
 Allow: /
@@ -17,21 +27,6 @@ Disallow: /admin
 Disallow: /onboarding
 Disallow: /reset-password
 Disallow: /invite/
-
-# Crawlers that train models on what they fetch, refused by name: Content-Signal
-# is a new, not-yet-universal convention, so the well-known bots that scrape for
-# training data get an explicit Disallow too.
-User-agent: GPTBot
-Disallow: /
-
-User-agent: CCBot
-Disallow: /
-
-User-agent: Google-Extended
-Disallow: /
-
-User-agent: Bytespider
-Disallow: /
 
 Sitemap: https://rdyrct.com/sitemap.xml
 Sitemap: https://rdyrct.com/blog/sitemap-index.xml

--- a/tests/e2e/production/seo.pw.ts
+++ b/tests/e2e/production/seo.pw.ts
@@ -62,6 +62,24 @@ test("robots.txt declares both sitemaps", async ({ request }) => {
   expect(robots).toContain("Sitemap: https://rdyrct.com/blog/sitemap-index.xml");
 });
 
+// What the live site serves is two sources merged: Cloudflare puts a managed
+// block above whatever the origin returns, carrying the content signals and
+// the AI training crawlers it refuses by name. This suite runs against a local
+// preview of the built worker, so it sees the origin half only. That half is
+// the part this repo owns and the part a bad edit here would break: the paths
+// that want no search traffic.
+//
+// The managed half is a switch in the Cloudflare dashboard with nothing in git
+// behind it. Checking it needs a request to the real hostname, which no suite
+// here makes.
+test("robots.txt keeps the private routes out of the index", async ({ request }) => {
+  const robots = await (await request.get("/robots.txt")).text();
+
+  for (const path of ["/api/", "/dashboard", "/admin", "/billing", "/settings"]) {
+    expect(robots).toContain(`Disallow: ${path}`);
+  }
+});
+
 test("a slug that resolves to nothing answers 404", async ({ request }) => {
   // Served under a 200 this is a soft 404: the shell's canonical points at the
   // landing page, so every mistyped or expired short link asked to be indexed

--- a/tests/e2e/production/seo.pw.ts
+++ b/tests/e2e/production/seo.pw.ts
@@ -75,7 +75,22 @@ test("robots.txt declares both sitemaps", async ({ request }) => {
 test("robots.txt keeps the private routes out of the index", async ({ request }) => {
   const robots = await (await request.get("/robots.txt")).text();
 
-  for (const path of ["/api/", "/dashboard", "/admin", "/billing", "/settings"]) {
+  // Every one of them, not a sample: a regression that drops a single line
+  // is exactly what this is here to catch.
+  for (const path of [
+    "/api/",
+    "/dashboard",
+    "/analytics",
+    "/links",
+    "/members",
+    "/billing",
+    "/domains",
+    "/settings",
+    "/admin",
+    "/onboarding",
+    "/reset-password",
+    "/invite/",
+  ]) {
     expect(robots).toContain(`Disallow: ${path}`);
   }
 });


### PR DESCRIPTION
`robots.txt` is two sources merged. Cloudflare puts a managed block above whatever the origin serves, and `public/robots.txt` is the rest. [Their docs](https://developers.cloudflare.com/bots/additional-configurations/managed-robots-txt/) describe the merge, and their worked example ends in the same shape ours does, so the origin's own `User-agent: *` group sitting below the managed one is the intended output rather than a misconfiguration. RFC 9309 section 2.2.1 merges groups that share a token, and Google's parser does, so the path rules apply.

That leaves our half redundant twice over:

- It listed `GPTBot`, `CCBot`, `Google-Extended` and `Bytespider`. Cloudflare's block already refuses all four, adds `Amazonbot`, `Applebot-Extended`, `ClaudeBot`, `meta-externalagent` and `CloudflareBrowserRenderingCrawler`, and keeps the list current as new crawlers appear.
- It set a second `Content-Signal` line saying what the managed block had already said.

Both were a copy that goes stale the week the list changes, with nothing to notice. What is left is the part only this repo knows: the paths that want no search traffic, and the two sitemaps.

Nothing about the served file changes for a crawler. The four bot rules and the content signal all still arrive, from Cloudflare instead of from us.

## On the test

The production suite runs against a local preview of the built worker, not the live hostname, so it only ever sees the origin half. The new test covers that half, which is the part a bad edit in this repo would break. The managed half is a switch in the zone's security settings with nothing in git behind it, and no suite here can reach it; the comment says so rather than implying coverage that does not exist.

Verified against the live site before and after: `curl https://rdyrct.com/robots.txt` returns the managed block, the content signal, the named crawlers, then our paths and sitemaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO**
  * Simplified `robots.txt` management while preserving private-route protections and sitemap declarations.
  * AI crawler policies are now managed through the site’s hosting configuration.

* **Tests**
  * Added end-to-end coverage confirming private routes remain excluded from search engine indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->