### PR TITLE
Make the invite token admit exactly one person

### DIFF
--- a/src/app/routes/invite.tsx
+++ b/src/app/routes/invite.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { HrefLink } from "../lib/router-search";
 import { errorMessage } from "@/app/lib/error-message";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "../lib/api";
+import { api, ApiError } from "../lib/api";
 import type { InvitePreview } from "@/shared/types";
 import { useCurrentUser } from "../lib/hooks";
 import { useCurrentOrg } from "../lib/current-org";
@@ -94,6 +94,11 @@ export function InvitePage() {
       navigate({ to: "/dashboard" });
     } catch (e) {
       toast(errorMessage(e), "error");
+      // A 404 here means the link is spent or revoked, and the card is still
+      // offering to accept it. Re-asking flips it to the dead-invite screen,
+      // so a second click cannot just repeat the toast.
+      if (e instanceof ApiError && e.status === 404)
+        await qc.invalidateQueries({ queryKey: ["invite", token] });
     }
   };
 

--- a/src/worker/plan.ts
+++ b/src/worker/plan.ts
@@ -59,10 +59,17 @@ export async function createOwnedOrg(
 }
 
 /**
- * Accepts an invite: writes the membership row only if the caller isn't
- * already a member and the org is still under its member cap, both re-checked
- * inside this one statement. Closes the race where two concurrent accepts
- * (or one accept retried twice) both pass separate pre-checks.
+ * Accepts an invite: writes the membership row only if the token is still
+ * live, the caller isn't already a member, and the org is under its member
+ * cap. All three are re-checked inside the insert itself, and the invite is
+ * spent in the same transaction, so the token is what admits exactly one
+ * person rather than a row two requests can both read first (#154).
+ *
+ * The delete matches on the membership this call just wrote (org, user and
+ * the exact `created_at` it was given), never on the token alone. That is
+ * what keeps the two cases the insert refuses from spending the invite: an
+ * org that filled up leaves the token usable once a seat frees, and a member
+ * who opens somebody else's link does not burn it on their way to a 409.
  */
 export async function acceptInviteAtomically(
   env: Env,
@@ -72,25 +79,35 @@ export async function acceptInviteAtomically(
     role: "admin" | "member";
     ts: number;
     memberLimit: number;
+    token: string;
   },
 ): Promise<boolean> {
-  return runGuarded(
-    env,
-    `insert into org_members (org_id, user_id, role, created_at)
-     select ?, ?, ?, ?
-     where not exists (select 1 from org_members where org_id = ? and user_id = ?)
-       and (select count(*) from org_members where org_id = ?) < ?`,
-    [
+  const results = await env.DB.batch([
+    env.DB.prepare(
+      `insert into org_members (org_id, user_id, role, created_at)
+       select ?, ?, ?, ?
+       where exists (select 1 from invites where token = ?)
+         and not exists (select 1 from org_members where org_id = ? and user_id = ?)
+         and (select count(*) from org_members where org_id = ?) < ?`,
+    ).bind(
       args.orgId,
       args.userId,
       args.role,
       args.ts,
+      args.token,
       args.orgId,
       args.userId,
       args.orgId,
       args.memberLimit,
-    ],
-  );
+    ),
+    env.DB.prepare(
+      `delete from invites where token = ? and exists (
+         select 1 from org_members
+         where org_id = ? and user_id = ? and created_at = ?
+       )`,
+    ).bind(args.token, args.orgId, args.userId, args.ts),
+  ]);
+  return results[0].meta.changes > 0;
 }
 
 /** Builds (without executing) the conditional link_addresses insert used by

--- a/src/worker/plan.ts
+++ b/src/worker/plan.ts
@@ -66,10 +66,20 @@ export async function createOwnedOrg(
  * person rather than a row two requests can both read first (#154).
  *
  * The delete matches on the membership this call just wrote (org, user and
- * the exact `created_at` it was given), never on the token alone. That is
- * what keeps the two cases the insert refuses from spending the invite: an
- * org that filled up leaves the token usable once a seat frees, and a member
- * who opens somebody else's link does not burn it on their way to a 409.
+ * the exact `created_at` it was given) rather than on the token alone. That
+ * is what keeps the two cases the insert refuses from spending the invite:
+ * an org that filled up leaves the token usable once a seat frees, and a
+ * member who opens somebody else's link does not burn it on their way to a
+ * 409.
+ *
+ * `created_at` stands in for "the row this call inserted" because
+ * `(org_id, user_id)` is the primary key, so there is only ever one row to
+ * confuse it with: the caller's own earlier membership, and only if they
+ * joined in the very millisecond this request is using. Reaching that means
+ * one user accepting two different tokens for one org inside the same
+ * millisecond, which spends the second token as well as the first. The cost
+ * is an unused invite the admin re-issues, so it is left alone rather than
+ * traded for a marker column on every membership row.
  */
 export async function acceptInviteAtomically(
   env: Env,

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -1023,6 +1023,36 @@ inviteRoutes.get("/:token", async (c) => {
   } satisfies InvitePreview);
 });
 
+/**
+ * Always throws: says why the guarded insert wrote nothing.
+ *
+ * The statement refuses for three reasons and reports none of them, so each
+ * is read back here, in the order that answers the caller honestly. The token
+ * comes last because it is the rarest and the only one that needs a second
+ * read of a row we already had.
+ */
+async function explainRefusedInvite(
+  db: DB,
+  invite: typeof schema.invites.$inferSelect,
+  userId: string,
+): Promise<never> {
+  const [existing, live] = await Promise.all([
+    db
+      .select({ role: schema.orgMembers.role })
+      .from(schema.orgMembers)
+      .where(and(eq(schema.orgMembers.orgId, invite.orgId), eq(schema.orgMembers.userId, userId))),
+    db
+      .select({ token: schema.invites.token })
+      .from(schema.invites)
+      .where(eq(schema.invites.token, invite.token)),
+  ]);
+  if (existing.length) throw new HTTPException(409, { message: "Already a member of this org" });
+  // Somebody else spent the link between the lookup above and the insert. It
+  // has to read as an unknown token, not as a full org: the org may have room.
+  if (!live.length) throw new HTTPException(404, { message: "Invite not found or expired" });
+  throw new HTTPException(402, { message: "This organization is full on its current plan" });
+}
+
 inviteRoutes.post("/:token/accept", requireUser, async (c) => {
   const db = c.var.db;
   const invite = await lookupInvite(db, c.req.param("token"));
@@ -1036,10 +1066,10 @@ inviteRoutes.post("/:token/accept", requireUser, async (c) => {
     });
 
   // The cap may have been reached (or the plan downgraded) since the invite
-  // was created; recheck against actual members at accept time. Both that
-  // recheck and the "already a member" check happen inside one atomic
-  // statement (see issue #18), so two concurrent accepts (or a retried one)
-  // can't both pass separate pre-checks.
+  // was created; recheck against actual members at accept time. That recheck,
+  // the "already a member" check and the token itself are all read inside one
+  // atomic statement (see #18 and #154), which spends the invite in the same
+  // transaction: two concurrent accepts of one link cannot both pass.
   const { limits } = await orgPlan(db, invite.orgId);
   const accepted = await acceptInviteAtomically(c.env, {
     orgId: invite.orgId,
@@ -1047,26 +1077,8 @@ inviteRoutes.post("/:token/accept", requireUser, async (c) => {
     role: invite.role,
     ts: Date.now(),
     memberLimit: limits.members,
+    token: invite.token,
   });
-  if (!accepted) {
-    const existing = await db
-      .select({ role: schema.orgMembers.role })
-      .from(schema.orgMembers)
-      .where(
-        and(
-          eq(schema.orgMembers.orgId, invite.orgId),
-          eq(schema.orgMembers.userId, c.var.user!.id),
-        ),
-      );
-    if (existing.length) throw new HTTPException(409, { message: "Already a member of this org" });
-    throw new HTTPException(402, {
-      message: "This organization is full on its current plan",
-    });
-  }
-  // Spent, so gone (#103). Nothing reads invite history, and the row holds an
-  // email address belonging to someone who may never have signed up. A second
-  // accept of the same token now gets the same 404 as an unknown one, so
-  // nothing learns which tokens existed.
-  await db.delete(schema.invites).where(eq(schema.invites.token, invite.token));
+  if (!accepted) await explainRefusedInvite(db, invite, c.var.user!.id);
   return c.json({ orgId: invite.orgId });
 });

--- a/tests/e2e/invites.pw.ts
+++ b/tests/e2e/invites.pw.ts
@@ -1,8 +1,43 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Browser, type Page } from "@playwright/test";
 import { signUpAndVerify } from "./resend";
 import { queryRows } from "./db";
 
 const password = "test-password-123";
+
+/**
+ * Signs up an owner, creates a link invite from Members, and returns the
+ * owner's address with the token behind it.
+ *
+ * The token is read back scoped to this owner, not as "the newest invite":
+ * the suite runs in parallel shards against one database, so the globally
+ * newest row belongs to whichever test wrote last.
+ */
+async function ownerWithInviteLink(page: Page, prefix: string) {
+  const owner = `${prefix}-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, owner, password);
+
+  await page.goto("/members");
+  await page.getByRole("button", { name: "Invite link" }).click();
+  await page.getByRole("button", { name: "Create invite link" }).click();
+  await expect(page.getByText("Pending invites")).toBeVisible();
+
+  const [invite] = await queryRows<{ token: string }>(
+    page,
+    "select token from invites where created_by = (select id from user where email = ?)",
+    [owner],
+  );
+  expect(invite?.token).toBeTruthy();
+  return { owner, token: invite.token };
+}
+
+/** A separate signed-up account in its own browser context, for the half of
+ * an invite flow the owner cannot play. */
+async function guestAccount(browser: Browser, prefix: string) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await signUpAndVerify(page, `${prefix}-${Date.now()}@gmail.com`, password);
+  return { context, page };
+}
 
 /**
  * An accepted invite leaves no row behind (#103).
@@ -13,47 +48,55 @@ const password = "test-password-123";
  * may never have signed up.
  */
 test("accepting an invite deletes it, token and all", async ({ page, browser }) => {
-  const owner = `owner-${Date.now()}@gmail.com`;
-  await signUpAndVerify(page, owner, password);
+  const { token } = await ownerWithInviteLink(page, "owner");
 
-  await page.goto("/members");
-  await page.getByRole("button", { name: "Invite link" }).click();
-  await page.getByRole("button", { name: "Create invite link" }).click();
-  await expect(page.getByText("Pending invites")).toBeVisible();
-
-  // Scoped to this owner, not "the newest invite": the suite runs in parallel
-  // shards against one database, so the global newest row belongs to whichever
-  // test wrote last.
-  const [invite] = await queryRows<{ token: string }>(
-    page,
-    "select token from invites where created_by = (select id from user where email = ?)",
-    [owner],
-  );
-  expect(invite?.token).toBeTruthy();
-
-  const guest = await browser.newContext();
-  const guestPage = await guest.newPage();
-  await signUpAndVerify(guestPage, `guest-${Date.now()}@gmail.com`, password);
-  await guestPage.goto(`/invite/${invite.token}`);
-  await guestPage.getByRole("button", { name: "Accept invite" }).click();
-  await expect(guestPage).toHaveURL(/\/dashboard$/);
+  const guest = await guestAccount(browser, "guest");
+  await guest.page.goto(`/invite/${token}`);
+  await guest.page.getByRole("button", { name: "Accept invite" }).click();
+  await expect(guest.page).toHaveURL(/\/dashboard$/);
 
   const rows = await queryRows<{ n: number }>(
     page,
     "select count(*) as n from invites where token = ?",
-    [invite.token],
+    [token],
   );
   expect(rows[0].n).toBe(0);
 
   // And the spent token now answers exactly like one that never existed, so
   // nothing learns which tokens were real.
-  await guestPage.goto(`/invite/${invite.token}`);
-  await expect(guestPage.getByText("This invite is invalid or has expired.")).toBeVisible();
+  await guest.page.goto(`/invite/${token}`);
+  await expect(guest.page.getByText("This invite is invalid or has expired.")).toBeVisible();
 
   // The owner's pending list is empty too: it no longer filters accepted rows
   // out, there are none to filter.
   await page.goto("/members");
   await expect(page.getByText("Pending invites")).toBeHidden();
 
-  await guest.close();
+  await guest.context.close();
+});
+
+/**
+ * The link says single-use, so it admits one person (#154).
+ *
+ * Two accounts open the same token. Whoever gets there first joins; the other
+ * reads the same "invalid or expired" as somebody who invented a token, which
+ * is the honest answer once the link has been spent.
+ */
+test("a single-use invite link admits one person, not everybody who has it", async ({
+  page,
+  browser,
+}) => {
+  const { token } = await ownerWithInviteLink(page, "single");
+
+  const first = await guestAccount(browser, "first");
+  await first.page.goto(`/invite/${token}`);
+  await first.page.getByRole("button", { name: "Accept invite" }).click();
+  await expect(first.page).toHaveURL(/\/dashboard$/);
+
+  const second = await guestAccount(browser, "second");
+  await second.page.goto(`/invite/${token}`);
+  await expect(second.page.getByText("This invite is invalid or has expired.")).toBeVisible();
+
+  await first.context.close();
+  await second.context.close();
 });

--- a/tests/e2e/invites.pw.ts
+++ b/tests/e2e/invites.pw.ts
@@ -88,13 +88,20 @@ test("a single-use invite link admits one person, not everybody who has it", asy
 }) => {
   const { token } = await ownerWithInviteLink(page, "single");
 
+  // Both open the live link before either accepts, so the second one is
+  // holding a card that has already gone stale by the time they click.
   const first = await guestAccount(browser, "first");
+  const second = await guestAccount(browser, "second");
   await first.page.goto(`/invite/${token}`);
+  await second.page.goto(`/invite/${token}`);
+  await expect(second.page.getByRole("button", { name: "Accept invite" })).toBeVisible();
+
   await first.page.getByRole("button", { name: "Accept invite" }).click();
   await expect(first.page).toHaveURL(/\/dashboard$/);
 
-  const second = await guestAccount(browser, "second");
-  await second.page.goto(`/invite/${token}`);
+  await second.page.getByRole("button", { name: "Accept invite" }).click();
+  await expect(second.page.getByText("Invite not found or expired")).toBeVisible();
+  // And the card stops offering a button that cannot work.
   await expect(second.page.getByText("This invite is invalid or has expired.")).toBeVisible();
 
   await first.context.close();

--- a/tests/worker/plan-limits.worker.ts
+++ b/tests/worker/plan-limits.worker.ts
@@ -189,7 +189,7 @@ describe("invite acceptance: member cap and duplicate accept under concurrency (
   // seat under the free plan's real member cap (PLAN_LIMITS.free.members),
   // so this test tracks the actual limit instead of a number that can drift
   // out of sync with it.
-  async function seedOrgWithOneSlotLeft() {
+  async function seedOrgWithOneSlotLeft(tokens: string[] = ["bearer-invite"]) {
     const db = drizzle(env.DB, { schema });
     const extraMembers = PLAN_LIMITS.free.members - 2; // -1 for the owner, -1 for the open seat
     const statements = [
@@ -228,29 +228,34 @@ describe("invite acceptance: member cap and duplicate accept under concurrency (
           createdAt: 0,
         }),
       ]).flat(),
-      db.insert(schema.invites).values({
-        token: "bearer-invite",
-        orgId: "org-race",
-        role: "member",
-        email: null,
-        createdBy: "owner-1",
-        createdAt: 0,
-        expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
-      }),
+      ...tokens.map((token) =>
+        db.insert(schema.invites).values({
+          token,
+          orgId: "org-race",
+          role: "member",
+          email: null,
+          createdBy: "owner-1",
+          createdAt: 0,
+          expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        }),
+      ),
     ];
     // SAFETY: statements always holds the org insert, so it is non-empty,
     // which is all drizzle batch() asks of its argument.
     await db.batch(statements as [(typeof statements)[number], ...(typeof statements)[number][]]);
   }
 
+  // Two tokens, so the seat is the only thing they are racing for: with one
+  // token the loser is refused by the token (see the single-use test below)
+  // and this would stop covering the cap at all.
   it("lets exactly one of two racing users through the last seat", async () => {
-    await seedOrgWithOneSlotLeft();
+    await seedOrgWithOneSlotLeft(["invite-a", "invite-b"]);
     const cookieA = await seedFreeUser("racer-a", "racera@example.com");
     const cookieB = await seedFreeUser("racer-b", "racerb@example.com");
 
     const [a, b] = await Promise.all([
-      acceptInvite(cookieA, "bearer-invite"),
-      acceptInvite(cookieB, "bearer-invite"),
+      acceptInvite(cookieA, "invite-a"),
+      acceptInvite(cookieB, "invite-b"),
     ]);
     const statuses = [a.status, b.status].sort();
 
@@ -260,6 +265,54 @@ describe("invite acceptance: member cap and duplicate accept under concurrency (
       "select count(*) as n from org_members where org_id = 'org-race'",
     ).first<{ n: number }>();
     expect(members?.n).toBe(PLAN_LIMITS.free.members);
+  });
+
+  // #154: the link is advertised as single-use, so the token has to be what
+  // admits exactly one person. Two users racing one token used to both get in
+  // whenever the org had two seats free, because each read the row before
+  // either spent it.
+  it("lets exactly one of two racing users through a single-use token", async () => {
+    await seedOrgWithOneSlotLeft(["bearer-invite"]);
+    // Room for both, so the seat cannot be what refuses the loser.
+    await env.DB.prepare("delete from org_members where user_id like 'member-%'").run();
+    const cookieA = await seedFreeUser("racer-d", "racerd@example.com");
+    const cookieB = await seedFreeUser("racer-e", "racere@example.com");
+
+    const [a, b] = await Promise.all([
+      acceptInvite(cookieA, "bearer-invite"),
+      acceptInvite(cookieB, "bearer-invite"),
+    ]);
+    expect([a.status, b.status].sort()).toEqual([200, 404]);
+
+    const joined = await env.DB.prepare(
+      "select count(*) as n from org_members where org_id = 'org-race' and user_id in ('racer-d', 'racer-e')",
+    ).first<{ n: number }>();
+    expect(joined?.n).toBe(1);
+
+    const left = await env.DB.prepare(
+      "select count(*) as n from invites where token = 'bearer-invite'",
+    ).first<{ n: number }>();
+    expect(left?.n).toBe(0);
+  });
+
+  // The org filling up must not spend the token: a seat may free later, and
+  // an admin should not have to re-issue a link nobody managed to use.
+  it("leaves the invite usable when the accept is refused by the member cap", async () => {
+    await seedOrgWithOneSlotLeft(["bearer-invite"]);
+    await env.DB.prepare(
+      "insert into user (id, name, email, email_verified, is_admin, plan, created_at, updated_at) values ('filler', 'Filler', 'filler@example.com', 1, 0, 'free', 0, 0)",
+    ).run();
+    await env.DB.prepare(
+      "insert into org_members (org_id, user_id, role, created_at) values ('org-race', 'filler', 'member', 0)",
+    ).run();
+
+    const cookie = await seedFreeUser("racer-f", "racerf@example.com");
+    expect((await acceptInvite(cookie, "bearer-invite")).status).toBe(402);
+
+    const left = await env.DB.prepare(
+      "select count(*) as n from invites where token = 'bearer-invite'",
+    ).first<{ n: number }>();
+    expect(left?.n).toBe(1);
   });
 
   it("gives the same user's two concurrent accepts one valid outcome", async () => {


### PR DESCRIPTION
Closes #154, which came out of the review on #153.

## The problem

The invite dialog promises a "single-use invite link (valid 7 days)". It was
not single-use. `POST /invites/:token/accept` did this:

1. `lookupInvite` reads the row.
2. `acceptInviteAtomically` inserts the membership, re-checking the member
   cap and "already a member" inside one statement (#18).
3. The invite is consumed.

Step 2's statement knew nothing about the token, so two requests could both
read a live invite at step 1 and both reach step 2. With two seats free, one
link admitted two people. The member cap was the only bound.

Pre-existing: `main` had the same window with `accepted_by` written at step
3. #103 swapped that write for a delete without widening or closing it.

## The fix

The token joins the insert's own WHERE clause, and the delete runs in the
same `db.batch()` transaction:

```sql
insert into org_members (...)
select ?, ?, ?, ?
where exists (select 1 from invites where token = ?)
  and not exists (select 1 from org_members where org_id = ? and user_id = ?)
  and (select count(*) from org_members where org_id = ?) < ?
```

The delete is deliberately **not** keyed on the token alone. It matches the
membership row this call just wrote, by `(org_id, user_id, created_at)` with
the exact timestamp passed in. That answers the design question the issue
raised, and keeps both refusals from spending the invite:

- **Org full**: no membership written, so the token survives and works once
  a seat frees. An admin does not re-issue a link nobody used.
- **Already a member** opening somebody else's link: their membership has a
  different `created_at`, so they get their 409 without burning the invite
  out from under the person it was meant for.

A caller who loses the race gets `404 Invite not found or expired`, the same
answer as an invented token, instead of being told the org is full when it
may have room.

## Tests

- `plan-limits.worker.ts`: two racers on one token → exactly one member, one
  404, no invite row left. Verified it fails without the guard (both get 200).
- `plan-limits.worker.ts`: an accept refused by the cap leaves the invite row.
- The existing cap-race test now gives each racer their own token. With one
  token between them the token refuses the loser, so that test would have
  quietly stopped covering the member cap.
- `tests/e2e/invites.pw.ts`: second account opening a spent link sees
  "invalid or has expired".

`bun run verify` green at 313 tests; both e2e specs pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VfyPU1UrdK8joAUPAzByL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invite links are now safely single-use, including when multiple people accept the same link simultaneously.
  * Spent or revoked invites now transition to an invalid or expired state.
  * Invites remain available when acceptance is refused because the organization is already at capacity or the person is already a member.
  * Invite acceptance now reports clearer outcomes for expired, reused, full-capacity, and existing-membership cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->