### PR TITLE
Give the public pages a main landmark, and stop asking who a stranger is

### DIFF
--- a/src/app/components/legal-page-layout.tsx
+++ b/src/app/components/legal-page-layout.tsx
@@ -27,9 +27,9 @@ export function LegalPageLayout({ children, authed }: { children: ReactNode; aut
   return (
     <div className="relative mx-auto min-h-dvh max-w-5xl px-6">
       <LandingHeader authed={authed} />
-      <div className="mx-auto max-w-3xl py-12">
+      <main className="mx-auto max-w-3xl py-12">
         <div className="flex flex-col gap-8 text-sm">{children}</div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/components/marketing-page.tsx
+++ b/src/app/components/marketing-page.tsx
@@ -41,12 +41,16 @@ export function MarketingPage({
         <div className="relative mx-auto min-h-dvh max-w-5xl px-6">
           <LandingHeader authed={authed} />
 
-          <div className="pt-14 pb-2 text-center sm:pt-20">
-            <h1 className="text-3xl font-bold tracking-tight text-balance sm:text-4xl">{title}</h1>
-            <p className="mx-auto mt-3 max-w-xl text-sm text-muted sm:text-base">{intro}</p>
-          </div>
+          <main>
+            <div className="pt-14 pb-2 text-center sm:pt-20">
+              <h1 className="text-3xl font-bold tracking-tight text-balance sm:text-4xl">
+                {title}
+              </h1>
+              <p className="mx-auto mt-3 max-w-xl text-sm text-muted sm:text-base">{intro}</p>
+            </div>
 
-          {children}
+            {children}
+          </main>
 
           <Footer />
         </div>

--- a/src/app/lib/audience.ts
+++ b/src/app/lib/audience.ts
@@ -11,8 +11,12 @@ import { readAuthHint } from "./user-cache";
  * header settles. Snapshotted once: mid-visit flips come from the query.
  */
 export function useAudience() {
-  const currentUser = useCurrentUser();
   const [authHint] = useState(readAuthHint);
+  // A browser that has never held a session has nothing to ask about: the
+  // query would 401 and land back on this same answer, having logged a page
+  // error on the way. Once it has been signed in the hint says so, the query
+  // runs, and an expired session corrects the header a round trip later.
+  const currentUser = useCurrentUser(authHint);
   const authed = currentUser.isPending ? authHint : !!currentUser.data;
   const cta = authed
     ? { ctaTo: "/dashboard", ctaLabel: "Open dashboard" }

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -28,9 +28,19 @@ import type {
   WithQuotaUsage,
 } from "@/shared/types";
 
-export function useCurrentUser() {
+/**
+ * `enabled: false` is for the marketing pages, which ask this only to choose
+ * between "Sign up" and "Open dashboard". A signed-out visitor has no session
+ * to find, and the 401 that came back was logged by the browser as a page
+ * error on every first visit to the landing page. Skipping the round trip for
+ * a browser that has never been signed in (see useAudience) costs that visitor
+ * nothing and saves them a request. Every caller that decides or submits
+ * anything leaves it enabled and waits for the real answer.
+ */
+export function useCurrentUser(enabled = true) {
   return useQuery<CurrentUser | null>({
     queryKey: ["user"],
+    enabled,
     queryFn: async () => {
       try {
         const user = await api<CurrentUser>("/user");

--- a/src/app/routes/landing.tsx
+++ b/src/app/routes/landing.tsx
@@ -28,8 +28,7 @@ import {
   useReducedMotion,
   type Variants,
 } from "motion/react";
-import { useEffect } from "react";
-import { useCurrentUser } from "../lib/hooks";
+import { lazy, Suspense, useEffect } from "react";
 import { useSeo } from "../lib/seo";
 import { useMarketingScroll } from "../lib/marketing-scroll";
 import { FaqJsonLd } from "../components/faq-json-ld";
@@ -46,7 +45,17 @@ import { HeroShortener } from "../components/hero-shortener";
 import { HeroSignedIn } from "../components/hero-signed-in";
 import { LandingHeader } from "../components/landing-header";
 import cloudflareLogo from "../assets/cloudflare.svg";
-import { LandingAnalyticsMock } from "../components/landing-analytics";
+/**
+ * The mock pulls in the whole charts bundle (Plot, the renderer, the scales),
+ * which is 118 KB the landing page was parsing before first paint to draw one
+ * decorative chart most of a screen below the fold. Lazy, so the entry chunk
+ * carries the page and the charts arrive alongside it instead of in front of
+ * it. AnalyticsPreviewSection reserves the space, so nothing moves when it
+ * lands.
+ */
+const LandingAnalyticsMock = lazy(() =>
+  import("../components/landing-analytics").then((m) => ({ default: m.LandingAnalyticsMock })),
+);
 import { formatNumber } from "../lib/numbers";
 import { cn } from "../ui/cn";
 
@@ -251,9 +260,15 @@ function NoCell({ tier }: { tier?: Tier }) {
  * `next`, so the intent survives OTP verification.
  */
 function usePaidPlanTo() {
-  const currentUser = useCurrentUser();
+  // Through useAudience rather than useCurrentUser directly: this asks the
+  // same question the header does ("is this a stranger?"), and asking it
+  // twice meant asking the server twice, once through the gate that skips the
+  // round trip for a browser that has never been signed in and once around
+  // it. It also reads better while the query is in flight, where `authed`
+  // falls back to what this browser was last time instead of "no".
+  const { authed } = useAudience();
   return (plan: "hobby" | "pro") =>
-    currentUser.data
+    authed
       ? `/billing?plan=${plan}`
       : `/signup?next=${encodeURIComponent(`/billing?plan=${plan}`)}`;
 }
@@ -1091,8 +1106,17 @@ function AnalyticsPreviewSection() {
           on sample data.
         </p>
       </div>
+      {/* The reserved box is the mock's own outer shell, so the swap changes
+          what is inside the card and never its footprint: no layout shift,
+          and something card-shaped to look at while the chunk lands. */}
       <div className="flex justify-center">
-        <LandingAnalyticsMock />
+        <Suspense
+          fallback={
+            <div className="h-[1140px] w-full max-w-4xl rounded-2xl bg-surface sm:h-[720px] smooth-shadow-ring-2xl" />
+          }
+        >
+          <LandingAnalyticsMock />
+        </Suspense>
       </div>
 
       {/* The only ask between the hero and the pricing table. On a phone this
@@ -1365,16 +1389,18 @@ export function LandingPage() {
           />
 
           <LandingHeader authed={authed} />
-          <HeroSection ctaTo={ctaTo} ctaLabel={ctaLabel} authed={authed} name={name} />
-          <CustomDomainSection />
-          <HowItWorksSection />
-          <AnalyticsPreviewSection />
-          <FeaturesSection />
-          <CloudflareSection />
-          <PricingTeaser />
-          <SelfHostSection />
-          <FaqSection />
-          <FinalCtaSection ctaTo={ctaTo} ctaLabel={ctaLabel} />
+          <main>
+            <HeroSection ctaTo={ctaTo} ctaLabel={ctaLabel} authed={authed} name={name} />
+            <CustomDomainSection />
+            <HowItWorksSection />
+            <AnalyticsPreviewSection />
+            <FeaturesSection />
+            <CloudflareSection />
+            <PricingTeaser />
+            <SelfHostSection />
+            <FaqSection />
+            <FinalCtaSection ctaTo={ctaTo} ctaLabel={ctaLabel} />
+          </main>
 
           <Footer />
         </div>

--- a/src/app/routes/qr-generator.tsx
+++ b/src/app/routes/qr-generator.tsx
@@ -236,7 +236,7 @@ export function QrGeneratorPage() {
     <div className="relative mx-auto min-h-dvh max-w-5xl px-6">
       <LandingHeader authed={authed} />
 
-      <section className="flex flex-col items-center gap-8 py-14 sm:py-20">
+      <main className="flex flex-col items-center gap-8 py-14 sm:py-20">
         <div className="flex max-w-2xl flex-col items-center gap-4 text-center">
           <h1 className="text-3xl font-bold tracking-tight text-balance sm:text-4xl">
             Free QR code generator
@@ -306,7 +306,7 @@ export function QrGeneratorPage() {
         <QrFaq />
 
         <OpenSourceNote />
-      </section>
+      </main>
 
       <Footer />
     </div>

--- a/tests/e2e/public-pages.pw.ts
+++ b/tests/e2e/public-pages.pw.ts
@@ -438,3 +438,48 @@ test("the app actually mounts, rather than leaving the crawler block on screen",
   // The crawler block is clipped to 1px and has no header; the app has one.
   await expect(page.locator("header").getByRole("link", { name: "Sign up" })).toBeVisible();
 });
+
+// Every page owes a screen-reader user one main landmark: it is what "skip to
+// content" skips to, and without it the only way past the header and its nav
+// is to walk them link by link, on every page, every visit. The app shell has
+// had one all along; the public pages, which are the ones strangers land on,
+// had none.
+//
+// Exactly one, not at least one: two mains is the same as none, since neither
+// is then "the content".
+test("every public page has one main landmark", async ({ page }) => {
+  for (const path of ["/", "/qr-code-generator", "/pricing", "/roadmap", "/privacy", "/terms"]) {
+    await page.goto(path);
+    // The header renders before the page chunk, so wait for the page itself.
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+    await expect(page.getByRole("main"), `main landmark on ${path}`).toHaveCount(1);
+  }
+});
+
+// A stranger has no session, so asking /user who they are could only ever come
+// back 401, and the browser logs every one of those as a page error. First
+// visit to the homepage, which is the visit that matters most, opened the
+// console on an error. The header still has to come out right, which is the
+// second half of this test: skipping the request must not make a signed-out
+// visitor look signed in.
+test("a first visit does not ask who it is", async ({ page }) => {
+  const userCalls: string[] = [];
+  page.on("request", (r) => {
+    if (new URL(r.url()).pathname === "/api/user") userCalls.push(r.url());
+  });
+
+  await page.goto("/");
+  await expect(page.locator("header").getByRole("link", { name: "Sign up" })).toBeVisible();
+  // The header paints before the rest of the page has even mounted, so
+  // asserting here caught nothing: the first version of this test passed
+  // against a build that still made the call. Every section has to have
+  // mounted, including the ones that ask this to decide where a CTA points,
+  // and the lazy analytics mock has to have landed.
+  await page
+    .getByRole("link", { name: /start pro/i })
+    .first()
+    .scrollIntoViewIfNeeded();
+  await page.waitForLoadState("networkidle");
+
+  expect(userCalls, "a browser that was never signed in has nothing to ask").toEqual([]);
+});


### PR DESCRIPTION
Three findings from a Lighthouse run on rdyrct.com (mobile). Verified by re-running Lighthouse against the built app.

| | before | after |
|---|---|---|
| Accessibility | 99 | **100** |
| Best practices | 96 | **100** |
| SEO | 100 | 100 |
| CLS | 0 | 0 |
| Total blocking time | 90ms | 60ms |

## No public page had a main landmark

`AppShell` has had one all along, so this only ever hit the pages strangers land on. Without it there is nothing for "skip to content" to skip to, and the only way past the header and its nav is link by link, on every page, every visit.

Landing, the QR generator, the `MarketingPage` shell (pricing, roadmap) and `LegalPageLayout` (privacy, terms) each wrap their content in `<main>` now. The header and footer stay outside it, so `banner` and `contentinfo` keep their landmark roles.

## Every first visit to the homepage logged a page error

`/user` 401s for a visitor with no session. That is correct, and the browser logs it as a page error regardless, so the console was open on an error for every first-time visitor.

Two hooks were asking, and both were asking the same question ("is this a stranger?") to pick a CTA. `useAudience` now skips the round trip when this browser has never held a session, and `usePaidPlanTo` goes through `useAudience` rather than around it, so the gate lives in one place.

A browser that has been signed in still asks, and an expired session still corrects the header a round trip later. Nothing that decides or submits anything changed: `useCurrentUser` defaults to enabled.

## The landing page parsed 118 KB of charts before first paint

`LandingAnalyticsMock` pulls in the whole charts bundle to draw one decorative chart most of a screen below the fold. It is lazy now, behind a placeholder the same size as the mock. Confirmed in the build output: `charts-*.js` moved from a static import in the landing chunk to a dynamic dependency.

CLS stays 0, which was the risk worth checking.

## Not fixed

The render-blocking stylesheet (11.5 KB, ~300ms estimated). Inlining it needs a build plugin, and the ones that do this want to own the CSP, which the Worker sets per response. Not worth that trade for one same-origin file that caches for a day.

## Tests

Two e2e scenarios in `tests/e2e/public-pages.pw.ts`: one main landmark on each of the six public pages, and no `/api/user` call on a first visit. The second one caught a real miss: the first version asserted too early and passed against a build that still made the call, which is how `usePaidPlanTo` was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VfyPU1UrdK8joAUPAzByL