### PR TITLE
Delete spent invites, name the routes honestly, point at llms.txt

### DIFF
--- a/migrations/0023_drop_invites_accepted_by.sql
+++ b/migrations/0023_drop_invites_accepted_by.sql
@@ -1,0 +1,5 @@
+-- #103: an accepted invite is deleted now, so the column that marked one
+-- has nothing left to mark. Existing accepted rows go with it: nothing reads
+-- invite history, and every reader filtered them back out.
+delete from invites where accepted_by is not null;
+alter table invites drop column accepted_by;

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -256,30 +256,26 @@ export function useAddressMutations(orgId: string, linkId: string) {
     qc.invalidateQueries({ queryKey: ["linkStats", orgId] });
     applyQuotaUsage(qc, orgId, quota);
   };
+  const address = (addressId: string) => `/orgs/${orgId}/links/${linkId}/addresses/${addressId}`;
   const keepForever = useMutation({
     mutationFn: (addressId: string) =>
-      api<WithQuotaUsage<{ ok: true }>>(
-        `/orgs/${orgId}/links/${linkId}/addresses/${addressId}/keep-forever`,
-        { method: "POST" },
-      ),
+      api<WithQuotaUsage<{ ok: true }>>(address(addressId), {
+        method: "PATCH",
+        body: { kind: "permanent" },
+      }),
     onSuccess: invalidate,
   });
   const remove = useMutation({
     mutationFn: (addressId: string) =>
-      api<WithQuotaUsage<{ ok: true }>>(
-        `/orgs/${orgId}/links/${linkId}/addresses/${addressId}/remove`,
-        { method: "POST", body: { confirm: true } },
-      ),
+      api<WithQuotaUsage<{ ok: true }>>(address(addressId), { method: "DELETE" }),
     onSuccess: invalidate,
   });
   const promote = useMutation({
     mutationFn: (addressId: string) =>
-      api<WithQuotaUsage<LinkDTO>>(
-        `/orgs/${orgId}/links/${linkId}/addresses/${addressId}/promote`,
-        {
-          method: "POST",
-        },
-      ),
+      api<WithQuotaUsage<LinkDTO>>(address(addressId), {
+        method: "PATCH",
+        body: { kind: "primary" },
+      }),
     onSuccess: invalidate,
   });
   const create = useMutation({
@@ -339,11 +335,11 @@ export function useDomainMutations(orgId: string) {
       }),
     onSuccess: invalidate,
   });
+  // A read, triggered by a button: re-checking a domain only re-reads what the
+  // activation workflow last wrote (#104). It lives here rather than in a
+  // query because nothing polls it, somebody asks for it.
   const refresh = useMutation({
-    mutationFn: (id: string) =>
-      api<DomainDTO>(`/orgs/${orgId}/domains/${id}/refresh`, {
-        method: "POST",
-      }),
+    mutationFn: (id: string) => api<DomainDTO>(`/orgs/${orgId}/domains/${id}`),
     onSuccess: invalidate,
   });
   const setRootRedirect = useMutation({
@@ -386,7 +382,7 @@ export function useCheckout() {
 export function usePortal() {
   // react-doctor-disable-next-line react-doctor/query-mutation-missing-invalidation
   return useMutation({
-    mutationFn: () => api<{ url: string }>(`/billing/portal`),
+    mutationFn: () => api<{ url: string }>(`/billing/portal`, { method: "POST" }),
   });
 }
 
@@ -439,7 +435,7 @@ export const useAdminAnonLinks = () =>
 export const useAdminAudit = () =>
   useQuery<AdminActionRow[]>({
     queryKey: ["admin", "audit"],
-    queryFn: () => api("/admin/links/audit"),
+    queryFn: () => api("/admin/audit"),
   });
 
 export const useAdminUsers = () =>

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -170,9 +170,9 @@ function SuspendDialog({ link, onClose }: { link: AdminLinkRow | null; onClose: 
 
   const suspend = useMutation({
     mutationFn: (input: { id: string; reason: string }) =>
-      api(`/admin/links/${input.id}/suspend`, {
-        method: "POST",
-        body: { reason: input.reason },
+      api(`/admin/links/${input.id}`, {
+        method: "PATCH",
+        body: { suspended: true, reason: input.reason },
       }),
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ["admin", "links"] });
@@ -579,7 +579,8 @@ function useOwnedLinkActions(onRestored: () => void, onDeleted: () => void) {
   };
 
   const restore = useMutation({
-    mutationFn: (id: string) => api(`/admin/links/${id}/unsuspend`, { method: "POST" }),
+    mutationFn: (id: string) =>
+      api(`/admin/links/${id}`, { method: "PATCH", body: { suspended: false } }),
     onSuccess: async () => {
       await refresh();
       toast("Link restored.");

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -179,9 +179,6 @@ export const invites = sqliteTable(
     }),
     createdAt: integer("created_at").notNull(),
     expiresAt: integer("expires_at").notNull(),
-    acceptedBy: text("accepted_by").references(() => user.id, {
-      onDelete: "set null",
-    }),
   },
   (t) => [index("idx_invites_org").on(t.orgId)],
 );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -11,7 +11,7 @@ import { withSession } from "./session";
 import { getAuth } from "./better-auth";
 import { withBackground } from "./background";
 import { userRoutes } from "./routes/auth";
-import { orgRoutes, inviteRoutes } from "./routes/orgs";
+import { orgRoutes, inviteRoutes, sweepExpiredInvites } from "./routes/orgs";
 import { linkRoutes } from "./routes/links";
 import { qrLogoRoutes } from "./routes/qr-logos";
 import { adminRoutes } from "./routes/admin";
@@ -378,7 +378,7 @@ const wrapped = Sentry.withSentry<Env, StorageMessage | ClickMessage>(
       // Daily: drop invites nobody opened before they expired (#103). An
       // accepted one is already deleted at accept time; this clears the rest,
       // so no token and no invited address outlives the week it was good for.
-      await env.DB.prepare(`delete from invites where expires_at < ?`).bind(Date.now()).run();
+      await sweepExpiredInvites(env);
 
       // Daily: drop anonymous links nobody claimed inside their 24 hours, and
       // the KV keys they were resolving through (Direction A of #96).

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -375,6 +375,11 @@ const wrapped = Sentry.withSentry<Env, StorageMessage | ClickMessage>(
       // redirect path already stopped resolving them; this frees their slugs.
       await sweepExpiredAliases(env, drizzle(env.DB, { schema }));
 
+      // Daily: drop invites nobody opened before they expired (#103). An
+      // accepted one is already deleted at accept time; this clears the rest,
+      // so no token and no invited address outlives the week it was good for.
+      await env.DB.prepare(`delete from invites where expires_at < ?`).bind(Date.now()).run();
+
       // Daily: drop anonymous links nobody claimed inside their 24 hours, and
       // the KV keys they were resolving through (Direction A of #96).
       await sweepExpiredAnonLinks(env);

--- a/src/worker/page-meta.ts
+++ b/src/worker/page-meta.ts
@@ -48,6 +48,17 @@ class Text {
 }
 
 /**
+ * What machine-readable description this page has, pointed at from the
+ * response itself (RFC 8288) rather than left for an agent to guess at.
+ *
+ * `describedby` and `/llms.txt` only: that file exists and says what the site
+ * is. `api-catalog` and `service-desc` belong here too, and go in when the
+ * documents they name exist (#133, #136). A Link header that points at a 404
+ * is worse than no header.
+ */
+const LINK_HEADER = '</llms.txt>; rel="describedby"; type="text/plain"';
+
+/**
  * Rewrites the head of an HTML response for `path`, or returns it untouched
  * when the path is not a page we describe.
  *
@@ -60,6 +71,8 @@ export function withPageMeta(response: Response, url: URL): Response {
   if (!response.headers.get("content-type")?.includes("text/html")) return response;
 
   const canonical = canonicalFor(url, url.pathname);
+  const described = new Response(response.body, response);
+  described.headers.set("Link", LINK_HEADER);
   return new HTMLRewriter()
     .on("title", new Text(meta.title))
     .on('meta[name="description"]', new MetaContent(meta.description))
@@ -69,5 +82,5 @@ export function withPageMeta(response: Response, url: URL): Response {
     .on('meta[name="twitter:title"]', new MetaContent(meta.title))
     .on('meta[name="twitter:description"]', new MetaContent(meta.description))
     .on('link[rel="canonical"]', new Href(canonical))
-    .transform(response);
+    .transform(described);
 }

--- a/src/worker/routes/admin-links.ts
+++ b/src/worker/routes/admin-links.ts
@@ -17,7 +17,7 @@
 import { Hono, type Context } from "hono";
 import { oneOf } from "../../shared/lookup";
 import type { JsonValue } from "../../shared/types";
-import { optionalText, parseOptionalBody } from "../schemas";
+import { optionalFlag, optionalText, parseOptionalBody } from "../schemas";
 import * as v from "valibot";
 import { HTTPException } from "hono/http-exception";
 import { and, desc, eq, isNull, isNotNull, like, or, sql } from "drizzle-orm";
@@ -29,7 +29,6 @@ import { scoreDestination } from "../risk";
 import { jsonBodyLimit } from "../body-limit";
 import {
   ADMIN_LINK_SORTS,
-  type AdminActionRow,
   type AdminAnonLinkRow,
   type AdminLinkRow,
   type AdminLinkSort,
@@ -44,6 +43,9 @@ const reasonsSchema = v.fallback(v.array(v.string()), []);
 
 /** The reason a moderation action carries. */
 const reasonBodySchema = v.object({ reason: optionalText });
+
+/** The same, plus which way the state change goes. */
+const suspensionBodySchema = v.object({ reason: optionalText, suspended: optionalFlag });
 
 const MAX_ROWS = 200;
 
@@ -68,11 +70,15 @@ function suspensionPatch(suspend: boolean, actorId: string, reason: string | nul
 
 /** The reason a moderation action must carry. Suspending without one leaves
  * a decision nobody can account for later. */
-async function requiredReason(c: Context<AppEnv>, required: boolean): Promise<string> {
-  const body = parseOptionalBody(reasonBodySchema, await c.req.json<JsonValue>().catch(() => ({})));
-  const reason = body.reason.trim().slice(0, 500);
+function checkReason(raw: string, required: boolean): string {
+  const reason = raw.trim().slice(0, 500);
   if (required && !reason) throw new HTTPException(400, { message: "A reason is required" });
   return reason;
+}
+
+async function requiredReason(c: Context<AppEnv>, required: boolean): Promise<string> {
+  const body = parseOptionalBody(reasonBodySchema, await c.req.json<JsonValue>().catch(() => ({})));
+  return checkReason(body.reason, required);
 }
 
 const clickCount = sql<number>`(
@@ -258,13 +264,22 @@ async function setSuspended(
   return { addresses };
 }
 
-adminLinkRoutes.post("/:linkId/suspend", async (c) =>
-  c.json(await setSuspended(c, c.req.param("linkId")!, true, await requiredReason(c, true))),
-);
-
-adminLinkRoutes.post("/:linkId/unsuspend", async (c) =>
-  c.json(await setSuspended(c, c.req.param("linkId")!, false, null)),
-);
+/**
+ * Suspend or restore one link.
+ *
+ * One state change, so one endpoint (#104): `{ suspended }` says which way,
+ * and a reason is required to suspend but meaningless to undo.
+ */
+adminLinkRoutes.patch("/:linkId", async (c) => {
+  const body = parseOptionalBody(
+    suspensionBodySchema,
+    await c.req.json<JsonValue>().catch(() => ({})),
+  );
+  if (body.suspended == null)
+    throw new HTTPException(400, { message: "suspended must be true or false" });
+  const reason = body.suspended ? checkReason(body.reason, true) : null;
+  return c.json(await setSuspended(c, c.req.param("linkId")!, body.suspended, reason));
+});
 
 /**
  * Re-run the destination check on demand (#68).
@@ -445,37 +460,4 @@ adminLinkRoutes.delete("/anonymous/:id", async (c) => {
     detail: { slug: anon.slug, destination: anon.destination },
   });
   return c.json({ ok: true });
-});
-
-/** The audit log, newest first, optionally narrowed to one target. */
-adminLinkRoutes.get("/audit", async (c) => {
-  const db = c.var.db;
-  const targetType = c.req.query("targetType");
-  const targetId = c.req.query("targetId");
-  const rows = await db
-    .select({
-      id: schema.adminActions.id,
-      actorUserId: schema.adminActions.actorUserId,
-      actorEmail: schema.user.email,
-      action: schema.adminActions.action,
-      targetType: schema.adminActions.targetType,
-      targetId: schema.adminActions.targetId,
-      detail: schema.adminActions.detail,
-      createdAt: schema.adminActions.createdAt,
-    })
-    .from(schema.adminActions)
-    // Left join: the actor may have been deleted since, and the entry has to
-    // outlive them. That is why the table holds no foreign key.
-    .leftJoin(schema.user, eq(schema.user.id, schema.adminActions.actorUserId))
-    .where(
-      targetType && targetId
-        ? and(
-            eq(schema.adminActions.targetType, targetType),
-            eq(schema.adminActions.targetId, targetId),
-          )
-        : undefined,
-    )
-    .orderBy(desc(schema.adminActions.createdAt))
-    .limit(MAX_ROWS);
-  return c.json(rows satisfies AdminActionRow[]);
 });

--- a/src/worker/routes/admin-links.ts
+++ b/src/worker/routes/admin-links.ts
@@ -276,7 +276,7 @@ adminLinkRoutes.patch("/:linkId", async (c) => {
     await c.req.json<JsonValue>().catch(() => ({})),
   );
   if (body.suspended == null)
-    throw new HTTPException(400, { message: "suspended must be true or false" });
+    throw new HTTPException(400, { message: "Say whether to suspend or restore this link" });
   const reason = body.suspended ? checkReason(body.reason, true) : null;
   return c.json(await setSuspended(c, c.req.param("linkId")!, body.suspended, reason));
 });

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -14,6 +14,7 @@ import {
   type AdminOrgRow,
   type AdminOrgDetail,
   type AdminUserRow,
+  type AdminActionRow,
   type OrgPlan,
   orgPlanOf,
 } from "@/shared/types";
@@ -59,6 +60,47 @@ adminRoutes.use("*", requireAdmin);
 // above this line is reachable by any signed-in user. It was, briefly, and a
 // test caught it (#67).
 adminRoutes.route("/links", adminLinkRoutes);
+
+const AUDIT_MAX_ROWS = 200;
+
+/**
+ * The audit log, newest first, optionally narrowed to one target.
+ *
+ * Here rather than under /links, where it started: admin_actions covers users
+ * and orgs too, and a path that says otherwise is a lie about what it serves
+ * (#104).
+ */
+adminRoutes.get("/audit", async (c) => {
+  const db = c.var.db;
+  const targetType = c.req.query("targetType");
+  const targetId = c.req.query("targetId");
+  const rows = await db
+    .select({
+      id: schema.adminActions.id,
+      actorUserId: schema.adminActions.actorUserId,
+      actorEmail: schema.user.email,
+      action: schema.adminActions.action,
+      targetType: schema.adminActions.targetType,
+      targetId: schema.adminActions.targetId,
+      detail: schema.adminActions.detail,
+      createdAt: schema.adminActions.createdAt,
+    })
+    .from(schema.adminActions)
+    // Left join: the actor may have been deleted since, and the entry has to
+    // outlive them. That is why the table holds no foreign key.
+    .leftJoin(schema.user, eq(schema.user.id, schema.adminActions.actorUserId))
+    .where(
+      targetType && targetId
+        ? and(
+            eq(schema.adminActions.targetType, targetType),
+            eq(schema.adminActions.targetId, targetId),
+          )
+        : undefined,
+    )
+    .orderBy(desc(schema.adminActions.createdAt))
+    .limit(AUDIT_MAX_ROWS);
+  return c.json(rows satisfies AdminActionRow[]);
+});
 
 const day = sql<string>`date(ts / 1000, 'unixepoch')`;
 const userDay = sql<string>`date(created_at / 1000, 'unixepoch')`;

--- a/src/worker/routes/billing.ts
+++ b/src/worker/routes/billing.ts
@@ -64,7 +64,9 @@ billingRoutes.post("/checkout", requireUser, async (c) => {
   return c.json({ url: checkout.url });
 });
 
-billingRoutes.get("/portal", requireUser, async (c) => {
+// POST, not GET: this creates a Polar customer session. A GET that changes
+// something on a third party is one prefetch away from doing it unasked.
+billingRoutes.post("/portal", requireUser, async (c) => {
   const rows = await c.var.db
     .select({ customerId: schema.user.polarCustomerId })
     .from(schema.user)

--- a/src/worker/routes/domains.ts
+++ b/src/worker/routes/domains.ts
@@ -379,9 +379,10 @@ domainRoutes.post("/", async (c) => {
   return c.json(toDTO(row), 201);
 });
 
-// Manual re-check. A pure read now: the background workflow owns activation, so
-// this only reflects the latest D1 status the workflow wrote.
-domainRoutes.post("/:id/refresh", async (c) => {
+// Manual re-check. A pure read: the background workflow owns activation, so
+// this only reflects the latest D1 status the workflow wrote, which is why it
+// is a GET (#104).
+domainRoutes.get("/:id", async (c) => {
   const row = await getDomain(c, c.req.param("orgId")!, c.req.param("id"));
   return c.json(toDTO(row));
 });

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -253,9 +253,6 @@ async function findAddress(db: DB, orgId: string, linkId: string, addressId: str
   return address;
 }
 
-/** Resolves the `:linkId`/`:addressId` params every address-mutation route
- * (keep-forever, remove, promote) starts from: the link and address, 404ing
- * if either doesn't belong to this org. */
 /** The three lines every :linkId route opens with. */
 async function linkFromRequest(c: Context<AppEnv>) {
   const db = c.var.db;

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context } from "hono";
 import { nonEmpty } from "../../shared/lookup";
 import type { JsonValue } from "../../shared/types";
-import { optionalText, parseOptionalBody } from "../schemas";
+import { optionalText, parseBody, parseOptionalBody } from "../schemas";
 import * as v from "valibot";
 import { HTTPException } from "hono/http-exception";
 import { eq, and, desc, isNull, sql } from "drizzle-orm";
@@ -1088,58 +1088,65 @@ linkRoutes.post("/:linkId/addresses", requireOrgRole("member"), async (c) => {
   return c.json(dto, status);
 });
 
-linkRoutes.post(
-  "/:linkId/addresses/:addressId/keep-forever",
-  requireOrgRole("member"),
-  async (c) => {
-    const { db, orgId, address } = await findLinkAndAddress(c);
-    if (address.kind !== "temp_alias")
-      throw new HTTPException(400, { message: "Only a temporary alias can be kept forever" });
+/**
+ * One address, three things a caller can do to it, and only two verbs needed
+ * (#104): `PATCH { kind }` keeps a temporary alias forever or promotes one to
+ * primary, and `DELETE` retires it.
+ */
+const addressPatchSchema = v.object({ kind: v.picklist(["permanent", "primary"]) });
 
-    const { limits } = await orgPlan(db, orgId);
+linkRoutes.patch("/:linkId/addresses/:addressId", requireOrgRole("member"), async (c) => {
+  const body = parseBody(addressPatchSchema, await c.req.json<JsonValue>().catch(() => ({})));
+  return body.kind === "primary" ? promoteAddress(c) : keepAddressForever(c);
+});
 
-    // Atomic: the org's links cap is re-checked at write time inside one D1
-    // statement (see issue #18). Also guarded on retired_at IS NULL: if the
-    // daily sweep already retired this alias (it missed the window between
-    // expiring and this request), the update affects zero rows rather than
-    // reviving a dead one.
-    const kept = await keepAddressForeverWithinLimit(c.env, {
-      addressId: address.id,
-      orgId,
-      linkLimit: limits.links,
-    });
-    if (!kept) {
-      const [current] = await db
-        .select({ kind: schema.linkAddresses.kind, retiredAt: schema.linkAddresses.retiredAt })
-        .from(schema.linkAddresses)
-        .where(eq(schema.linkAddresses.id, address.id));
-      if (!current || current.retiredAt !== null)
-        throw new HTTPException(409, { message: "This address already expired" });
-      // Still an active temp_alias: the guard failed on the cap, not a race.
-      // If it's no longer temp_alias, a concurrent keep-forever already
-      // promoted it — the caller's intent is already satisfied, so fall
-      // through to the re-publish + success response below instead of a
-      // false upgrade prompt.
-      if (current.kind === "temp_alias")
-        throw new HTTPException(402, {
-          message: "Upgrade your plan to keep more links",
-          cause: { code: "link_limit" },
-        });
-    }
+async function keepAddressForever(c: Context<AppEnv>) {
+  const { db, orgId, address } = await findLinkAndAddress(c);
+  if (address.kind !== "temp_alias")
+    throw new HTTPException(400, { message: "Only a temporary alias can be kept forever" });
 
-    // Re-publish is required, not optional: the cached expiresAt in KV must
-    // clear too, or the redirect path's lazy-expiry check would still treat
-    // this as expired.
-    const hostname = await domainHostname(db, orgId, address.domainId);
-    await enqueueStorage(c.env, [syncLinkMsg(address.slug, hostname)]);
-    return c.json(await okWithQuota(db, orgId));
-  },
-);
+  const { limits } = await orgPlan(db, orgId);
 
-linkRoutes.post("/:linkId/addresses/:addressId/remove", requireOrgRole("member"), async (c) => {
-  const body = await c.req.json<{ confirm?: boolean }>().catch(() => ({ confirm: false }));
-  if (!body.confirm) throw new HTTPException(400, { message: "Confirm removal to continue" });
+  // Atomic: the org's links cap is re-checked at write time inside one D1
+  // statement (see issue #18). Also guarded on retired_at IS NULL: if the
+  // daily sweep already retired this alias (it missed the window between
+  // expiring and this request), the update affects zero rows rather than
+  // reviving a dead one.
+  const kept = await keepAddressForeverWithinLimit(c.env, {
+    addressId: address.id,
+    orgId,
+    linkLimit: limits.links,
+  });
+  if (!kept) {
+    const [current] = await db
+      .select({ kind: schema.linkAddresses.kind, retiredAt: schema.linkAddresses.retiredAt })
+      .from(schema.linkAddresses)
+      .where(eq(schema.linkAddresses.id, address.id));
+    if (!current || current.retiredAt !== null)
+      throw new HTTPException(409, { message: "This address already expired" });
+    // Still an active temp_alias: the guard failed on the cap, not a race.
+    // If it's no longer temp_alias, a concurrent keep-forever already
+    // promoted it — the caller's intent is already satisfied, so fall
+    // through to the re-publish + success response below instead of a
+    // false upgrade prompt.
+    if (current.kind === "temp_alias")
+      throw new HTTPException(402, {
+        message: "Upgrade your plan to keep more links",
+        cause: { code: "link_limit" },
+      });
+  }
 
+  // Re-publish is required, not optional: the cached expiresAt in KV must
+  // clear too, or the redirect path's lazy-expiry check would still treat
+  // this as expired.
+  const hostname = await domainHostname(db, orgId, address.domainId);
+  await enqueueStorage(c.env, [syncLinkMsg(address.slug, hostname)]);
+  return c.json(await okWithQuota(db, orgId));
+}
+
+// No `confirm` flag: it never told the server anything it could act on, and
+// asking before an irreversible click is the UI's job (#104).
+linkRoutes.delete("/:linkId/addresses/:addressId", requireOrgRole("member"), async (c) => {
   const { db, orgId, address } = await findLinkAndAddress(c);
   if (address.kind === "primary")
     throw new HTTPException(400, {
@@ -1161,7 +1168,7 @@ linkRoutes.post("/:linkId/addresses/:addressId/remove", requireOrgRole("member")
   return c.json(await okWithQuota(db, orgId));
 });
 
-linkRoutes.post("/:linkId/addresses/:addressId/promote", requireOrgRole("member"), async (c) => {
+async function promoteAddress(c: Context<AppEnv>) {
   const { db, orgId, link: existing, address } = await findLinkAndAddress(c);
   if (address.kind === "primary") {
     const [dto, quota] = await Promise.all([
@@ -1242,4 +1249,4 @@ linkRoutes.post("/:linkId/addresses/:addressId/promote", requireOrgRole("member"
     quotaUsageFields(db, orgId),
   ]);
   return c.json({ ...dto, ...quota });
-});
+}

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -301,16 +301,15 @@ orgRoutes.get("/:orgId/invites", requireOrgRole("admin"), async (c) => {
       email: schema.invites.email,
       createdAt: schema.invites.createdAt,
       expiresAt: schema.invites.expiresAt,
-      acceptedBy: schema.invites.acceptedBy,
     })
     .from(schema.invites)
     .where(eq(schema.invites.orgId, c.req.param("orgId")))
     .orderBy(desc(schema.invites.createdAt));
   const ts = Date.now();
-  return c.json(rows.filter((r) => !r.acceptedBy && r.expiresAt > ts) satisfies InviteDTO[]);
+  return c.json(rows.filter((r) => r.expiresAt > ts) satisfies InviteDTO[]);
 });
 
-/** Members + open (unaccepted, unexpired) invites, for the plan member cap. */
+/** Members + open (unexpired) invites, for the plan member cap. */
 async function occupiedSeats(db: AppEnv["Variables"]["db"], orgId: string): Promise<number> {
   const ts = Date.now();
   const [members, pending] = await Promise.all([
@@ -321,13 +320,7 @@ async function occupiedSeats(db: AppEnv["Variables"]["db"], orgId: string): Prom
     db
       .select({ n: sql<number>`count(*)` })
       .from(schema.invites)
-      .where(
-        and(
-          eq(schema.invites.orgId, orgId),
-          sql`${schema.invites.acceptedBy} is null`,
-          gte(schema.invites.expiresAt, ts),
-        ),
-      ),
+      .where(and(eq(schema.invites.orgId, orgId), gte(schema.invites.expiresAt, ts))),
   ]);
   return (members[0]?.n ?? 0) + (pending[0]?.n ?? 0);
 }
@@ -374,7 +367,6 @@ orgRoutes.post("/:orgId/invites", requireOrgRole("admin"), async (c) => {
       createdBy: c.var.user!.id,
       createdAt: ts,
       expiresAt: ts + INVITE_TTL_MS,
-      acceptedBy: null,
     } as const;
     await c.var.db.insert(schema.invites).values(invite);
     return c.json(
@@ -407,7 +399,6 @@ orgRoutes.post("/:orgId/invites", requireOrgRole("admin"), async (c) => {
     createdBy: c.var.user!.id,
     createdAt: ts,
     expiresAt: ts + INVITE_TTL_MS,
-    acceptedBy: null,
   }));
 
   await c.var.db.insert(schema.invites).values(created);
@@ -588,7 +579,7 @@ async function assertMember(
 async function lookupInvite(db: DB, token: string) {
   const rows = await db.select().from(schema.invites).where(eq(schema.invites.token, token));
   const invite = rows[0];
-  if (!invite || invite.acceptedBy || invite.expiresAt < Date.now())
+  if (!invite || invite.expiresAt < Date.now())
     throw new HTTPException(404, { message: "Invite not found or expired" });
   return invite;
 }
@@ -992,14 +983,13 @@ inviteRoutes.get("/:token", async (c) => {
     .select({
       role: schema.invites.role,
       expiresAt: schema.invites.expiresAt,
-      acceptedBy: schema.invites.acceptedBy,
       orgName: schema.orgs.name,
     })
     .from(schema.invites)
     .innerJoin(schema.orgs, eq(schema.invites.orgId, schema.orgs.id))
     .where(eq(schema.invites.token, c.req.param("token")));
   const invite = rows[0];
-  if (!invite || invite.acceptedBy || invite.expiresAt < Date.now())
+  if (!invite || invite.expiresAt < Date.now())
     throw new HTTPException(404, { message: "Invite not found or expired" });
   return c.json({
     orgName: invite.orgName,
@@ -1047,9 +1037,10 @@ inviteRoutes.post("/:token/accept", requireUser, async (c) => {
       message: "This organization is full on its current plan",
     });
   }
-  await db
-    .update(schema.invites)
-    .set({ acceptedBy: c.var.user!.id })
-    .where(eq(schema.invites.token, invite.token));
+  // Spent, so gone (#103). Nothing reads invite history, and the row holds an
+  // email address belonging to someone who may never have signed up. A second
+  // accept of the same token now gets the same 404 as an unknown one, so
+  // nothing learns which tokens existed.
+  await db.delete(schema.invites).where(eq(schema.invites.token, invite.token));
   return c.json({ orgId: invite.orgId });
 });

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -452,6 +452,32 @@ orgRoutes.delete("/:orgId/invites/:token", requireOrgRole("admin"), async (c) =>
   return c.json({ ok: true });
 });
 
+/** How many expired invites one sweep statement retires at a time. */
+const INVITE_SWEEP_CHUNK = 500;
+
+/**
+ * Drops invites nobody opened before they expired (#103).
+ *
+ * An accepted invite is already deleted at accept time, so this is the other
+ * half: no token and no invited address outlives the week it was good for.
+ * Bounded batches for the same reason the click trim uses them, even though
+ * an org's open invites are capped by its member limit.
+ */
+export async function sweepExpiredInvites(env: Env): Promise<number> {
+  const stmt = env.DB.prepare(
+    `delete from invites where token in (
+       select token from invites where expires_at < ? limit ?
+     )`,
+  );
+  let deleted = 0;
+  let changes = 0;
+  do {
+    changes = (await stmt.bind(Date.now(), INVITE_SWEEP_CHUNK).run()).meta.changes;
+    deleted += changes;
+  } while (changes > 0);
+  return deleted;
+}
+
 /* ---------------- stats helpers ---------------- */
 
 function emptySeries(days: number): Map<string, number> {

--- a/tests/e2e/invites.pw.ts
+++ b/tests/e2e/invites.pw.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
+import { queryRows } from "./db";
+
+const password = "test-password-123";
+
+/**
+ * An accepted invite leaves no row behind (#103).
+ *
+ * The row held a live token and, for an email invite, the address it was sent
+ * to. Nothing ever read that history: every reader filtered it back out, so
+ * the retention bought nothing and cost an address belonging to somebody who
+ * may never have signed up.
+ */
+test("accepting an invite deletes it, token and all", async ({ page, browser }) => {
+  const owner = `owner-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, owner, password);
+
+  await page.goto("/members");
+  await page.getByRole("button", { name: "Invite link" }).click();
+  await page.getByRole("button", { name: "Create invite link" }).click();
+  await expect(page.getByText("Pending invites")).toBeVisible();
+
+  const [invite] = await queryRows<{ token: string }>(
+    page,
+    "select token from invites order by created_at desc limit 1",
+  );
+  expect(invite?.token).toBeTruthy();
+
+  const guest = await browser.newContext();
+  const guestPage = await guest.newPage();
+  await signUpAndVerify(guestPage, `guest-${Date.now()}@gmail.com`, password);
+  await guestPage.goto(`/invite/${invite.token}`);
+  await guestPage.getByRole("button", { name: "Accept invite" }).click();
+  await expect(guestPage).toHaveURL(/\/dashboard$/);
+
+  const rows = await queryRows<{ n: number }>(
+    page,
+    "select count(*) as n from invites where token = ?",
+    [invite.token],
+  );
+  expect(rows[0].n).toBe(0);
+
+  // And the spent token now answers exactly like one that never existed, so
+  // nothing learns which tokens were real.
+  await guestPage.goto(`/invite/${invite.token}`);
+  await expect(guestPage.getByText("This invite is invalid or has expired.")).toBeVisible();
+
+  // The owner's pending list is empty too: it no longer filters accepted rows
+  // out, there are none to filter.
+  await page.goto("/members");
+  await expect(page.getByText("Pending invites")).toBeHidden();
+
+  await guest.close();
+});

--- a/tests/e2e/invites.pw.ts
+++ b/tests/e2e/invites.pw.ts
@@ -21,9 +21,13 @@ test("accepting an invite deletes it, token and all", async ({ page, browser }) 
   await page.getByRole("button", { name: "Create invite link" }).click();
   await expect(page.getByText("Pending invites")).toBeVisible();
 
+  // Scoped to this owner, not "the newest invite": the suite runs in parallel
+  // shards against one database, so the global newest row belongs to whichever
+  // test wrote last.
   const [invite] = await queryRows<{ token: string }>(
     page,
-    "select token from invites order by created_at desc limit 1",
+    "select token from invites where created_by = (select id from user where email = ?)",
+    [owner],
   );
   expect(invite?.token).toBeTruthy();
 

--- a/tests/e2e/public-pages.pw.ts
+++ b/tests/e2e/public-pages.pw.ts
@@ -531,3 +531,18 @@ test("the analytics placeholder reserves exactly what the mock takes", async ({ 
     expect(Math.abs(actual - reserved), `reserved height at ${width}px`).toBeLessThan(8);
   }
 });
+
+// #137: a public page points at what describes it (RFC 8288), so an agent
+// that fetches one learns where the machine-readable copy lives instead of
+// guessing at well-known paths. Only the pages we describe carry it: the app
+// behind the login wants no such traffic.
+test("public pages point at their machine-readable description", async ({ request }) => {
+  for (const path of ["/", "/pricing", "/qr-code-generator", "/privacy", "/terms"]) {
+    const res = await request.get(path);
+    expect(res.status(), path).toBe(200);
+    expect(res.headers()["link"] ?? "", path).toContain('</llms.txt>; rel="describedby"');
+  }
+
+  const dashboard = await request.get("/dashboard");
+  expect(dashboard.headers()["link"] ?? "").toBe("");
+});

--- a/tests/e2e/public-pages.pw.ts
+++ b/tests/e2e/public-pages.pw.ts
@@ -540,7 +540,9 @@ test("public pages point at their machine-readable description", async ({ reques
   for (const path of ["/", "/pricing", "/qr-code-generator", "/privacy", "/terms"]) {
     const res = await request.get(path);
     expect(res.status(), path).toBe(200);
-    expect(res.headers()["link"] ?? "", path).toContain('</llms.txt>; rel="describedby"');
+    expect(res.headers()["link"] ?? "", path).toContain(
+      '</llms.txt>; rel="describedby"; type="text/plain"',
+    );
   }
 
   const dashboard = await request.get("/dashboard");

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -55,9 +55,9 @@ describe("Cloudflare rate limiting", () => {
     expect(signedApiGroup("/api/orgs/org-1/links", "POST")).toBe("write");
     expect(signedApiGroup("/api/orgs/org-1/qr-logo", "POST")).toBe("qr_upload");
     expect(signedApiGroup("/api/orgs/org-1/domains", "GET")).toBe("domain");
-    expect(signedApiGroup("/api/orgs/org-1/domains/id/refresh", "POST")).toBe("domain");
+    expect(signedApiGroup("/api/orgs/org-1/domains/id", "GET")).toBe("domain");
     expect(signedApiGroup("/api/billing/checkout", "POST")).toBe("checkout");
-    expect(signedApiGroup("/api/billing/portal", "GET")).toBe("checkout");
+    expect(signedApiGroup("/api/billing/portal", "POST")).toBe("checkout");
     expect(signedApiGroup("/api/orgs/org-1/links", "GET")).toBeNull();
   });
 

--- a/tests/worker/admin-moderation.worker.ts
+++ b/tests/worker/admin-moderation.worker.ts
@@ -95,13 +95,24 @@ async function createLiveLink(cookie: string, destination?: string) {
 }
 
 /** Call a moderation route, then apply the republishes it enqueued. */
-async function moderate(path: string, cookie: string, body?: JsonValue, linkIds: string[] = []) {
+async function moderate(
+  path: string,
+  cookie: string,
+  body?: JsonValue,
+  linkIds: string[] = [],
+  method: "POST" | "PATCH" = "POST",
+) {
   const res = await admin(path, cookie, {
-    method: "POST",
+    method,
     body: JSON.stringify(body ?? {}),
   });
   for (const id of linkIds) await syncKv(...(await slugsOf(id)));
   return res;
+}
+
+/** Suspend or restore one link, and apply the republishes it enqueued. */
+async function setSuspended(linkId: string, cookie: string, suspended: boolean, reason = "") {
+  return moderate(`/links/${linkId}`, cookie, { suspended, reason }, [linkId], "PATCH");
 }
 
 describe("suspending one link", () => {
@@ -111,17 +122,12 @@ describe("suspending one link", () => {
     expect(await kvFor(link.slug)).toBeTruthy();
 
     const cookie = await adminCookie();
-    const res = await moderate(
-      `/links/${link.id}/suspend`,
-      cookie,
-      { reason: "phishing report #412" },
-      [link.id],
-    );
+    const res = await setSuspended(link.id, cookie, true, "phishing report #412");
     expect(res.status).toBe(200);
     expect(await kvFor(link.slug)).toBeNull();
 
     const audit = await jsonBody<{ action: string; targetId: string; detail: string | null }[]>(
-      await admin("/links/audit", cookie),
+      await admin("/audit", cookie),
     );
     const entry = audit.find((a) => a.action === "link.suspend");
     expect(entry?.targetId).toBe(link.id);
@@ -137,10 +143,7 @@ describe("suspending one link", () => {
       .bind(link.id)
       .run();
 
-    await admin(`/links/${link.id}/suspend`, await adminCookie(), {
-      method: "POST",
-      body: JSON.stringify({ reason: "spam" }),
-    });
+    await setSuspended(link.id, await adminCookie(), true, "spam");
 
     const rows = await env.DB.prepare(
       "select (select count(*) from links where id = ?) as links, (select count(*) from clicks where link_id = ?) as clicks",
@@ -155,19 +158,19 @@ describe("suspending one link", () => {
     const link = await createLiveLink(owner);
     const cookie = await adminCookie();
 
-    await moderate(`/links/${link.id}/suspend`, cookie, { reason: "spam" }, [link.id]);
+    await setSuspended(link.id, cookie, true, "spam");
     expect(await kvFor(link.slug)).toBeNull();
 
-    await moderate(`/links/${link.id}/unsuspend`, cookie, {}, [link.id]);
+    await setSuspended(link.id, cookie, false);
     expect(await kvFor(link.slug)).toBeTruthy();
   });
 
   it("refuses a suspension with no reason", async () => {
     const owner = await freeOwnerCookie();
     const link = await createLink(owner);
-    const res = await admin(`/links/${link.id}/suspend`, await adminCookie(), {
-      method: "POST",
-      body: JSON.stringify({}),
+    const res = await admin(`/links/${link.id}`, await adminCookie(), {
+      method: "PATCH",
+      body: JSON.stringify({ suspended: true }),
     });
     expect(res.status).toBe(400);
   });
@@ -179,9 +182,7 @@ describe("suspension survives what would undo it", () => {
     // the key, and a suspension enforced anywhere else would be lifted by it.
     const owner = await freeOwnerCookie();
     const link = await createLiveLink(owner);
-    await moderate(`/links/${link.id}/suspend`, await adminCookie(), { reason: "malware" }, [
-      link.id,
-    ]);
+    await setSuspended(link.id, await adminCookie(), true, "malware");
 
     const res = await fetchWorker(
       new Request(`http://localhost/api/orgs/org-1/links/${link.id}`, {
@@ -215,9 +216,7 @@ describe("suspension survives what would undo it", () => {
     expect(aliases.results.length).toBe(2);
 
     await syncKv(...aliases.results.map((r) => r.slug));
-    await moderate(`/links/${link.id}/suspend`, await adminCookie(), { reason: "malware" }, [
-      link.id,
-    ]);
+    await setSuspended(link.id, await adminCookie(), true, "malware");
 
     for (const row of aliases.results) expect(await kvFor(row.slug)).toBeNull();
   });
@@ -350,7 +349,7 @@ describe("the cross-org search", () => {
     const link = await createLink(owner);
     await createLink(owner, "https://example.com/other");
     const cookie = await adminCookie();
-    await moderate(`/links/${link.id}/suspend`, cookie, { reason: "spam" }, [link.id]);
+    await setSuspended(link.id, cookie, true, "spam");
 
     const rows = await jsonBody<{ id: string }[]>(await admin("/links?suspended=1", cookie));
     expect(rows.map((r) => r.id)).toEqual([link.id]);
@@ -364,8 +363,11 @@ describe("who may reach any of this", () => {
     for (const [path, init] of [
       ["/links", {}],
       ["/links/anonymous", {}],
-      ["/links/audit", {}],
-      [`/links/${link.id}/suspend`, { method: "POST", body: JSON.stringify({ reason: "x" }) }],
+      ["/audit", {}],
+      [
+        `/links/${link.id}`,
+        { method: "PATCH", body: JSON.stringify({ suspended: true, reason: "x" }) },
+      ],
     ] as const) {
       const res = await admin(path, owner, init);
       expect(res.status, `${path} should 404 for a non-admin`).toBe(404);

--- a/tests/worker/billing.worker.ts
+++ b/tests/worker/billing.worker.ts
@@ -77,6 +77,7 @@ async function portal(cookie?: string): Promise<Response> {
   const ctx = createExecutionContext();
   const res = await worker.fetch(
     new Request("http://localhost/api/billing/portal", {
+      method: "POST",
       headers: cookie ? { cookie } : {},
     }),
     polarEnv(),
@@ -180,7 +181,7 @@ describe("POST /api/billing/checkout", () => {
   });
 });
 
-describe("GET /api/billing/portal", () => {
+describe("POST /api/billing/portal", () => {
   it("requires sign-in", async () => {
     expect((await portal()).status).toBe(401);
   });

--- a/tests/worker/domains.worker.ts
+++ b/tests/worker/domains.worker.ts
@@ -256,8 +256,7 @@ describe("domain reads do not mutate", () => {
     expect((await statusOf("domain-1"))?.status).toBe("checking_dns");
 
     const refresh = await call(
-      new Request("http://localhost/api/orgs/org-1/domains/domain-1/refresh", {
-        method: "POST",
+      new Request("http://localhost/api/orgs/org-1/domains/domain-1", {
         headers: { cookie },
       }),
     );

--- a/tests/worker/expiry.worker.ts
+++ b/tests/worker/expiry.worker.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import worker from "../../src/worker";
 import * as schema from "../../src/worker/db/schema";
 import { applyStorageMessage, sweepExpiredAliases, syncLinkMsg } from "../../src/worker/storage";
+import { sweepExpiredInvites } from "../../src/worker/routes/orgs";
 import {
   addressById,
   applyTestMigrations,
@@ -173,5 +174,55 @@ describe("sweepExpiredAliases", () => {
     await sweepExpiredAliases(testEnv, db());
     const second = (await addressById("addr-alias")).retiredAt;
     expect(second).toBe(first);
+  });
+});
+
+describe("sweepExpiredInvites", () => {
+  const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+  async function seedInvites() {
+    await db().batch([
+      db().insert(schema.orgs).values({ id: "org-1", name: "Test", createdAt: 0 }),
+      db()
+        .insert(schema.invites)
+        .values({
+          token: "stale-token",
+          orgId: "org-1",
+          role: "member",
+          email: "invited@example.com",
+          createdAt: 0,
+          expiresAt: Date.now() - 1000,
+        }),
+      db()
+        .insert(schema.invites)
+        .values({
+          token: "live-token",
+          orgId: "org-1",
+          role: "member",
+          email: null,
+          createdAt: 0,
+          expiresAt: Date.now() + INVITE_TTL_MS,
+        }),
+    ]);
+  }
+
+  async function tokens(): Promise<string[]> {
+    const rows = await db().select({ token: schema.invites.token }).from(schema.invites);
+    return rows.map((r) => r.token).sort();
+  }
+
+  it("deletes an expired invite and leaves an open one alone", async () => {
+    await seedInvites();
+
+    expect(await sweepExpiredInvites(testEnv)).toBe(1);
+    expect(await tokens()).toEqual(["live-token"]);
+  });
+
+  it("is a no-op re-run once the expired ones are gone", async () => {
+    await seedInvites();
+    await sweepExpiredInvites(testEnv);
+
+    expect(await sweepExpiredInvites(testEnv)).toBe(0);
+    expect(await tokens()).toEqual(["live-token"]);
   });
 });

--- a/tests/worker/link-addresses.worker.ts
+++ b/tests/worker/link-addresses.worker.ts
@@ -192,7 +192,9 @@ describe("addresses sub-resource", () => {
   it("keep-forever flips the alias to permanent and clears its expiry", async () => {
     const { cookie, linkId, aliasId } = await renamedLink();
 
-    const res = await api(cookie, "POST", `/links/${linkId}/addresses/${aliasId}/keep-forever`);
+    const res = await api(cookie, "PATCH", `/links/${linkId}/addresses/${aliasId}`, {
+      kind: "permanent",
+    });
     expect(res.status).toBe(200);
 
     const row = await addressById(aliasId);
@@ -209,25 +211,17 @@ describe("addresses sub-resource", () => {
       .set({ retiredAt: Date.now() })
       .where(eq(schema.linkAddresses.id, aliasId));
 
-    const res = await api(cookie, "POST", `/links/${linkId}/addresses/${aliasId}/keep-forever`);
+    const res = await api(cookie, "PATCH", `/links/${linkId}/addresses/${aliasId}`, {
+      kind: "permanent",
+    });
     expect(res.status).toBe(409);
   });
 
-  it("remove requires confirmation, then retires the address", async () => {
+  it("delete retires the address", async () => {
     const { cookie, linkId, aliasId } = await renamedLink();
 
-    const unconfirmed = await api(
-      cookie,
-      "POST",
-      `/links/${linkId}/addresses/${aliasId}/remove`,
-      {},
-    );
-    expect(unconfirmed.status).toBe(400);
-
-    const confirmed = await api(cookie, "POST", `/links/${linkId}/addresses/${aliasId}/remove`, {
-      confirm: true,
-    });
-    expect(confirmed.status).toBe(200);
+    const removed = await api(cookie, "DELETE", `/links/${linkId}/addresses/${aliasId}`);
+    expect(removed.status).toBe(200);
 
     const row = await addressById(aliasId);
     expect(row.retiredAt).not.toBeNull();
@@ -237,16 +231,16 @@ describe("addresses sub-resource", () => {
     const { cookie, linkId } = await renamedLink();
     const [primary] = (await addressesOf(linkId)).filter((a) => a.kind === "primary");
 
-    const res = await api(cookie, "POST", `/links/${linkId}/addresses/${primary.id}/remove`, {
-      confirm: true,
-    });
+    const res = await api(cookie, "DELETE", `/links/${linkId}/addresses/${primary.id}`);
     expect(res.status).toBe(400);
   });
 
   it("promote swaps the alias and primary slug/domain in place, on the same link", async () => {
     const { cookie, linkId, aliasId } = await renamedLink();
 
-    const res = await api(cookie, "POST", `/links/${linkId}/addresses/${aliasId}/promote`);
+    const res = await api(cookie, "PATCH", `/links/${linkId}/addresses/${aliasId}`, {
+      kind: "primary",
+    });
     expect(res.status).toBe(200);
     const link = await jsonBody<{ slug: string }>(res);
     expect(link.slug).toBe("old-slug"); // the promoted alias's slug
@@ -462,14 +456,14 @@ describe("plan limits (#38)", () => {
     expect(addresses.some((a) => a.kind === "temp_alias")).toBe(true);
   });
 
-  // Both actions leave the org holding one more counted address than it did:
-  // keep-forever makes the temp alias permanent, promote makes the old primary
-  // permanent. At the cap, neither has room.
-  it.each(["keep-forever", "promote"])("402s %s on a temp alias at the limit", async (action) => {
+  // Both kinds leave the org holding one more counted address than it did:
+  // "permanent" makes the temp alias permanent, "primary" makes the old
+  // primary permanent. At the cap, neither has room.
+  it.each(["permanent", "primary"])("402s kind=%s on a temp alias at the limit", async (kind) => {
     const { cookie, linkId, aliasId } = await renamedLink();
     await fillOrgToLimit();
 
-    const res = await api(cookie, "POST", `/links/${linkId}/addresses/${aliasId}/${action}`);
+    const res = await api(cookie, "PATCH", `/links/${linkId}/addresses/${aliasId}`, { kind });
     expect(res.status).toBe(402);
   });
 });

--- a/tests/worker/plan-limits.worker.ts
+++ b/tests/worker/plan-limits.worker.ts
@@ -101,10 +101,11 @@ async function postKeepForever(
   addressId: string,
 ): Promise<Response> {
   return fetchWorker(
-    new Request(
-      `http://localhost/api/orgs/${orgId}/links/${linkId}/addresses/${addressId}/keep-forever`,
-      { method: "POST", headers: { cookie } },
-    ),
+    new Request(`http://localhost/api/orgs/${orgId}/links/${linkId}/addresses/${addressId}`, {
+      method: "PATCH",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ kind: "permanent" }),
+    }),
   );
 }
 
@@ -235,7 +236,6 @@ describe("invite acceptance: member cap and duplicate accept under concurrency (
         createdBy: "owner-1",
         createdAt: 0,
         expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
-        acceptedBy: null,
       }),
     ];
     // SAFETY: statements always holds the org insert, so it is non-empty,

--- a/tests/worker/security-headers.worker.ts
+++ b/tests/worker/security-headers.worker.ts
@@ -45,7 +45,9 @@ describe("security headers (#21)", () => {
   });
 
   it("applies to an HTTPException error response", async () => {
-    const res = await fetchWorker(new Request("http://localhost/api/billing/portal"));
+    const res = await fetchWorker(
+      new Request("http://localhost/api/billing/portal", { method: "POST" }),
+    );
     expect(res.status).toBe(401); // requireUser, no session cookie
     expectSecurityHeaders(res);
   });


### PR DESCRIPTION
Closes #103, closes #104, closes #137.

Three small issues, each a few lines and no new machinery.

## #103: invites are deleted when they are spent

`invites` kept every row forever, and nothing read that history: four
separate readers filtered accepted rows back out. The row held a live
token and, for an email invite, an address belonging to somebody who may
never have signed up.

- Accepting deletes the row instead of setting `accepted_by`.
- A second accept of a spent token gets the same 404 as an unknown one, so
  nothing learns which tokens existed.
- The daily sweep drops invites nobody opened before they expired.
- Migration `0023` deletes the accepted rows and drops `accepted_by`, and
  the four filters go with it.

## #104: the routes whose HTTP method lied

| before | after |
| --- | --- |
| `GET /api/billing/portal` (creates a Polar session) | `POST /api/billing/portal` |
| `POST /domains/:id/refresh` (a pure read) | `GET /domains/:id` |
| `POST /admin/links/:id/suspend` + `/unsuspend` | `PATCH /admin/links/:id` with `{ suspended, reason }` |
| `GET /admin/links/audit` (serves users and orgs too) | `GET /admin/audit` |
| `POST .../addresses/:id/{keep-forever,remove,promote}` | `PATCH .../addresses/:id` with `{ kind }` + `DELETE` |

The `confirm: true` body went with the last one: confirmation is the UI's
job, and the server could never act on the flag.

No behaviour changes. Five endpoints became three.

## #137: public pages say what describes them

A `Link` header (RFC 8288) on the pages `PUBLIC_PAGE_META` already covers,
pointing at `/llms.txt`, which exists and says what the site is.

`api-catalog` and `service-desc` belong there too and go in when the
documents they name exist (#133, #136). A `Link` header pointing at a 404
is worse than no header, so this ships only the relation we can honour.

## Tests

- New `tests/e2e/invites.pw.ts`: accept an invite, then the row is gone,
  the token 404s like an unknown one, and the pending list is empty.
- New scenario in `public-pages.pw.ts`: every public page carries the
  header, `/dashboard` does not.
- The worker tests for suspension, addresses, billing, domains and rate-limit
  grouping follow the new verbs.

`bun run verify` green; the e2e specs in the blast radius (invites,
public-pages, link-addresses, admin-moderation, billing-page) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VfyPU1UrdK8joAUPAzByL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public pages now advertise their machine-readable description.
  * Added admin audit activity lookup with filtering and recent-first results.
  * Expired, unaccepted invitations are automatically removed.

* **Improvements**
  * Invitations are deleted after successful acceptance and no longer consume seats afterward.
  * Link address management now supports clearer update and removal actions.
  * Link suspension and restoration use a unified moderation action with reasons for suspensions.

* **API Changes**
  * Updated billing portal, domain status, and administration request methods and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->