### PR TITLE
One anonymous link, and let it arrive

### DIFF
--- a/src/app/components/hero-shortener.tsx
+++ b/src/app/components/hero-shortener.tsx
@@ -6,17 +6,11 @@
  * link, get a real short URL back, and only then decide whether an account is
  * worth it.
  *
- * The form never swaps out. Results open underneath it and stack, newest
- * first, so the link you just made is always directly under the button you
- * pressed and a link already on screen never changes again. There is no
- * "shorten another" control: the input stays filled, the button stays live,
- * and typing a new address is the whole gesture.
+ * The form never swaps out. One link opens underneath it, directly under the
+ * button that was pressed, and that is the ceiling without an account: the
+ * second link is the point where trying it becomes signing up.
  *
- * How tall this can get is bounded by the rate limit rather than by taste:
- * RL_ANON_LINK allows five links a minute from one address, so the realistic
- * worst case is a handful of rows.
- *
- * The links last 24 hours. Signing up keeps them: each claim token goes to
+ * The link lasts 24 hours. Signing up keeps it: the claim token goes to
  * localStorage and the app spends it once the new account has an org, so the
  * first dashboard is not empty (#65).
  */
@@ -57,7 +51,10 @@ function MadeLink({ link }: { link: StoredAnonLink }) {
     // under the link rather than under the code: attached to the QR they
     // made that column more than twice the height of this one, and the hole
     // left beside it wanted filler nobody needed.
-    <div className="grid grid-cols-[1fr_auto] items-start gap-3 border-t border-dashed border-border pt-3">
+    // The link arrives rather than appearing: it is the answer to the button
+    // that was just pressed, a few hundred milliseconds after it, and a card
+    // that pops into the layout reads as a jump rather than as a result.
+    <div className="anon-link-in grid grid-cols-[1fr_auto] items-start gap-3 border-t border-dashed border-border pt-3">
       <div className="flex min-w-0 flex-col gap-1.5">
         <div className="flex min-w-0 items-center gap-2 rounded-lg bg-surface-2 px-3 py-2.5">
           <a
@@ -92,54 +89,42 @@ function MadeLink({ link }: { link: StoredAnonLink }) {
   );
 }
 
-/** Written out per case rather than assembled from fragments: a sentence
- * stitched together from four inline conditionals is unreadable in source
- * and easy to break in one of its halves. */
-function keepCopy(count: number) {
-  if (count === 1)
-    return {
-      body: "This link works for 24 hours. Sign up and it becomes yours permanently, and starts counting every click: country, referrer, device, campaign.",
-      action: "Keep this link",
-    };
-  return {
-    body: `These ${count} links work for 24 hours. Sign up and they become yours permanently, and start counting every click: country, referrer, device, campaign.`,
-    action: "Keep them",
-  };
-}
-
-/** One ask for all of them: repeating it per row would turn a useful card
- * into a nag, and "keep these 3 links" is a better ask than three separate
- * "keep this link". */
-function KeepThemFooter({ count }: { count: number }) {
-  const copy = keepCopy(count);
+/** The ask, once, under the link it is about. */
+function KeepItFooter() {
   return (
-    <div className="flex flex-wrap items-center gap-2 border-t border-border pt-3">
-      <p className="min-w-52 flex-1 text-xs text-muted">{copy.body}</p>
+    // A beat behind the link itself, so the eye lands on the short URL first
+    // and the ask arrives after it.
+    <div className="anon-link-in flex flex-wrap items-center gap-2 border-t border-border pt-3 [animation-delay:70ms]">
+      <p className="min-w-52 flex-1 text-xs text-muted">
+        This link works for 24 hours. Sign up and it becomes yours permanently, and starts counting
+        every click: country, referrer, device, campaign.
+      </p>
       <a
         href="/signup"
         onClick={() => trackCta("hero_shortener_claim")}
         className={buttonClass({ variant: "primary", size: "sm" })}
       >
-        {copy.action} <ArrowRight size={14} />
+        Keep this link <ArrowRight size={14} />
       </a>
     </div>
   );
 }
 
-/** The stack, or the reassurance that stands in for it before there is one. */
+/** The link, or the reassurance that stands in for it before there is one. */
 function MadeLinks({ made }: { made: StoredAnonLink[] }) {
-  if (made.length === 0)
+  const link = made[0];
+  if (!link)
     return (
       <p className="text-xs text-muted">
-        No account, no email. Links last 24 hours. Sign up to keep them and start counting clicks.
+        No account, no email. The link lasts 24 hours. Sign up to keep it and start counting clicks.
       </p>
     );
   return (
     <>
-      {made.map((link) => (
-        <MadeLink key={link.slug} link={link} />
-      ))}
-      <KeepThemFooter count={made.length} />
+      {/* Keyed by slug so a new link is a new element: the animation runs on
+          mount, and a re-render for anything else does not replay it. */}
+      <MadeLink key={link.slug} link={link} />
+      <KeepItFooter />
     </>
   );
 }
@@ -150,7 +135,7 @@ export function HeroShortener() {
   const [destination, setDestination] = useState("");
   const [busy, setBusy] = useState(false);
   // Seeded from storage, so a reload keeps what this browser already made
-  // rather than presenting an empty form to somebody who has three links.
+  // rather than presenting an empty form to somebody who has a link.
   const [made, setMade] = useState<StoredAnonLink[]>(storedAnonLinks);
   const atCap = made.length >= MAX_ANON_LINKS;
   // One reason the button is dead, so the guard and the disabled state can
@@ -215,7 +200,7 @@ export function HeroShortener() {
           it out. The footer below already carries the way forward. */}
       {atCap && (
         <p className="text-xs text-muted">
-          That is {MAX_ANON_LINKS} links, the most this browser can make without an account.
+          That is one link, the most this browser can make without an account.
         </p>
       )}
 

--- a/src/app/lib/anon-links.ts
+++ b/src/app/lib/anon-links.ts
@@ -31,10 +31,11 @@ const KEY = "rdyrct:anon-links:v3";
  *
  * A product limit, not a security one: abuse is already handled by the Cap
  * proof-of-work and RL_ANON_LINK, both of which a browser cannot talk its
- * way past. This is the point where trying it becomes signing up. It frees
- * up as links expire, and claiming at signup clears it entirely.
+ * way past. One link is enough to show that shortening works, and the second
+ * one is where trying it becomes signing up. It frees up as the link expires,
+ * and claiming at signup clears it entirely.
  */
-export const MAX_ANON_LINKS = 3;
+export const MAX_ANON_LINKS = 1;
 
 const storedAnonLinkSchema = v.object({
   slug: v.string(),
@@ -77,7 +78,10 @@ export function storedAnonLinks(): StoredAnonLink[] {
     const parsed = v.safeParse(storedListSchema, JSON.parse(raw));
     if (!parsed.success) return [];
     const now = Date.now();
-    return parsed.output.filter((link) => link.expiresAt > now);
+    // Sliced on the way out as well as on the way in: a browser that made
+    // three links before the cap became one still holds all three, and the
+    // hero must not show more than it now lets anyone make.
+    return parsed.output.filter((link) => link.expiresAt > now).slice(0, MAX_ANON_LINKS);
   } catch {
     return [];
   }

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -324,11 +324,7 @@ function useClaimAnonLinks(orgId: string | undefined) {
       // The one moment in the app worth sounding pleased about: they made
       // something before they had an account, and it survived. A sentence
       // that reads like a receipt wastes it.
-      toast(
-        kept === 1
-          ? "Welcome. Your link is already here."
-          : `Welcome. All ${kept} links are already here.`,
-      );
+      toast("Welcome. Your link is already here.");
     })();
   }, [orgId, qc, toast]);
 }

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -408,6 +408,26 @@ body {
   }
 }
 
+/* The hero's anonymous link, arriving. It answers a button somebody pressed
+   a moment earlier, so it rises into place instead of replacing empty space
+   in one frame. Short and once: nothing here loops or waits on scroll. */
+.anon-link-in {
+  animation: anon-link-in 220ms ease-out both;
+}
+
+@keyframes anon-link-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .anon-link-in {
+    animation: none;
+  }
+}
+
 /* skeleton blocks hold a static shade instead of pulsing */
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse {

--- a/tests/anon-links.test.ts
+++ b/tests/anon-links.test.ts
@@ -12,11 +12,12 @@ import {
  *
  * Worth testing directly because every one of its failure modes is silent:
  * an expired link renders as a URL that 404s, a lost claim token turns
- * "keep these 3 links" into a lie, and junk under our key would otherwise
- * decide what requests signup makes.
+ * "keep this link" into a lie, and junk under our key would otherwise decide
+ * what requests signup makes.
  */
 
 const HOUR = 60 * 60 * 1000;
+const KEY = "rdyrct:anon-links:v3";
 
 /** The two methods this module touches, and nothing else. */
 function fakeStorage() {
@@ -62,10 +63,10 @@ describe("keeping links across a reload", () => {
     ]);
   });
 
-  test("keeps the newest first, matching the order the hero shows", () => {
+  test("keeps the newest, which is the one the hero shows", () => {
     rememberAnonLink(link("first0"), "https://example.com/1");
     rememberAnonLink(link("second"), "https://example.com/2");
-    expect(storedAnonLinks().map((l) => l.slug)).toEqual(["second", "first0"]);
+    expect(storedAnonLinks().map((l) => l.slug)).toEqual(["second"]);
   });
 
   test("does not store the same link twice if it is remembered again", () => {
@@ -82,8 +83,30 @@ describe("the cap", () => {
     }
     const kept = storedAnonLinks();
     expect(kept).toHaveLength(MAX_ANON_LINKS);
-    // The most recent survive; the first two are gone.
-    expect(kept.map((l) => l.slug)).toEqual(["slug4", "slug3", "slug2"]);
+    // The most recent survive, newest first; the oldest two are gone.
+    const newest = Array.from(
+      { length: MAX_ANON_LINKS },
+      (_, i) => `slug${MAX_ANON_LINKS + 1 - i}`,
+    );
+    expect(kept.map((l) => l.slug)).toEqual(newest);
+  });
+
+  test("shows only the cap, even if this browser stored more before", () => {
+    // The cap used to be three. A browser that filled it must not keep
+    // rendering three links the form no longer lets anyone make.
+    store.set(
+      KEY,
+      JSON.stringify(
+        ["old000", "old111", "old222"].map((slug) => ({
+          slug,
+          url: `https://rdyrct.com/${slug}`,
+          source: "https://example.com",
+          claimToken: `tok-${slug}`,
+          expiresAt: Date.now() + HOUR,
+        })),
+      ),
+    );
+    expect(storedAnonLinks()).toHaveLength(MAX_ANON_LINKS);
   });
 });
 
@@ -105,8 +128,6 @@ describe("expiry", () => {
 });
 
 describe("junk under our key", () => {
-  const KEY = "rdyrct:anon-links:v3";
-
   test("discards anything that is not an array", () => {
     for (const junk of ['{"slug":"x"}', '"a string"', "42", "not json at all"]) {
       store.set(KEY, junk);

--- a/tests/anon-links.test.ts
+++ b/tests/anon-links.test.ts
@@ -106,7 +106,11 @@ describe("the cap", () => {
         })),
       ),
     );
-    expect(storedAnonLinks()).toHaveLength(MAX_ANON_LINKS);
+    // The front of the stored list is the newest, so that is what survives:
+    // keeping the oldest would show a link hours closer to expiring.
+    expect(storedAnonLinks().map((l) => l.slug)).toEqual(
+      ["old000", "old111", "old222"].slice(0, MAX_ANON_LINKS),
+    );
   });
 });
 

--- a/tests/e2e/anon-shortener.pw.ts
+++ b/tests/e2e/anon-shortener.pw.ts
@@ -92,48 +92,6 @@ test("signing up keeps the link that was made before the account (#65)", async (
   expect(Number(anon[0].n)).toBe(0);
 });
 
-/**
- * The footer says "keep these 2 links", so signup has to keep both. An
- * earlier version stored one claim token and overwrote it, which made that
- * copy a promise about the most recent link only.
- */
-test("signing up keeps every link made before the account, not just the last", async ({ page }) => {
-  const first = `https://example.com/multi-a-${Date.now()}`;
-  const second = `https://example.com/multi-b-${Date.now()}`;
-
-  const firstSlug = (await shorten(page, first)).split("/").pop()!;
-  const field = page.getByLabel("Shorten a link, no account needed");
-  await field.fill(second);
-  await page.getByRole("button", { name: "Shorten it" }).click();
-  await expect(page.getByRole("link", { name: "Your short link" })).toHaveCount(2, {
-    timeout: 20_000,
-  });
-  const secondSlug = (await page
-    .getByRole("link", { name: "Your short link" })
-    .first()
-    .getAttribute("href"))!
-    .split("/")
-    .pop()!;
-
-  await signUpAndVerify(page, `multi-${Date.now()}@gmail.com`, password);
-
-  for (const slug of [firstSlug, secondSlug]) {
-    await expect
-      .poll(
-        async () => {
-          const rows = await queryRows<{ n: number }>(
-            page,
-            "select count(*) as n from links where slug = ?",
-            [slug],
-          );
-          return Number(rows[0].n);
-        },
-        { message: `link ${slug} should have been claimed`, timeout: 15_000 },
-      )
-      .toBe(1);
-  }
-});
-
 test("a destination that is not a web address is refused, in a toast", async ({ page }) => {
   // "not-a-web-address" has no dot, so it survives the scheme-less
   // normalisation the signed-in quick-create also does and then fails the
@@ -159,42 +117,20 @@ test("the shortener refuses a request with no proof of work", async ({ page }) =
   expect(await response.text()).toContain("human");
 });
 
-/**
- * The form never swaps out, and links accumulate. This is the layout
- * decision the hero was rebuilt around: a link already on screen must never
- * change or disappear because somebody made another one.
- */
-test("shortening again keeps the first link and stacks the new one on top", async ({ page }) => {
-  const first = `https://example.com/first-${Date.now()}`;
-  const second = `https://example.com/second-${Date.now()}`;
-
-  const firstUrl = await shorten(page, first);
-
-  // The form is still a form: filled, live, and in the same place. No
-  // "shorten another" button to press first.
+/** The result is an answer to a button somebody pressed, so it arrives
+ * instead of appearing. Asserted as the animation the card carries, which is
+ * the part a stylesheet edit can drop by accident. */
+test("the link animates in rather than appearing at once", async ({ page }) => {
+  await page.goto("/");
   const field = page.getByLabel("Shorten a link, no account needed");
-  await expect(field).toBeVisible();
-  await field.fill(second);
+  await field.fill(`https://example.com/animated-${Date.now()}`);
   await page.getByRole("button", { name: "Shorten it" }).click();
 
-  const links = page.getByRole("link", { name: "Your short link" });
-  await expect(links).toHaveCount(2, { timeout: 20_000 });
+  const link = page.getByRole("link", { name: "Your short link" });
+  await expect(link).toBeVisible({ timeout: 20_000 });
 
-  // Newest first, and the earlier one is still there and unchanged.
-  const hrefs = await links.evaluateAll<string[], HTMLAnchorElement>((nodes) =>
-    nodes.map((n) => n.href),
-  );
-  expect(hrefs[1]).toBe(firstUrl);
-  expect(hrefs[0]).not.toBe(firstUrl);
-
-  // Each row says which address it came from, which is the question that
-  // appears as soon as there is more than one.
-  await expect(page.getByText(`from ${first}`)).toBeVisible();
-  await expect(page.getByText(`from ${second}`)).toBeVisible();
-
-  // One ask for both, counting them, rather than one per row.
-  await expect(page.getByRole("link", { name: "Keep them" })).toHaveCount(1);
-  await expect(page.getByText(/These 2 links work for 24 hours/)).toBeVisible();
+  const card = page.locator(".anon-link-in").first();
+  await expect(card).toHaveCSS("animation-name", "anon-link-in");
 });
 
 test("links survive a reload, so leaving the page does not lose them", async ({ page }) => {
@@ -228,30 +164,26 @@ test("links survive a reload, so leaving the page does not lose them", async ({ 
     .toBe(1);
 });
 
-test("three links is the ceiling without an account", async ({ page }) => {
-  await page.goto("/");
-  const field = page.getByLabel("Shorten a link, no account needed");
-  const button = page.getByRole("button", { name: "Shorten it" });
-
-  for (let i = 0; i < 3; i++) {
-    await field.fill(`https://example.com/cap-${Date.now()}-${i}`);
-    await button.click();
-    await expect(page.getByRole("link", { name: "Your short link" })).toHaveCount(i + 1, {
-      timeout: 20_000,
-    });
-  }
+test("one link is the ceiling without an account", async ({ page }) => {
+  const destination = `https://example.com/cap-${Date.now()}`;
+  await shorten(page, destination);
 
   // The button goes dead and says why, rather than failing on submit.
+  const button = page.getByRole("button", { name: "Shorten it" });
   await expect(button).toBeDisabled();
   await expect(page.getByText(/most this browser can make without an account/i)).toBeVisible();
 
+  // One ask, under the one link.
+  await expect(page.getByRole("link", { name: "Keep this link" })).toHaveCount(1);
+  await expect(page.getByText(`from ${destination}`)).toBeVisible();
+
   // The ceiling holds across a reload: it is stored, not just in memory.
   await page.reload();
-  await expect(page.getByRole("link", { name: "Your short link" })).toHaveCount(3);
+  await expect(page.getByRole("link", { name: "Your short link" })).toHaveCount(1);
   await expect(page.getByRole("button", { name: "Shorten it" })).toBeDisabled();
 });
 
-test("each stacked link can still download its own QR", async ({ page }) => {
+test("the link can still download its own QR", async ({ page }) => {
   // The download buttons sit under the link rather than under the code, so
   // this checks the move did not detach them from the QR they belong to.
   const destination = `https://example.com/qr-dl-${Date.now()}`;


### PR DESCRIPTION
The hero handed out three anonymous links before it asked for anything. Two of them were never the point: the first link already proves shortening works, and the second is where trying it should turn into signing up.

- `MAX_ANON_LINKS` is 1, and every plural sentence that counted links is gone: `keepCopy`/`KeepThemFooter` collapse into one `KeepItFooter` ("Keep this link"), the cap line reads "That is one link, the most this browser can make without an account", and the claim toast in `shell.tsx` loses its count branch.
- `storedAnonLinks()` slices on the way out as well as on the way in. A browser that filled the old cap still holds three records, and the hero must not render links the form no longer lets anyone make.
- The result stops appearing in one frame. `.anon-link-in` rises and fades it in over 220ms, with the signup ask a beat behind it (70ms), and `animation: none` under `prefers-reduced-motion`. The card is keyed by slug, so the animation replays for a new link and not for any other re-render.

## Tests

- Unit cap tests now derive their expectations from `MAX_ANON_LINKS` instead of hard-coded threes, plus a new case for a browser holding more than the cap from before.
- e2e: the stacking spec and "three links is the ceiling" are replaced by "one link is the ceiling", and a new spec asserts the result card carries the animation.
- `bun run verify` green; `bunx playwright test tests/e2e/anon-shortener.pw.ts` 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VfyPU1UrdK8joAUPAzByL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Anonymous visitors now retain only their newest link.
  - Added a smooth entrance animation for newly created links, with reduced-motion support.
  - Updated messaging to explain single-link retention and 24-hour availability.

- **Bug Fixes**
  - Older stored links are automatically removed when limits are enforced.
  - Signup and claim messaging now consistently reflects the single-link experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->