### PR TITLE
Guard the JSON-LD, and point the logo at the logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             "@id": "https://rdyrct.com/#organization",
             "name": "rdyrct",
             "url": "https://rdyrct.com",
-            "logo": "https://rdyrct.com/og.png",
+            "logo": "https://rdyrct.com/favicon.svg",
             "sameAs": ["https://github.com/baronunread/rdyrct"]
           },
           {

--- a/tests/jsonld.test.ts
+++ b/tests/jsonld.test.ts
@@ -1,0 +1,89 @@
+/**
+ * index.html carries one JSON-LD block, written by hand, and it is the only
+ * thing an answer engine reads to learn what this product costs. Two ways it
+ * goes wrong silently:
+ *
+ * A syntax slip makes the whole block unparseable, and nothing in the app
+ * notices: the browser ignores the tag, every page still renders, and the
+ * loss shows up as an absence somewhere nobody looks. The same goes for a
+ * dangling `@id` reference, which parses fine and describes a graph whose
+ * halves no longer connect.
+ *
+ * And the offer mirrors PLAN_PRICES in src/shared/types.ts, so raising a
+ * price leaves a stale number quoted here, in the one place built to be
+ * quoted back.
+ */
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import * as v from "valibot";
+import { PLAN_PRICES } from "../src/shared/types";
+
+/**
+ * A node keeps whatever else it declares (`looseObject`), because this suite
+ * is about the shape the graph hangs together by, not an inventory of every
+ * property schema.org allows on it.
+ */
+const Node = v.looseObject({
+  "@type": v.string(),
+  "@id": v.optional(v.string()),
+});
+
+const Document = v.object({
+  "@context": v.literal("https://schema.org"),
+  "@graph": v.array(Node),
+});
+
+/** What `publisher` and `isPartOf` hold: a pointer to another node, nothing else. */
+const Reference = v.object({ "@id": v.string() });
+
+const SoftwareApplication = v.looseObject({
+  offers: v.looseObject({
+    lowPrice: v.string(),
+    highPrice: v.string(),
+    priceCurrency: v.string(),
+  }),
+});
+
+/**
+ * Parsed, not asserted: an unparseable block or a node missing its `@type`
+ * fails here, before any test below reads a property off it.
+ */
+function graph() {
+  const html = readFileSync("index.html", "utf8");
+  const found = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g) ?? [];
+  expect(found.length, "index.html should carry exactly one JSON-LD block").toBe(1);
+
+  const json = found[0].replace(/^<script[^>]*>/, "").replace(/<\/script>$/, "");
+  return v.parse(Document, JSON.parse(json))["@graph"];
+}
+
+test("the block parses and every node declares a type", () => {
+  expect(graph().length).toBeGreaterThan(0);
+});
+
+test("every @id a node points at is a node in the same graph", () => {
+  const nodes = graph();
+  const declared = new Set(nodes.map((node) => node["@id"]).filter(Boolean));
+
+  for (const node of nodes) {
+    for (const [key, value] of Object.entries(node)) {
+      const reference = v.safeParse(Reference, value);
+      if (!reference.success) continue;
+      expect(declared, `${node["@type"]}.${key} points at a node that is not here`).toContain(
+        reference.output["@id"],
+      );
+    }
+  }
+});
+
+test("the quoted price is the price this app charges", () => {
+  const app = graph().find((node) => node["@type"] === "SoftwareApplication");
+  expect(app, "the graph should describe the app itself").toBeDefined();
+
+  const { offers } = v.parse(SoftwareApplication, app);
+  // PLAN_PRICES carries the currency symbol for display; schema.org wants the
+  // bare number beside priceCurrency.
+  expect(offers.highPrice).toBe(PLAN_PRICES.pro.replace("$", ""));
+  expect(offers.lowPrice, "the free plan is the bottom of the range").toBe("0");
+  expect(offers.priceCurrency).toBe("USD");
+});


### PR DESCRIPTION
An automated SEO scan claimed the structured data on rdyrct.com was invalid. It isn't. But chasing that turned up two things worth fixing.

## The JSON-LD had no test

`tests/e2e/production/seo.pw.ts` covers titles, canonicals, OG tags, robots.txt and the no-JS text, and never touches the `ld+json` block. That block is hand-written JSON in `index.html` and its failure mode is silent: a malformed tag is ignored by the browser, every page still renders, and the loss shows up as an absence in somebody else's index.

`tests/jsonld.test.ts` parses it with valibot (same as the worker does for untrusted input) and asserts:

- it parses, and every node declares a `@type`
- every `@id` a node references resolves to a node in the same graph
- `offers.highPrice` equals `PLAN_PRICES.pro`

That last one is the real catch. The block carries a comment saying it mirrors `PLAN_PRICES`, which means a price change leaves a stale number quoted in the one place built to be quoted back by answer engines.

Mutation-checked rather than trusted green: breaking `publisher`'s `@id` and bumping `highPrice` fails 2 of 3.

## Organization.logo pointed at the social card

`og.png` is a 1200x630 card with headline text on it. Google's logo guidance wants the mark, and SVG is a supported format, so it points at `favicon.svg` now. Unrelated to anything the scan reported.

## Not changed

The scan's other seven items are already implemented (HSTS and Permissions-Policy are set in `src/worker/security-headers.ts` and `public/_headers`, brotli is on, hashed assets are cached) or are artifacts of a cold single-shot measurement. Warm TTFB measures 83ms with ~46ms of that connect+TLS.

No e2e scenario: both changes are static-file assertions the unit test covers directly, and neither touches a request path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VfyPU1UrdK8joAUPAzByL