### PR TITLE
Define what a downgrade does, and never delete on one

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -61,6 +61,15 @@ PR closes in the body.
   once, at the end. The full e2e suite is CI's job, not a local default.
 - `bun run fallow` before the PR. It catches duplication you would otherwise
   ship.
+- **A new migration needs `bun run db:migrate:local`.** Nothing applies it for
+  you: not `bun run dev`, not the worker tests, which apply migrations into
+  their own database. #165's table was missing from the dev D1 for a whole
+  session, and the thing that finally asked for it was the seeder.
+- **Fix what you trip over, in its own commit.** This branch turned up a
+  pre-commit hook that failed any commit touching only a skill file, and a
+  test helper that swallowed the one error message that would have explained
+  a failure. Both cost twenty minutes and neither had anything to do with the
+  issue. Leaving them costs the next person the same twenty minutes.
 
 ### Mutation-test any new guard
 
@@ -183,6 +192,12 @@ reports pass when its review never ran: it posts a rate-limit warning instead
 and the PR looks reviewed. When that happens, comment `@coderabbitai review`
 once the limit resets and wait for the real thing.
 
+It bites twice. The limit is per-account and shared with every other PR, so
+the run that reviewed your first push says nothing about the commits you
+pushed to answer it. After fixing a review, check that the next one covered
+the fixes: `gh pr view <n> --json comments` and look at which commit the
+latest CodeRabbit comment names.
+
 Every comment ends in one of three states, with a reply on the thread saying
 which:
 
@@ -205,17 +220,37 @@ Spawn a fresh agent with no context from your session, and give it the PR
 number, the issues it closes, and any deliberate scope decisions it should
 not re-litigate. Ask for a verdict plus findings with `file:line`.
 
-This is the step that catches what you cannot catch on your own diff. It has
-found a sweep with no test (making an acceptance criterion unverified), a
-stale doc comment, and an error string that read as field-name jargon in a
-toast. Tell it to verify claims by running things rather than reasoning about
-them, and to leave the working tree exactly as it found it.
+This is the step that catches what you cannot catch on your own diff, and it
+is worth the wait even when everything says the PR is done. On #165 all seven
+checks were green and all twelve CodeRabbit threads were fixed and resolved;
+the cold review then returned "do not ship" and ten more findings, two of
+which broke the feature outright. One of those was the only event that
+mattered, `subscription.revoked`, silently never running the pass the whole
+branch existed for.
+
+It has also found a sweep with no test (making an acceptance criterion
+unverified), a stale doc comment, and an error string that read as field-name
+jargon in a toast.
+
+Tell it to verify claims by running things rather than reasoning about them,
+and to leave the working tree exactly as it found it. Name the deliberate
+decisions it should not re-litigate, or it spends its budget re-deriving
+choices already argued in the PR body, and say what to hunt for instead:
+where the feature's own rule is broken, which acceptance criteria nothing
+covers, and any path where something is deleted or silently lost.
 
 ## 8. Merge
 
 Squash, delete the branch, sync `main`. Only when CI is green **and** both
 reviews are genuinely clean. Confirm the checks ran against the head commit,
 not an earlier push.
+
+Before that, walk the issues the PR closes and check each one has its
+evidence: a test that would fail without it, and a screenshot if it has a
+face. Asked whether #165 had a screenshot for every new feature, the honest
+answer was no: three surfaces, including the entire first issue in the batch,
+were described in the PR body and shown nowhere. "The PR has screenshots" is
+not the same claim as "each issue has one".
 
 Then take the next issue.
 

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -99,6 +99,49 @@ fix, what was deliberately not done, and what a reviewer should know at
 release (a route rename means anyone on the old bundle gets errors until they
 reload). List every issue it closes.
 
+### Anything with a face gets screenshots
+
+If the change touches an interface, post the screenshots as a PR comment. Not
+because a PR should be pretty: a screenshot is the only part of a review that
+checks what a person will actually see, and prose describing a screen is the
+easiest thing in a PR body to write convincingly and wrongly.
+
+They pay for themselves while you take them. Driving #165's states turned up
+an invite form still offered in an org the server would refuse an invite
+from, which every test had passed straight over because no test asks "would a
+person be offered this".
+
+Capture them by driving the real app, never by mocking a state:
+
+- A throwaway `tests/e2e/zz-shots.pw.ts` that reuses the helpers in
+  `tests/e2e/orgs.ts` to build each state, then `page.screenshot()`. Delete it
+  once the images are out; it is a capture script, not a check.
+- Dismiss the consent banner first (it covers the bottom-right of every page),
+  and rename the seeded org and users, or every shot carries
+  `shots-1787481680744's links` where a name should be.
+- `test.use({ viewport: { width: 1280, height: 900 } })`. Take the shot on the
+  screen that shows the change, not the prettiest one.
+
+**Host them in R2, never in the repo and never in a side branch.** Both put
+binaries in git history for a comment, and pushing an orphan branch to serve
+images is using GitHub as a CDN it did not offer to be:
+
+```sh
+bunx wrangler r2 object put "brnr/github/rdyrct/pr-<n>/<name>.png" \
+  --file <name>.png --content-type image/png --remote
+```
+
+They serve from `https://cdn.brnr.dev/github/rdyrct/pr-<n>/<name>.png`. Check
+one with `curl -o /dev/null -w '%{http_code}'` before writing the comment,
+then check GitHub proxied them after: it rewrites external images through
+camo, so `gh api repos/<owner>/<repo>/issues/comments/<id> -H "Accept:
+application/vnd.github.html+json"` should show six `<img>` tags and each camo
+URL should return `image/png`. A broken image reads as a broken feature.
+
+Caption each one with what it proves, not what it is. "Still listed, still
+redirecting, counting down to the day it stops" is a review; "Domains page"
+is a filename.
+
 ## 5. Wait for CI
 
 Seven checks: `static`, `unit`, `react-doctor`, `React Doctor`, `e2e (1..3)`.

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -111,34 +111,46 @@ an invite form still offered in an org the server would refuse an invite
 from, which every test had passed straight over because no test asks "would a
 person be offered this".
 
-Capture them by driving the real app, never by mocking a state.
+**Shoot the seed data, not data you invented for the shot.** `bun run
+db:seed:local` builds 60 orgs with real names, 90 days of clicks and a few
+orgs already mid-downgrade. A capture script that makes up its own rows gives
+you four links called "Spring campaign 31" and every chart reading zero,
+which shows nothing about how the screen looks in a populated account. It
+also means the screenshots exercise the seeder: doing this for #165 turned up
+a wipe that missed a table, a seeded state that never occurred, and a
+migration that had never been applied to the dev database at all. If the
+feature has a state the seeder cannot produce, add it there rather than
+faking it in the capture.
 
-`bunx agent-browser` is the tool for looking at a page you can already reach,
-and it is what AGENTS.md means by visual verification: `open`, `snapshot`,
-`screenshot`, `eval`, against the running dev server. Use it for a single
-screen, a spot check, a "does this actually render" question.
+That decides the tool, too. A seeded user is already verified and shares one
+password, so `bunx agent-browser` can just sign in:
 
-It is the wrong tool for a state that takes a sign-up to reach. Driving the
-signup, the emailed 6-digit code, an invite accepted in a second browser and a
-plan change through a CLI is a long chain of `click`/`type` where refs go
-stale on every re-render and typing into a react-hook-form field silently
-lands nowhere. For those, write a throwaway `tests/e2e/zz-shots.pw.ts` that
-reuses the helpers in `tests/e2e/orgs.ts` to build each state, then
-`page.screenshot()`. Delete it once the images are out; it is a capture
-script, not a check.
+```sh
+bunx agent-browser set viewport 1280 900
+bunx agent-browser open https://rdyrct.localhost/login
+bunx agent-browser eval "localStorage.setItem('rdyrct:consent:v2','granted')"
+bunx agent-browser fill 'input[type="email"]' someone@seed.test
+bunx agent-browser fill 'input[type="password"]' seed-password-123
+bunx agent-browser click 'button[type="submit"]'
+bunx agent-browser open https://rdyrct.localhost/members
+bunx agent-browser screenshot shots/members.png
+```
 
-Either way, four things that cost a retake each:
+Use CSS selectors, not the `@ref` handles from `snapshot`: refs go stale on
+every re-render, and a stale one fails silently. Reach for a throwaway
+`tests/e2e/zz-shots.pw.ts` (reusing the helpers in `tests/e2e/orgs.ts`) only
+for a state the seeder cannot reach, since driving a signup and its emailed
+code through the CLI is where agent-browser stops paying off. Delete it once
+the images are out; it is a capture script, not a check.
 
-- Dismiss the consent banner first (it covers the bottom-right of every page),
-  and rename the seeded org and users, or every shot carries
-  `shots-1787481680744's links` where a name should be.
-- `test.use({ viewport: { width: 1280, height: 900 } })`. Take the shot on the
-  screen that shows the change, not the prettiest one.
-- Menus and dialogs fade in. Wait, and pass `animations: "disabled"`, or the
-  shot catches them half transparent.
-- Seeding rows straight into D1 beats clicking 34 links into existence, but
-  `rawSql` binds through the dev Explorer, which caps a statement at 100
-  parameters. Chunk the inserts.
+Either way, three things that cost a retake each:
+
+- The consent banner covers the bottom-right of every page. Clear it through
+  `localStorage`, not by clicking, which is one less thing to go stale.
+- 1280x900, and take the shot on the screen that shows the change, not the
+  prettiest one.
+- Menus and dialogs fade in. Wait for them, and in Playwright pass
+  `animations: "disabled"`, or the shot catches them half transparent.
 
 **Host them in R2, never in the repo and never in a side branch.** Both put
 binaries in git history for a comment, and pushing an orphan branch to serve

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -28,9 +28,29 @@ Read the issue, then read the code it names. Two things to establish:
 Say so plainly if either answer is no, then do the right thing and explain
 why in the PR body. Do not silently ship something different.
 
-## 2. Branch
+## 2. Branch, and take several issues at once
 
 Off `main`, always. `main` is protected and direct pushes bypass review.
+
+**Prefer a batch of related issues to one branch per issue.** One branch, one
+PR, one review, one CI run. #153 closed #103, #104 and #137 together and read
+better for it: the reviewer saw the whole shape of the change instead of three
+diffs that each looked arbitrary.
+
+Group by what a reviewer would want to read in one sitting:
+
+- The same area of the code, so the context is loaded once.
+- A chain where each issue depends on the last, so splitting them would mean
+  merging something unusable on its own.
+- A pile of small ones, none of which justifies its own review.
+
+Split when the batch stops being reviewable: unrelated areas, a diff nobody
+can hold in their head, or one risky change that should be revertable on its
+own. A migration or anything touching auth or billing is worth isolating, so
+a revert does not take four unrelated fixes with it.
+
+Name the branch for the theme, not the issue numbers, and list every issue the
+PR closes in the body.
 
 ## 3. Implement
 
@@ -58,12 +78,26 @@ Do this for anything with a branch worth having: a security check, a cap, a
 race guard. It is the difference between "the suite is green" and "this test
 would catch a regression".
 
-## 4. Open the PR
+## 4. Open the PR, once, when it is finished
+
+**Opening the PR is what asks for the review, so only open when you want to be
+reviewed.** Every issue in the batch done, every test written, `bun run
+verify` and `bun run fallow` green locally. Work on the branch as long as you
+need; push nothing to a PR until the branch is the thing you would merge.
+
+A PR opened early gets reviewed against a half-finished diff. That review is
+worse than useless: it reports things you were about to fix, it costs a real
+review (they are rate limited, and running out is how a PR ends up looking
+reviewed when it was not, see step 6), and the findings you then have to sort
+through are noise you created.
+
+No draft PRs as a workaround either. A draft still burns the review and still
+produces comments to triage.
 
 The body carries the reasoning, not just the change. What was wrong, why this
 fix, what was deliberately not done, and what a reviewer should know at
 release (a route rename means anyone on the old bundle gets errors until they
-reload).
+reload). List every issue it closes.
 
 ## 5. Wait for CI
 

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -126,6 +126,9 @@ lands nowhere. For those, write a throwaway `tests/e2e/zz-shots.pw.ts` that
 reuses the helpers in `tests/e2e/orgs.ts` to build each state, then
 `page.screenshot()`. Delete it once the images are out; it is a capture
 script, not a check.
+
+Either way, four things that cost a retake each:
+
 - Dismiss the consent banner first (it covers the bottom-right of every page),
   and rename the seeded org and users, or every shot carries
   `shots-1787481680744's links` where a name should be.
@@ -150,8 +153,8 @@ They serve from `https://cdn.brnr.dev/github/rdyrct/pr-<n>/<name>.png`. Check
 one with `curl -o /dev/null -w '%{http_code}'` before writing the comment,
 then check GitHub proxied them after: it rewrites external images through
 camo, so `gh api repos/<owner>/<repo>/issues/comments/<id> -H "Accept:
-application/vnd.github.html+json"` should show six `<img>` tags and each camo
-URL should return `image/png`. A broken image reads as a broken feature.
+application/vnd.github.html+json"` should show one `<img>` per image and each
+camo URL should return `image/png`. A broken image reads as a broken feature.
 
 Caption each one with what it proves, not what it is. "Still listed, still
 redirecting, counting down to the day it stops" is a review; "Domains page"

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -111,16 +111,31 @@ an invite form still offered in an org the server would refuse an invite
 from, which every test had passed straight over because no test asks "would a
 person be offered this".
 
-Capture them by driving the real app, never by mocking a state:
+Capture them by driving the real app, never by mocking a state.
 
-- A throwaway `tests/e2e/zz-shots.pw.ts` that reuses the helpers in
-  `tests/e2e/orgs.ts` to build each state, then `page.screenshot()`. Delete it
-  once the images are out; it is a capture script, not a check.
+`bunx agent-browser` is the tool for looking at a page you can already reach,
+and it is what AGENTS.md means by visual verification: `open`, `snapshot`,
+`screenshot`, `eval`, against the running dev server. Use it for a single
+screen, a spot check, a "does this actually render" question.
+
+It is the wrong tool for a state that takes a sign-up to reach. Driving the
+signup, the emailed 6-digit code, an invite accepted in a second browser and a
+plan change through a CLI is a long chain of `click`/`type` where refs go
+stale on every re-render and typing into a react-hook-form field silently
+lands nowhere. For those, write a throwaway `tests/e2e/zz-shots.pw.ts` that
+reuses the helpers in `tests/e2e/orgs.ts` to build each state, then
+`page.screenshot()`. Delete it once the images are out; it is a capture
+script, not a check.
 - Dismiss the consent banner first (it covers the bottom-right of every page),
   and rename the seeded org and users, or every shot carries
   `shots-1787481680744's links` where a name should be.
 - `test.use({ viewport: { width: 1280, height: 900 } })`. Take the shot on the
   screen that shows the change, not the prettiest one.
+- Menus and dialogs fade in. Wait, and pass `animations: "disabled"`, or the
+  shot catches them half transparent.
+- Seeding rows straight into D1 beats clicking 34 links into existence, but
+  `rawSql` binds through the dev Explorer, which caps a statement at 100
+  parameters. Chunk the inserts.
 
 **Host them in R2, never in the repo and never in a side branch.** Both put
 binaries in git history for a comment, and pushing an orphan branch to serve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,26 @@ analyticsDays }`). Slugs on the **shared** domain are always random (every
   no org left (it deleted the only one), and `/billing` still works org-less,
   so landing paid CTAs (`/signup?next=/billing?plan=…`) can check out before
   the first org exists (`/onboarding` redirects to `/dashboard`).
+- **A downgrade never deletes** (#29). Every plan change runs
+  `reconcileUser()` (`src/worker/reconcile.ts`): from the Polar webhook, from
+  an admin comp grant or revoke, and by hand from
+  `POST /api/admin/users/:id/reconcile`. It records what is over cap in
+  `org_entitlements` and marks the resources beyond it, and the marks are
+  what everything else reads: `orgs.locked_at` makes an org read-only in
+  `requireOrgRole` (its links keep redirecting), `domains.locked_at` plus
+  the org's `grace_ends_at` become `servesUntil` in the domain's KV value so
+  the redirect path enforces the 30 days with no D1 read, and
+  `org_members.previous_role` is what an upgrade reads to put demoted members
+  back. Idempotent: every decision is recomputed from live rows, and the
+  grace period only restarts when the plan the last pass compared against is
+  not the plan this one sees. The owner picks which org stays active
+  (`POST /orgs/:orgId/keep-active`) and who keeps write access (the member
+  role PATCH); reconciliation defaults to longest-standing so an owner who
+  ignores both still has a working account. Two emails, day 0 from the pass
+  and day 23 from the daily cron (`sweepGraceWarnings`). The UI says all of
+  it through one `OverLimitBanner` and one `LockedPanel`
+  (`src/app/components/over-limit.tsx`): use those rather than inventing a
+  fourth way to say "this is over your plan".
 - **Auth**: BetterAuth (email+password, `requireEmailVerification` via the
   `emailOTP` plugin, 6-digit code; password reset stays a link). PBKDF2/WebCrypto
   hashing (`src/worker/password.ts`). The account matching the `SUPERADMIN_EMAIL`
@@ -267,7 +287,7 @@ migrations/            D1 schema (numbered SQL migrations, applied in order)
 scripts/               Local dev utilities (e.g. seed-local.ts)
 src/worker/            Hono API, BetterAuth, KV publishing, redirect hot path
   routes/              auth (user), orgs, links, qr-logos, domains, billing, admin
-  better-auth.ts plan.ts util.ts guards.ts org-role.ts rate-limit.ts session.ts
+  better-auth.ts plan.ts reconcile.ts util.ts guards.ts org-role.ts rate-limit.ts session.ts
   email.ts password.ts kv.ts storage.ts sentry.ts clicks.ts workflows.ts
 src/shared/types.ts    DTOs + PLAN_LIMITS (shared worker ↔ app)
 src/app/               React SPA

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -5,11 +5,6 @@
         "count": 1
       }
     },
-    "src/app/components/charts.tsx": {
-      "crap_moderate": {
-        "count": 2
-      }
-    },
     "src/app/components/country-map.tsx": {
       "crap_high": {
         "count": 1
@@ -29,6 +24,11 @@
       }
     },
     "src/app/components/links-table.tsx": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "src/app/components/over-limit.tsx": {
       "crap_moderate": {
         "count": 1
       }
@@ -75,7 +75,7 @@
       }
     },
     "src/app/routes/analytics.tsx": {
-      "crap_high": {
+      "crap_critical": {
         "count": 1
       }
     },
@@ -84,10 +84,10 @@
         "count": 1
       },
       "crap_high": {
-        "count": 2
+        "count": 1
       },
       "crap_moderate": {
-        "count": 2
+        "count": 3
       }
     },
     "src/app/routes/billing.tsx": {
@@ -106,10 +106,13 @@
     },
     "src/app/routes/dashboard.tsx": {
       "crap_moderate": {
-        "count": 2
+        "count": 3
       }
     },
     "src/app/routes/domains.tsx": {
+      "crap_high": {
+        "count": 2
+      },
       "crap_moderate": {
         "count": 2
       }
@@ -120,6 +123,9 @@
       }
     },
     "src/app/routes/links.tsx": {
+      "crap_high": {
+        "count": 2
+      },
       "crap_moderate": {
         "count": 3
       }
@@ -144,6 +150,11 @@
         "count": 1
       }
     },
+    "src/worker/index.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
     "src/worker/routes/admin.ts": {
       "crap_moderate": {
         "count": 1
@@ -158,12 +169,13 @@
       "crap_moderate": {
         "count": 1
       }
+    },
+    "src/worker/storage.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
     }
   },
   "runtime_coverage_findings": [],
-  "target_keys": [
-    "src/app/lib/current-org.ts:high impact",
-    "src/app/lib/theme.ts:high impact",
-    "src/app/lib/use-shake.ts:high impact"
-  ]
+  "target_keys": ["src/app/lib/current-org.ts:high impact", "src/app/lib/use-shake.ts:high impact"]
 }

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -28,18 +28,13 @@
         "count": 1
       }
     },
-    "src/app/components/over-limit.tsx": {
-      "crap_moderate": {
-        "count": 1
-      }
-    },
     "src/app/components/qr-color-field.tsx": {
       "crap_moderate": {
         "count": 1
       }
     },
     "src/app/components/qr-defaults-card.tsx": {
-      "crap_moderate": {
+      "crap_critical": {
         "count": 1
       }
     },
@@ -110,8 +105,11 @@
       }
     },
     "src/app/routes/domains.tsx": {
+      "crap_critical": {
+        "count": 1
+      },
       "crap_high": {
-        "count": 2
+        "count": 1
       },
       "crap_moderate": {
         "count": 2

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,5 +6,14 @@ pre-commit:
     # (lint, react-doctor) runs in CI, where nobody can pass --no-verify.
     - name: format
       glob: "*.{cjs,cts,css,html,js,json,jsonc,jsx,md,mjs,mts,ts,tsx}"
+      # Same paths oxfmt ignores (.oxfmtrc.json). Without them a commit that
+      # touches only a skill file hands oxfmt a list it must ignore entirely,
+      # and it exits 2 on "no target files": the one job that repairs instead
+      # of complaining would block a commit it has nothing to do with. Keep
+      # the two lists in step.
+      exclude:
+        - ".agents/skills/**"
+        - ".claude/skills/**"
+        - ".oxlint/anti-slop/**"
       run: bunx oxfmt --write {staged_files}
       stage_fixed: true

--- a/migrations/0024_add_viewer_role.sql
+++ b/migrations/0024_add_viewer_role.sql
@@ -1,0 +1,45 @@
+-- Migration 0024: a fourth org role, `viewer`, that reads everything and
+-- writes nothing (#157).
+--
+-- Both `role` columns carry a CHECK constraint, and SQLite cannot alter one,
+-- so both tables are rebuilt. This follows 0003 (which rebuilt `domains`)
+-- rather than 0008's rename-column trick, because 0008's warning is about
+-- dropping a *parent* table: `DROP TABLE user` fires an implicit DELETE that
+-- cascades into session/account/org_members. `org_members` and `invites` are
+-- children only, referenced by nothing, so dropping them cascades nowhere.
+
+DROP INDEX IF EXISTS idx_org_members_user;
+
+CREATE TABLE org_members_new (
+  org_id TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'member', 'viewer')),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (org_id, user_id)
+);
+
+INSERT INTO org_members_new (org_id, user_id, role, created_at)
+  SELECT org_id, user_id, role, created_at FROM org_members;
+
+DROP TABLE org_members;
+ALTER TABLE org_members_new RENAME TO org_members;
+CREATE INDEX idx_org_members_user ON org_members(user_id);
+
+DROP INDEX IF EXISTS idx_invites_org;
+
+CREATE TABLE invites_new (
+  token TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK (role IN ('admin', 'member', 'viewer')),
+  email TEXT,
+  created_by TEXT REFERENCES user(id) ON DELETE SET NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+
+INSERT INTO invites_new (token, org_id, role, email, created_by, created_at, expires_at)
+  SELECT token, org_id, role, email, created_by, created_at, expires_at FROM invites;
+
+DROP TABLE invites;
+ALTER TABLE invites_new RENAME TO invites;
+CREATE INDEX idx_invites_org ON invites(org_id);

--- a/migrations/0025_entitlement_reconciliation.sql
+++ b/migrations/0025_entitlement_reconciliation.sql
@@ -1,0 +1,41 @@
+-- Migration 0025: what a downgrade did to an org, written down (#158).
+--
+-- One row per org that has ever been reconciled. `over_json` is what was over
+-- cap when the pass last ran, `grace_ends_at` is when the 30 days run out for
+-- the resources that keep working through it (custom domains, #159). Both are
+-- cleared when the org is back inside its plan, so a row with a null
+-- `grace_ends_at` and an empty `over_json` means "fine", not "never checked".
+--
+-- The marker columns live on the resources themselves rather than in here:
+-- one lookup, in the place every reader already has in hand.
+
+CREATE TABLE org_entitlements (
+  org_id TEXT PRIMARY KEY REFERENCES orgs(id) ON DELETE CASCADE,
+  -- The owner's plan the last pass compared against.
+  plan TEXT NOT NULL,
+  -- {"links":500,"members":25,"domains":5} — only the resources over cap.
+  over_json TEXT NOT NULL DEFAULT '{}',
+  -- Epoch ms the grace period ends; null while nothing is over.
+  grace_ends_at INTEGER,
+  reconciled_at INTEGER NOT NULL,
+  -- Epoch ms the day-0 and day-23 emails went out, for the grace period
+  -- `grace_ends_at` describes. Cleared with it.
+  notified_at INTEGER,
+  warned_at INTEGER
+);
+
+-- The daily cron reads this to find graces about to run out.
+CREATE INDEX idx_org_entitlements_grace ON org_entitlements(grace_ends_at);
+
+-- Which org the owner keeps active when they own more than their plan allows
+-- (#160). Null means active. A locked org is read-only and still counts
+-- against the cap.
+ALTER TABLE orgs ADD COLUMN locked_at INTEGER;
+
+-- A domain beyond the plan's `domains` cap (#159). Still serving until the
+-- org's grace ends, then not; never deleted.
+ALTER TABLE domains ADD COLUMN locked_at INTEGER;
+
+-- What this member was before a downgrade demoted them to viewer (#161), so
+-- re-upgrading puts them back. Null means they were never demoted.
+ALTER TABLE org_members ADD COLUMN previous_role TEXT;

--- a/scripts/seed-local.ts
+++ b/scripts/seed-local.ts
@@ -13,7 +13,7 @@
  */
 
 import { ALIAS_TTL_MS } from "../src/worker/util";
-import type { JsonValue } from "../src/shared/types";
+import { PLAN_LIMITS, type JsonValue, type OverLimits } from "../src/shared/types";
 
 const API = "https://rdyrct.localhost/cdn-cgi/explorer/api";
 const PASSWORD = "seed-password-123";
@@ -394,6 +394,7 @@ async function wipe(): Promise<number> {
     "DELETE FROM links WHERE domain_id IN (SELECT id FROM domains WHERE id LIKE 'seed-%')",
     "DELETE FROM domains WHERE id LIKE 'seed-%'",
     "DELETE FROM invites WHERE org_id LIKE 'seed-%'",
+    "DELETE FROM org_entitlements WHERE org_id LIKE 'seed-%'",
     "DELETE FROM org_members WHERE org_id LIKE 'seed-%'",
     "DELETE FROM orgs WHERE id LIKE 'seed-%'",
     "DELETE FROM session WHERE user_id LIKE 'seed-%'",
@@ -411,6 +412,15 @@ interface SeedUser {
   email: string;
   plan: "free" | "hobby" | "pro";
   createdAt: number;
+}
+
+interface SeedOrg {
+  id: string;
+  name: string;
+  plan: SeedUser["plan"];
+  ownerId: string;
+  createdAt: number;
+  domain: { id: string; hostname: string } | null;
 }
 
 async function seed() {
@@ -497,14 +507,6 @@ async function seed() {
   const memberCap = { free: 3, hobby: 5, pro: 25 } as const;
   const linkRange = { free: [6, 28], hobby: [30, 110], pro: [60, 220] } as const;
 
-  interface SeedOrg {
-    id: string;
-    name: string;
-    plan: SeedUser["plan"];
-    ownerId: string;
-    createdAt: number;
-    domain: { id: string; hostname: string } | null;
-  }
   const orgs: SeedOrg[] = [];
   const orgStatements: string[] = [];
   const orgCountries = new Map<string, (readonly [string, number])[]>();
@@ -824,6 +826,8 @@ async function seed() {
     console.log(`  clicks inserted: ${clicksInserted}/${clickValues.length}`);
   }
 
+  await seedDowngrades(orgs, now, day);
+
   /* summary */
   console.log("\nSeeded:");
   console.log(`  users:  ${users.length} (password for all: ${PASSWORD})`);
@@ -835,6 +839,97 @@ async function seed() {
     console.log(
       `  ${org.name.padEnd(16)} ${org.plan.padEnd(6)} ${owners[orgs.indexOf(org)].email}`,
     );
+}
+
+/**
+ * Puts a few orgs mid-downgrade (#29), so local dev and any screenshot taken
+ * from it show the state a plan change leaves behind.
+ *
+ * The marks are written directly, the same ones `reconcileUser` writes: this
+ * is a seeder, so it fabricates an end state rather than driving the pass
+ * that produces one. Keep it in step with `src/worker/reconcile.ts` if the
+ * rules there change.
+ *
+ * Deliberately a handful, not a sweep: the point is to have one of each state
+ * to look at, while the rest of the seeded data stays ordinary.
+ */
+async function seedDowngrades(orgs: SeedOrg[], now: number, day: number): Promise<void> {
+  // Paid orgs with a custom domain and the most people in them. Picking blind
+  // left every downgraded org with two members, so the demotion state, one of
+  // the four this is here to show, never appeared in a seeded database.
+  const withDomains = orgs.filter((o) => o.plan !== "free" && o.domain !== null);
+  if (!withDomains.length) return;
+  const memberCounts = new Map(
+    (
+      await sql<{ org_id: string; n: string }>(
+        "SELECT org_id, count(*) AS n FROM org_members WHERE org_id LIKE 'seed-%' GROUP BY org_id",
+      )
+    ).map((r) => [r.org_id, Number(r.n)]),
+  );
+  const candidates = withDomains
+    .sort((a, b) => (memberCounts.get(b.id) ?? 0) - (memberCounts.get(a.id) ?? 0))
+    .slice(0, 3);
+
+  const statements: string[] = [];
+  // The real caps, so this stays true if a plan changes.
+  const free = PLAN_LIMITS.free;
+
+  for (const [index, org] of candidates.entries()) {
+    // Staggered, so the countdown reads differently on each: one just
+    // downgraded, one with a week left, one already past its grace.
+    const graceEndsAt = now + [27 * day, 6 * day, -2 * day][index];
+
+    const [links, members] = await Promise.all([
+      sql<{ n: string }>(
+        `SELECT count(*) AS n FROM link_addresses WHERE org_id = ${q(org.id)} AND retired_at IS NULL AND kind IN ('primary','permanent_alias')`,
+      ),
+      sql<{ user_id: string; role: string }>(
+        `SELECT user_id, role FROM org_members WHERE org_id = ${q(org.id)} ORDER BY created_at, user_id`,
+      ),
+    ]);
+    const linkCount = Number(links[0]?.n ?? 0);
+
+    const over: OverLimits = { domains: 1 };
+    if (linkCount > free.links) over.links = linkCount;
+    if (members.length > free.members) over.members = members.length;
+
+    statements.push(`UPDATE user SET plan = 'free' WHERE id = ${q(org.ownerId)}`);
+    statements.push(
+      `UPDATE domains SET locked_at = ${now} WHERE org_id = ${q(org.id)}`,
+      `INSERT INTO org_entitlements (org_id, plan, over_json, grace_ends_at, reconciled_at, notified_at)
+       VALUES (${q(org.id)}, 'free', ${q(JSON.stringify(over))}, ${graceEndsAt}, ${now}, ${now})`,
+    );
+
+    // Longest-standing keep their role, owner exempt; the rest become viewers
+    // with what they were recorded, exactly as the pass does it.
+    const keep = new Set(members.slice(0, free.members).map((m) => m.user_id));
+    for (const member of members) {
+      if (keep.has(member.user_id) || member.role === "owner" || member.role === "viewer") continue;
+      statements.push(
+        `UPDATE org_members SET role = 'viewer', previous_role = ${q(member.role)}
+         WHERE org_id = ${q(org.id)} AND user_id = ${q(member.user_id)}`,
+      );
+    }
+
+    // The redirect path reads the deadline off KV and never touches D1, so a
+    // seeded lock that skipped this would keep serving forever.
+    await kvPut(`domain:${org.domain!.hostname}`, {
+      domainId: org.domain!.id,
+      orgId: org.id,
+      rootRedirect: "",
+      servesUntil: graceEndsAt,
+    });
+  }
+
+  // One owner over the owned-org cap, so the locked-org state exists too.
+  const extraOrgId = uid();
+  statements.push(
+    `INSERT INTO orgs (id, name, created_at, locked_at) VALUES (${q(extraOrgId)}, ${q(`${candidates[0].name} Labs`)}, ${now - 30 * day}, ${now})`,
+    `INSERT INTO org_members (org_id, user_id, role, created_at) VALUES (${q(extraOrgId)}, ${q(candidates[0].ownerId)}, 'owner', ${now - 30 * day})`,
+  );
+
+  await sqlBatch(statements);
+  console.log(`  downgraded: ${candidates.length} orgs, 1 locked org`);
 }
 
 /* ---------------- main ---------------- */

--- a/scripts/seed-local.ts
+++ b/scripts/seed-local.ts
@@ -896,6 +896,17 @@ async function seedDowngrades(orgs: SeedOrg[], now: number, day: number): Promis
     statements.push(`UPDATE user SET plan = 'free' WHERE id = ${q(org.ownerId)}`);
     statements.push(
       `UPDATE domains SET locked_at = ${now} WHERE org_id = ${q(org.id)}`,
+      // QR defaults set while the org was paying. They keep applying on free
+      // and only go read-only (#162), which is the whole point of that rule
+      // and a state nothing else here produced: the settings screen had no
+      // seeded org that could show it.
+      //
+      // Not 'rounded'/'extra-rounded': the built-in defaults are the empty
+      // string in this form, and the pickers leave them out of their options
+      // rather than listing each twice. Writing the names the app never
+      // writes gave the read-only pickers a value with no option to match,
+      // so they rendered blank under a preview that was visibly styled.
+      `UPDATE orgs SET qr_style = 'dots', qr_corner = 'dot', qr_color = '#7c5cff', qr_eye_color = '#2f1f5e' WHERE id = ${q(org.id)}`,
       `INSERT INTO org_entitlements (org_id, plan, over_json, grace_ends_at, reconciled_at, notified_at)
        VALUES (${q(org.id)}, 'free', ${q(JSON.stringify(over))}, ${graceEndsAt}, ${now}, ${now})`,
     );

--- a/src/app/components/link-editor.tsx
+++ b/src/app/components/link-editor.tsx
@@ -13,6 +13,7 @@ import { Lock, Info } from "lucide-react";
 import { shortUrl } from "../lib/api";
 import { QR_CORNER_STYLES, QR_DOT_STYLES, type DomainDTO, type LinkInput } from "@/shared/types";
 import { Button } from "../ui/button";
+import { buttonClass } from "../ui/button-class";
 import { cn } from "../ui/cn";
 import { Dialog } from "../ui/dialog";
 import { Field, Input } from "../ui/field";
@@ -62,23 +63,13 @@ const QR_OVERRIDE_FIELDS = [
   "qrLogoSize",
 ] as const;
 
-/**
- * Clears a link's QR overrides when the plan no longer allows them.
- *
- * An organization that downgrades keeps whatever its links already had, and
- * the editor loads those values whether or not it draws the controls for
- * them. Submitted, the server answers 402 and the whole save fails: somebody
- * on Free could not fix a typo in a title, and the message they got talked
- * about QR codes. Sending the fields back as empty is also what the hidden
- * controls imply, so the save does what the dialog looks like it will do.
- */
-function withoutQrOverrides(data: LinkInput): LinkInput {
-  const cleared = { ...data };
-  for (const field of QR_OVERRIDE_FIELDS) {
-    if (field === "qrLogoSize") cleared.qrLogoSize = null;
-    else cleared[field] = "";
-  }
-  return cleared;
+/** Whether this link already carries a QR look of its own, so the editor can
+ * say it is kept and locked rather than showing an upsell for a feature the
+ * link is visibly using (#162). */
+function hasQrOverrides(data: LinkInput): boolean {
+  return QR_OVERRIDE_FIELDS.some((field) =>
+    field === "qrLogoSize" ? data.qrLogoSize != null : !!data[field],
+  );
 }
 
 const UTM_FIELDS: { key: UtmKey; label: string; placeholder: string }[] = [
@@ -343,7 +334,15 @@ function QrLogoField({ form, setForm }: { form: LinkInput; setForm: (f: LinkInpu
 /** Stands where the customization controls would be on a paid plan. The QR
  * itself is already on screen beside it, so this asks for the upgrade the
  * visitor can see the point of, rather than blocking the feature. */
-function QrCustomizationUpsell({ className }: { className?: string }) {
+/**
+ * What sits where the QR controls would be on a plan without `qrCustom`.
+ *
+ * Two different sentences, because they are two different situations. A link
+ * with no styling is being offered a feature. A link that already has some,
+ * on an org that downgraded, is keeping it: saying "add your logo on a paid
+ * plan" to somebody whose logo is right there in the preview reads as a bug.
+ */
+function QrCustomizationUpsell({ locked, className }: { locked?: boolean; className?: string }) {
   return (
     <div
       className={cn(
@@ -353,14 +352,14 @@ function QrCustomizationUpsell({ className }: { className?: string }) {
     >
       <div className="flex items-start gap-2">
         <Lock size={14} className="mt-0.5 shrink-0 text-muted" />
-        <p className="text-xs text-muted">
-          Add your logo, colors, and dot shapes to this QR on a paid plan.
+        <p className="max-w-prose text-xs text-muted">
+          {locked
+            ? "This QR keeps the look it already has, and still downloads that way. Changing it needs a paid plan."
+            : "Add your logo, colors, and dot shapes to this QR on a paid plan."}
         </p>
       </div>
-      <RouterLink to="/billing" className="shrink-0">
-        <Button variant="outline" size="sm">
-          See plans
-        </Button>
+      <RouterLink to="/billing" className={buttonClass({ variant: "outline", size: "sm" })}>
+        See plans
       </RouterLink>
     </div>
   );
@@ -579,7 +578,10 @@ export function LinkEditor({
   shakeKey: number;
 }) {
   const editing = editingLink != null;
-  const save = (data: LinkInput) => onSave(qrCustomEnabled ? data : withoutQrOverrides(data));
+  // Sends what it loaded. Clearing the QR fields on a plan without qrCustom
+  // was how a title edit silently destroyed a link's logo and colours (#162);
+  // the server now only refuses a save that *changes* them.
+  const save = (data: LinkInput) => onSave(data);
   const toast = useToast();
   const shake = useShake();
   const destinationRef = useRef<HTMLInputElement>(null);
@@ -678,7 +680,7 @@ export function LinkEditor({
         {qrCustomEnabled ? (
           <QrCustomization form={form} setForm={setForm} orgQr={orgQr} className="sm:col-span-2" />
         ) : (
-          <QrCustomizationUpsell className="sm:col-span-2" />
+          <QrCustomizationUpsell locked={hasQrOverrides(form)} className="sm:col-span-2" />
         )}
       </form>
 

--- a/src/app/components/links-table.tsx
+++ b/src/app/components/links-table.tsx
@@ -35,6 +35,9 @@ interface RowActions {
   navigate: (to: string) => void;
   onQrClick: (link: LinkDTO) => void;
   onEdit: (link: LinkDTO) => void;
+  /** False for a viewer, who may read every one of these rows and change
+   * none of them (#157). The analytics and QR entries stay: both are reads. */
+  canWrite: boolean;
   onDelete: (link: LinkDTO) => void;
   onCreateAlias: (link: LinkDTO) => void;
 }
@@ -99,7 +102,7 @@ function LinkCell({
 }
 
 function RowMenu({ link, actions }: { link: LinkDTO; actions: RowActions }) {
-  const { navigate, onQrClick, onEdit, onDelete, onCreateAlias } = actions;
+  const { navigate, onQrClick, onEdit, onDelete, onCreateAlias, canWrite } = actions;
   return (
     <Menu
       align="end"
@@ -118,16 +121,20 @@ function RowMenu({ link, actions }: { link: LinkDTO; actions: RowActions }) {
       <MenuItem onClick={() => onQrClick(link)}>
         <QrCode size={14} /> QR code
       </MenuItem>
-      <MenuItem onClick={() => onEdit(link)}>
-        <Pencil size={14} /> Edit
-      </MenuItem>
-      <MenuItem onClick={() => onCreateAlias(link)}>
-        <Link size={14} /> Create alias
-      </MenuItem>
-      <MenuSeparator />
-      <MenuItem className="text-danger" onClick={() => onDelete(link)}>
-        <Trash2 size={14} /> Delete
-      </MenuItem>
+      {canWrite && (
+        <>
+          <MenuItem onClick={() => onEdit(link)}>
+            <Pencil size={14} /> Edit
+          </MenuItem>
+          <MenuItem onClick={() => onCreateAlias(link)}>
+            <Link size={14} /> Create alias
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem className="text-danger" onClick={() => onDelete(link)}>
+            <Trash2 size={14} /> Delete
+          </MenuItem>
+        </>
+      )}
     </Menu>
   );
 }

--- a/src/app/components/member-dialogs.tsx
+++ b/src/app/components/member-dialogs.tsx
@@ -1,5 +1,5 @@
 import { type UseMutationResult } from "@tanstack/react-query";
-import { INVITABLE_ROLES } from "@/shared/types";
+import { INVITABLE_ROLES, type InvitableRole } from "@/shared/types";
 import { oneOf } from "@/shared/lookup";
 import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
@@ -46,8 +46,8 @@ export function InviteMemberDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  role: "member" | "admin";
-  onRoleChange: (role: "member" | "admin") => void;
+  role: InvitableRole;
+  onRoleChange: (role: InvitableRole) => void;
   onCreate: () => void;
   isCreating: boolean;
 }) {
@@ -63,6 +63,7 @@ export function InviteMemberDialog({
             value={role}
             onChange={(e) => onRoleChange(oneOf(INVITABLE_ROLES, e.target.value, "member"))}
           >
+            <option value="viewer">viewer · read only</option>
             <option value="member">member · manage links</option>
             <option value="admin">admin · manage links and team</option>
           </Select>

--- a/src/app/components/over-limit.tsx
+++ b/src/app/components/over-limit.tsx
@@ -27,7 +27,7 @@ import { BusyContent } from "../ui/spinner";
 import { useToast } from "../ui/toast";
 import { buttonClass } from "../ui/button-class";
 import { useCurrentOrg } from "../lib/current-org";
-import { graceLabel } from "../lib/grace";
+import { graceLabel, graceRunning } from "../lib/grace";
 import {
   OVER_LIMIT_KEYS,
   PLAN_LIMITS,
@@ -86,10 +86,7 @@ export function OverLimitBanner() {
     <Notice>
       <p className="text-sm">
         <strong className="font-semibold">{org.name}</strong> has {joinPhrases(org.over, org.plan)}.
-        Nothing was deleted.{" "}
-        {org.graceEndsAt !== null && org.over.domains !== undefined
-          ? `Your custom domains keep redirecting for now (${graceLabel(org.graceEndsAt)}).`
-          : "What is over the limit is read-only until you upgrade."}
+        Nothing was deleted. {overLimitAdvice(org)}
       </p>
       <BillingLink />
     </Notice>
@@ -122,22 +119,43 @@ function LockedOrgNotice({ org }: { org: UserOrg }) {
       <p className="max-w-prose text-sm">
         <strong className="font-semibold">{org.name}</strong> is locked, because your plan covers{" "}
         {onlyOne ? "one organization" : `${PLAN_LIMITS[org.plan].orgs} organizations`} and you own
-        more. Nothing was deleted and its links keep working. Upgrade to unlock every organization,
-        or use this one instead of the one that is active now.
+        more. Nothing was deleted and its links keep working.
+        {org.role === "owner"
+          ? " Upgrade to unlock every organization, or use this one instead of the one that is active now."
+          : " Its owner can upgrade, or make this the organization they keep active."}
       </p>
       <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={keepActive.isPending}
-          onClick={() => keepActive.mutate()}
-        >
-          <BusyContent busy={keepActive.isPending}>Use this one</BusyContent>
-        </Button>
+        {/* The route is owner-only, so anybody else gets a button whose one
+            outcome is a 403 toast. Everyone still sees the explanation. */}
+        {org.role === "owner" && (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={keepActive.isPending}
+            onClick={() => keepActive.mutate()}
+          >
+            <BusyContent busy={keepActive.isPending}>Use this one</BusyContent>
+          </Button>
+        )}
         <BillingLink label="Upgrade to Pro" />
       </div>
     </Notice>
   );
+}
+
+/**
+ * What to do about it, which differs by what is over.
+ *
+ * Over-cap links and members are not read-only: every link stays editable and
+ * deletable, and only *new* ones are blocked. Only the domains have a
+ * deadline, and only while it is still ahead.
+ */
+function overLimitAdvice(org: UserOrg): string {
+  if (org.over.domains !== undefined)
+    return graceRunning(org.graceEndsAt)
+      ? `Your custom domains keep redirecting until ${new Date(org.graceEndsAt!).toLocaleDateString()} (${graceLabel(org.graceEndsAt!)}), then they stop.`
+      : "Your custom domains have stopped redirecting. Upgrading brings them straight back.";
+  return "Everything you have keeps working. You can delete what you no longer need, or upgrade to keep it all.";
 }
 
 function joinPhrases(over: OverLimits, plan: OrgPlan): string {
@@ -182,8 +200,10 @@ export function LockedPanel({
       <p className="max-w-prose text-sm text-muted">{reason}</p>
       {until != null && (
         <p className="tnum max-w-prose text-sm text-muted">
-          It keeps working until {new Date(until).toLocaleDateString()} ({graceLabel(until)}), then
-          it stops. Nothing is deleted, and upgrading brings it back with no setup to redo.
+          {graceRunning(until)
+            ? `It keeps working until ${new Date(until).toLocaleDateString()} (${graceLabel(until)}), then it stops.`
+            : "It has stopped working."}{" "}
+          Nothing is deleted, and upgrading brings it back with no setup to redo.
         </p>
       )}
       <div>

--- a/src/app/components/over-limit.tsx
+++ b/src/app/components/over-limit.tsx
@@ -1,0 +1,194 @@
+/**
+ * One way of saying "this is over your plan", used everywhere it is true
+ * (#163).
+ *
+ * The product used to say nothing. The links page showed a bare `500 / 30
+ * links` with no explanation and no way out, error copy assumed you were *at*
+ * the cap rather than 500 past it, and a downgraded org's members, domains
+ * and analytics gave no signal at all. Three surfaces inventing three
+ * explanations is how a person ends up believing their data was deleted.
+ *
+ * So there are two components and one sentence-builder here, and every
+ * locked or over-limit screen uses them:
+ *
+ * - `OverLimitBanner`: one per org, at the top of the app, listing what is
+ *   over and what to do.
+ * - `LockedPanel`: what a frozen thing shows in place of its controls, with
+ *   the countdown when there is one.
+ */
+import type { ReactNode } from "react";
+import { Lock } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { HrefLink } from "../lib/router-search";
+import { errorMessage } from "@/app/lib/error-message";
+import { api } from "../lib/api";
+import { Button } from "../ui/button";
+import { BusyContent } from "../ui/spinner";
+import { useToast } from "../ui/toast";
+import { buttonClass } from "../ui/button-class";
+import { useCurrentOrg } from "../lib/current-org";
+import { graceLabel } from "../lib/grace";
+import {
+  OVER_LIMIT_KEYS,
+  PLAN_LIMITS,
+  isOverLimit,
+  type OverLimits,
+  type OrgPlan,
+  type UserOrg,
+} from "@/shared/types";
+
+/**
+ * How each resource reads when an org holds more of it than the plan allows.
+ *
+ * Both halves of each phrase are here on purpose: "500 links, and this plan
+ * allows 30" reads correctly whether you are one over or four hundred and
+ * seventy over, which the old "upgrade for more" copy did not.
+ */
+const OVER_COPY = {
+  links: (count: number, limit: number) => `${count} links, and this plan allows ${limit}`,
+  members: (count: number, limit: number) => `${count} members, and this plan allows ${limit}`,
+  domains: (count: number, limit: number) =>
+    limit === 0
+      ? `${count} custom ${count === 1 ? "domain" : "domains"}, and this plan has none`
+      : `${count} custom domains, and this plan allows ${limit}`,
+} satisfies Record<(typeof OVER_LIMIT_KEYS)[number], (count: number, limit: number) => string>;
+
+function overPhrases(over: OverLimits, plan: OrgPlan): string[] {
+  const limits = PLAN_LIMITS[plan];
+  return OVER_LIMIT_KEYS.flatMap((key) => {
+    const count = over[key];
+    return count === undefined ? [] : [OVER_COPY[key](count, limits[key])];
+  });
+}
+
+function BillingLink({ label = "See plans" }: { label?: string }) {
+  return (
+    <HrefLink href="/billing" className={buttonClass({ variant: "outline", size: "sm" })}>
+      {label}
+    </HrefLink>
+  );
+}
+
+/**
+ * The org-wide banner. Renders only when there is something to say, so every
+ * page can mount it unconditionally.
+ *
+ * Nothing here is a warning colour. The state is "you have more than you pay
+ * for", not "something broke", and painting it red would make an ordinary
+ * billing fact look like an outage.
+ */
+export function OverLimitBanner() {
+  const { org } = useCurrentOrg();
+  if (!org) return null;
+  if (org.locked) return <LockedOrgNotice org={org} />;
+  if (!isOverLimit(org.over)) return null;
+  return (
+    <Notice>
+      <p className="text-sm">
+        <strong className="font-semibold">{org.name}</strong> has {joinPhrases(org.over, org.plan)}.
+        Nothing was deleted.{" "}
+        {org.graceEndsAt !== null && org.over.domains !== undefined
+          ? `Your custom domains keep redirecting for now (${graceLabel(org.graceEndsAt)}).`
+          : "What is over the limit is read-only until you upgrade."}
+      </p>
+      <BillingLink />
+    </Notice>
+  );
+}
+
+/**
+ * A locked org, with the two ways out (#160): upgrade, or keep this one
+ * active instead of whichever org currently is.
+ *
+ * The second is a real choice, not a nag. Reconciliation defaults to the
+ * oldest org so an owner who ignores this still has a working account; this
+ * is how they say they meant a different one. It is reversible: the same
+ * button on the other org swaps them back.
+ */
+function LockedOrgNotice({ org }: { org: UserOrg }) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const keepActive = useMutation({
+    mutationFn: () => api(`/orgs/${org.id}/keep-active`, { method: "POST" }),
+    onSuccess: async () => {
+      await qc.refetchQueries({ queryKey: ["user"] });
+      toast(`${org.name} is active again`);
+    },
+    onError: (err) => toast(errorMessage(err), "error"),
+  });
+  const onlyOne = PLAN_LIMITS[org.plan].orgs === 1;
+  return (
+    <Notice>
+      <p className="max-w-prose text-sm">
+        <strong className="font-semibold">{org.name}</strong> is locked, because your plan covers{" "}
+        {onlyOne ? "one organization" : `${PLAN_LIMITS[org.plan].orgs} organizations`} and you own
+        more. Nothing was deleted and its links keep working. Upgrade to unlock every organization,
+        or use this one instead of the one that is active now.
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={keepActive.isPending}
+          onClick={() => keepActive.mutate()}
+        >
+          <BusyContent busy={keepActive.isPending}>Use this one</BusyContent>
+        </Button>
+        <BillingLink label="Upgrade to Pro" />
+      </div>
+    </Notice>
+  );
+}
+
+function joinPhrases(over: OverLimits, plan: OrgPlan): string {
+  const phrases = overPhrases(over, plan);
+  if (phrases.length <= 1) return phrases[0] ?? "";
+  return `${phrases.slice(0, -1).join("; ")}; and ${phrases[phrases.length - 1]}`;
+}
+
+function Notice({ children }: { children: ReactNode }) {
+  return (
+    <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-surface-2 px-4 py-3">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * What a locked thing shows instead of its controls: what it is, why it is
+ * locked, when it stops working if there is a deadline, and one way back.
+ *
+ * `until` is the end of the grace period, for the things that keep working
+ * through it (custom domains). Anything frozen at once leaves it out rather
+ * than showing a countdown to nothing.
+ */
+export function LockedPanel({
+  title,
+  reason,
+  until,
+  cta = "See plans",
+}: {
+  title: string;
+  reason: string;
+  until?: number | null;
+  cta?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface-2 px-4 py-4">
+      <div className="flex items-center gap-2">
+        <Lock size={15} className="text-muted" aria-hidden />
+        <h2 className="font-semibold">{title}</h2>
+      </div>
+      <p className="max-w-prose text-sm text-muted">{reason}</p>
+      {until != null && (
+        <p className="tnum max-w-prose text-sm text-muted">
+          It keeps working until {new Date(until).toLocaleDateString()} ({graceLabel(until)}), then
+          it stops. Nothing is deleted, and upgrading brings it back with no setup to redo.
+        </p>
+      )}
+      <div>
+        <BillingLink label={cta} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/qr-defaults-card.tsx
+++ b/src/app/components/qr-defaults-card.tsx
@@ -11,7 +11,7 @@ import { Card } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
 import { useToast } from "../ui/toast";
 import { QrColorAndLogoFields, QrPreviewSidebar, QrPatternFields } from "./qr-fields";
-import { type QrValues } from "../lib/qr-look";
+import { hasAnyQrValue, type QrValues } from "../lib/qr-look";
 import { orgQrFrom } from "../lib/org-qr";
 import { canAdminOrg } from "../lib/org-limits";
 import posthog from "../lib/posthog";
@@ -88,8 +88,8 @@ function UpgradeQrPrompt({ locked }: { locked: boolean }) {
   return (
     <p className="max-w-prose text-sm text-muted">
       {locked
-        ? "These defaults still apply to every QR this organization generates. Changing them is a paid feature. "
-        : "QR customization is a paid feature. "}
+        ? "These defaults still apply to every QR code this organization makes. Changing them needs a paid plan. "
+        : "Changing how QR codes look needs a paid plan. "}
       <Link to="/billing" className="text-accent hover:underline">
         Upgrade
       </Link>{" "}
@@ -120,17 +120,6 @@ function SaveQrDefaultsAction({
     </div>
   );
 }
-
-/** The org-level QR fields, for asking whether any of them is set. */
-const QR_DEFAULT_FIELDS = [
-  "qrLogo",
-  "qrStyle",
-  "qrColor",
-  "qrCorner",
-  "qrBg",
-  "qrEyeColor",
-  "qrLogoSize",
-] as const;
 
 /** The editor grid, or the same grid read-only on a plan that kept its
  * defaults but may no longer change them (#162). */
@@ -179,9 +168,7 @@ export function QrDefaultsCard() {
   // Defaults the org already set, which keep applying on a plan that no
   // longer allows new ones: shown, read-only, rather than replaced by an
   // upsell for the feature they are visibly using (#162).
-  const hasQrDefaults = QR_DEFAULT_FIELDS.some((field) =>
-    field === "qrLogoSize" ? values.qrLogoSize != null : !!values[field],
-  );
+  const hasQrDefaults = hasAnyQrValue(values);
   const canEdit = isAdmin && hasQrCustom;
 
   return (

--- a/src/app/components/qr-defaults-card.tsx
+++ b/src/app/components/qr-defaults-card.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCurrentUser } from "../lib/hooks";
 import { useCurrentOrg } from "../lib/current-org";
 import { api, shortUrl } from "../lib/api";
-import { PLAN_LIMITS } from "@/shared/types";
+import { type OrgRole, PLAN_LIMITS } from "@/shared/types";
 import { Button } from "../ui/button";
 import { Card } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
@@ -75,10 +75,7 @@ function useQrDefaultsForm(
 }
 
 /** Owner/admin (or platform admin) can edit; everyone else can only view. */
-function canManageQrDefaults(
-  isPlatformAdmin: boolean | undefined,
-  role: "owner" | "admin" | "member" | undefined,
-) {
+function canManageQrDefaults(isPlatformAdmin: boolean | undefined, role: OrgRole | undefined) {
   return !!isPlatformAdmin || role === "owner" || role === "admin";
 }
 

--- a/src/app/components/qr-defaults-card.tsx
+++ b/src/app/components/qr-defaults-card.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCurrentUser } from "../lib/hooks";
 import { useCurrentOrg } from "../lib/current-org";
 import { api, shortUrl } from "../lib/api";
-import { type OrgRole, PLAN_LIMITS } from "@/shared/types";
+import { PLAN_LIMITS } from "@/shared/types";
 import { Button } from "../ui/button";
 import { Card } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
@@ -13,6 +13,7 @@ import { useToast } from "../ui/toast";
 import { QrColorAndLogoFields, QrPreviewSidebar, QrPatternFields } from "./qr-fields";
 import { type QrValues } from "../lib/qr-look";
 import { orgQrFrom } from "../lib/org-qr";
+import { canAdminOrg } from "../lib/org-limits";
 import posthog from "../lib/posthog";
 
 type QrDefaultsValues = QrValues;
@@ -74,19 +75,25 @@ function useQrDefaultsForm(
   return { values, setField, savingQr, save };
 }
 
-/** Owner/admin (or platform admin) can edit; everyone else can only view. */
-function canManageQrDefaults(isPlatformAdmin: boolean | undefined, role: OrgRole | undefined) {
-  return !!isPlatformAdmin || role === "owner" || role === "admin";
-}
-
-function UpgradeQrPrompt() {
+/**
+ * What sits here on a plan without `qrCustom`.
+ *
+ * Two sentences, because they are two situations (#162). An org with no
+ * defaults is being offered a feature. An org that already set some, and
+ * downgraded, is keeping them: they still apply to every QR the org
+ * generates, so telling that org to "upgrade to put your logo on every QR
+ * code" describes the state it is already in.
+ */
+function UpgradeQrPrompt({ locked }: { locked: boolean }) {
   return (
-    <p className="text-sm text-muted">
-      QR customization is a paid feature.{" "}
+    <p className="max-w-prose text-sm text-muted">
+      {locked
+        ? "These defaults still apply to every QR this organization generates. Changing them is a paid feature. "
+        : "QR customization is a paid feature. "}
       <Link to="/billing" className="text-accent hover:underline">
         Upgrade
       </Link>{" "}
-      to put your logo and style on every QR code.
+      {locked ? "to edit them again." : "to put your logo and style on every QR code."}
     </p>
   );
 }
@@ -114,14 +121,68 @@ function SaveQrDefaultsAction({
   );
 }
 
+/** The org-level QR fields, for asking whether any of them is set. */
+const QR_DEFAULT_FIELDS = [
+  "qrLogo",
+  "qrStyle",
+  "qrColor",
+  "qrCorner",
+  "qrBg",
+  "qrEyeColor",
+  "qrLogoSize",
+] as const;
+
+/** The editor grid, or the same grid read-only on a plan that kept its
+ * defaults but may no longer change them (#162). */
+function QrDefaultsFields({
+  values,
+  setField,
+  canEdit,
+  savingQr,
+  save,
+}: {
+  values: QrDefaultsValues;
+  setField: ReturnType<typeof useQrDefaultsForm>["setField"];
+  canEdit: boolean;
+  savingQr: boolean;
+  save: () => void;
+}) {
+  return (
+    <div className="grid gap-6 sm:grid-cols-[1fr_auto]">
+      <QrPatternFields values={values} setField={setField} isAdmin={canEdit} />
+      <div className="order-last sm:order-none">
+        <QrPreviewSidebar values={values} url={shortUrl("preview")} />
+      </div>
+      <QrColorAndLogoFields
+        values={values}
+        setField={setField}
+        isAdmin={canEdit}
+        className="sm:col-span-2"
+      />
+      {canEdit && (
+        <div className="sm:col-span-2">
+          <SaveQrDefaultsAction isAdmin={canEdit} savingQr={savingQr} save={save} />
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function QrDefaultsCard() {
   const { org } = useCurrentOrg();
   const orgId = org?.id ?? "";
   const currentUser = useCurrentUser();
-  const isAdmin = canManageQrDefaults(currentUser.data?.user.isAdmin, org?.role);
+  const isAdmin = canAdminOrg(currentUser.data?.user.isAdmin, org?.role, org?.locked);
   const hasQrCustom = org ? PLAN_LIMITS[org.plan].qrCustom : false;
 
   const { values, setField, savingQr, save } = useQrDefaultsForm(orgId, org!);
+  // Defaults the org already set, which keep applying on a plan that no
+  // longer allows new ones: shown, read-only, rather than replaced by an
+  // upsell for the feature they are visibly using (#162).
+  const hasQrDefaults = QR_DEFAULT_FIELDS.some((field) =>
+    field === "qrLogoSize" ? values.qrLogoSize != null : !!values[field],
+  );
+  const canEdit = isAdmin && hasQrCustom;
 
   return (
     <Card className="max-w-2xl">
@@ -132,24 +193,15 @@ export function QrDefaultsCard() {
             Applied to every link's QR code unless the link overrides them.
           </p>
         </div>
-        {!hasQrCustom ? (
-          <UpgradeQrPrompt />
-        ) : (
-          <div className="grid gap-6 sm:grid-cols-[1fr_auto]">
-            <QrPatternFields values={values} setField={setField} isAdmin={isAdmin} />
-            <div className="order-last sm:order-none">
-              <QrPreviewSidebar values={values} url={shortUrl("preview")} />
-            </div>
-            <QrColorAndLogoFields
-              values={values}
-              setField={setField}
-              isAdmin={isAdmin}
-              className="sm:col-span-2"
-            />
-            <div className="sm:col-span-2">
-              <SaveQrDefaultsAction isAdmin={isAdmin} savingQr={savingQr} save={save} />
-            </div>
-          </div>
+        {!hasQrCustom && <UpgradeQrPrompt locked={hasQrDefaults} />}
+        {(hasQrCustom || hasQrDefaults) && (
+          <QrDefaultsFields
+            values={values}
+            setField={setField}
+            canEdit={canEdit}
+            savingQr={savingQr}
+            save={save}
+          />
         )}
       </div>
     </Card>

--- a/src/app/lib/default-domain.ts
+++ b/src/app/lib/default-domain.ts
@@ -10,10 +10,10 @@ import type { DomainDTO } from "@/shared/types";
  * one of those the honest answer is the shared domain: a link is better
  * created at a working address than not created at all.
  *
- * `activeDomains` already carries all three rules, since it is the org's
- * domains filtered to `status === "active"` and only fetched for a plan and
- * role that may have them (`useOrgLimits`). So membership in that list is the
- * whole check.
+ * `activeDomains` already carries all of those, since it is the org's domains
+ * filtered to `status === "active"` and unlocked, and only fetched for a plan
+ * and role that may have them (`useOrgLimits`). So membership in that list is
+ * the whole check.
  */
 export function resolveDefaultDomainId(
   defaultDomainId: string | null | undefined,

--- a/src/app/lib/grace.ts
+++ b/src/app/lib/grace.ts
@@ -17,3 +17,9 @@ export function graceLabel(until: number, now = Date.now()): string {
   if (days === 0) return "the grace period has ended";
   return `${days} ${days === 1 ? "day" : "days"} left`;
 }
+
+/** Whether the deadline is still ahead. The copy around a countdown reads as
+ * a promise ("keeps working until X"), so it must not render once X is past. */
+export function graceRunning(until: number | null | undefined, now = Date.now()): boolean {
+  return until != null && until > now;
+}

--- a/src/app/lib/grace.ts
+++ b/src/app/lib/grace.ts
@@ -1,0 +1,19 @@
+/**
+ * How long a locked resource has left, in words (#159).
+ *
+ * Its own module rather than a second export from the component file that
+ * uses it, so the domains page can read the same sentence without importing
+ * a React module for a string.
+ */
+
+/** Days left, rounded up, so the last day reads "1 day" rather than "0". */
+function daysLeft(until: number, now = Date.now()): number {
+  return Math.max(0, Math.ceil((until - now) / 86_400_000));
+}
+
+/** "30 days left" / "1 day left" / "the grace period has ended". */
+export function graceLabel(until: number, now = Date.now()): string {
+  const days = daysLeft(until, now);
+  if (days === 0) return "the grace period has ended";
+  return `${days} ${days === 1 ? "day" : "days"} left`;
+}

--- a/src/app/lib/org-limits.ts
+++ b/src/app/lib/org-limits.ts
@@ -11,6 +11,19 @@ export function canListOrgDomains(isPlatformAdmin: boolean, role: OrgRole | unde
   return isPlatformAdmin || role === "owner" || role === "admin";
 }
 
+/**
+ * Whether this role may change anything in the org (#157).
+ *
+ * A viewer reads everything and writes nothing, so every control that would
+ * submit has to be hidden rather than left to fail: the server refuses them
+ * with a 403, and a button whose only outcome is an error toast is not a
+ * feature. Undefined role means the org has not loaded, which is also not a
+ * moment to offer a write.
+ */
+export function canWriteOrg(role: OrgRole | undefined): boolean {
+  return role === "owner" || role === "admin" || role === "member";
+}
+
 export function useOrgLimits() {
   const { org } = useCurrentOrg();
   const orgId = org?.id ?? "";
@@ -23,6 +36,9 @@ export function useOrgLimits() {
     [domains.data],
   );
   const orgQr = orgQrFrom(org);
+  // Every page that can offer a write already calls this hook, so the answer
+  // lives here rather than being re-derived from the role at each control.
+  const canWrite = canWriteOrg(org?.role);
   // Resolved here rather than at each call site, so nothing preselects a
   // domain that stopped serving (#69).
   const defaultDomainId = resolveDefaultDomainId(org?.defaultDomainId, activeDomains);
@@ -31,6 +47,7 @@ export function useOrgLimits() {
     orgId,
     currentUser,
     limits,
+    canWrite,
     canListDomains,
     domains,
     activeDomains,

--- a/src/app/lib/org-limits.ts
+++ b/src/app/lib/org-limits.ts
@@ -47,6 +47,20 @@ export function canWriteOrg(role: OrgRole | undefined, locked = false): boolean 
   return role === "owner" || role === "admin" || role === "member";
 }
 
+/**
+ * Why the domains page cannot offer its add form, which is not one question
+ * but two (#159, #160).
+ *
+ * A locked org is not short of a plan: it is on a plan that covers fewer
+ * organizations than its owner has. Answering it with "custom domains need a
+ * paid plan" is wrong to a Hobby owner reading it, and points at an upgrade
+ * that would not unlock anything.
+ */
+export function domainsBlockedBy(planDomains: number, locked: boolean): "lock" | "plan" | null {
+  if (locked) return "lock";
+  return planDomains > 0 ? null : "plan";
+}
+
 export function useOrgLimits() {
   const { org } = useCurrentOrg();
   const orgId = org?.id ?? "";

--- a/src/app/lib/org-limits.ts
+++ b/src/app/lib/org-limits.ts
@@ -20,7 +20,11 @@ export function canListOrgDomains(isPlatformAdmin: boolean, role: OrgRole | unde
  * feature. Undefined role means the org has not loaded, which is also not a
  * moment to offer a write.
  */
-export function canWriteOrg(role: OrgRole | undefined): boolean {
+export function canWriteOrg(role: OrgRole | undefined, locked = false): boolean {
+  // A locked org is read-only for everyone in it, its owner included (#160).
+  // Same answer as a viewer's, so every control already hidden for a viewer
+  // is hidden here too, and nothing new has to be threaded through.
+  if (locked) return false;
   return role === "owner" || role === "admin" || role === "member";
 }
 
@@ -38,7 +42,7 @@ export function useOrgLimits() {
   const orgQr = orgQrFrom(org);
   // Every page that can offer a write already calls this hook, so the answer
   // lives here rather than being re-derived from the role at each control.
-  const canWrite = canWriteOrg(org?.role);
+  const canWrite = canWriteOrg(org?.role, org?.locked);
   // Resolved here rather than at each call site, so nothing preselects a
   // domain that stopped serving (#69).
   const defaultDomainId = resolveDefaultDomainId(org?.defaultDomainId, activeDomains);

--- a/src/app/lib/org-limits.ts
+++ b/src/app/lib/org-limits.ts
@@ -20,6 +20,25 @@ export function canListOrgDomains(isPlatformAdmin: boolean, role: OrgRole | unde
  * feature. Undefined role means the org has not loaded, which is also not a
  * moment to offer a write.
  */
+/**
+ * Whether this role may administer the org: domains, members, invites and the
+ * org-wide QR defaults, none of which a plain member may touch.
+ *
+ * Locked-aware for the same reason `canWriteOrg` is (#160): a locked org
+ * accepts no writes from anyone, its owner included, so a control that would
+ * submit has to be hidden rather than left to 403. Platform admins act as
+ * owner everywhere, and the lock still applies to them, because the server
+ * refuses their write too.
+ */
+export function canAdminOrg(
+  isPlatformAdmin: boolean | undefined,
+  role: OrgRole | undefined,
+  locked = false,
+): boolean {
+  if (locked) return false;
+  return !!isPlatformAdmin || role === "owner" || role === "admin";
+}
+
 export function canWriteOrg(role: OrgRole | undefined, locked = false): boolean {
   // A locked org is read-only for everyone in it, its owner included (#160).
   // Same answer as a viewer's, so every control already hidden for a viewer
@@ -35,8 +54,11 @@ export function useOrgLimits() {
   const limits = PLAN_LIMITS[org?.plan ?? "free"];
   const canListDomains = canListOrgDomains(!!currentUser.data?.user.isAdmin, org?.role);
   const domains = useDomains(orgId, canListDomains);
+  // `lockedAt` as well as `status`: a downgrade leaves a domain `active` and
+  // locked, and a locked one takes no new links (#159). Without this the
+  // editor kept preselecting it and every default-path create came back 402.
   const activeDomains = useMemo(
-    () => (domains.data ?? []).filter((d) => d.status === "active"),
+    () => (domains.data ?? []).filter((d) => d.status === "active" && d.lockedAt === null),
     [domains.data],
   );
   const orgQr = orgQrFrom(org);

--- a/src/app/lib/qr-look.ts
+++ b/src/app/lib/qr-look.ts
@@ -109,6 +109,18 @@ export interface QrValues {
   qrLogoSize: string;
 }
 
+/**
+ * Has anything been set at all?
+ *
+ * Every field is a string and "" means unset, so one test answers for all of
+ * them, `qrLogoSize` included. Comparing that one against null instead, as
+ * the org settings card used to, is always true: an org that had set nothing
+ * was told its defaults were locked.
+ */
+export function hasAnyQrValue(values: QrValues): boolean {
+  return Object.values(values).some((v) => v !== "");
+}
+
 export function qrPreviewProps(values: QrValues) {
   return {
     logo: values.qrLogo || undefined,

--- a/src/app/lib/schemas.ts
+++ b/src/app/lib/schemas.ts
@@ -1,4 +1,5 @@
 import * as v from "valibot";
+import { INVITABLE_ROLES } from "@/shared/types";
 
 /** The first-run form asks for a link, not an organization name (#65). The
  * server decides what counts as a web address, and accepts scheme-less input
@@ -37,7 +38,7 @@ export const hostnameSchema = v.object({
 
 export const inviteEmailSchema = v.object({
   email: v.pipe(v.string(), v.email("Enter a valid email address")),
-  role: v.picklist(["member", "admin"]),
+  role: v.picklist(INVITABLE_ROLES),
 });
 
 export const loginSchema = v.object({

--- a/src/app/lib/user-cache.ts
+++ b/src/app/lib/user-cache.ts
@@ -50,6 +50,16 @@ const orgSchema = v.object({
   qrBg: v.string(),
   qrEyeColor: v.string(),
   qrLogoSize: v.nullable(v.number()),
+  // Entitlement state (#158). A cached copy is chrome, same as the rest of
+  // this record: the banner it paints is one page load old, and the query
+  // behind it corrects the moment it lands.
+  locked: v.boolean(),
+  over: v.object({
+    links: v.optional(v.number()),
+    members: v.optional(v.number()),
+    domains: v.optional(v.number()),
+  }),
+  graceEndsAt: v.nullable(v.number()),
 });
 
 /** Whole-record or nothing: a half-parsed user would render a shell with

--- a/src/app/routes/admin/orgs.tsx
+++ b/src/app/routes/admin/orgs.tsx
@@ -26,6 +26,7 @@ const roleColor = {
   owner: "accent",
   admin: "mint",
   member: "muted",
+  viewer: "muted",
 } satisfies Record<OrgRole, "accent" | "mint" | "muted">;
 
 const planBadgeColor = {

--- a/src/app/routes/analytics.tsx
+++ b/src/app/routes/analytics.tsx
@@ -16,6 +16,8 @@ import { AnalyticsSkeleton } from "../components/skeletons";
 import { NoOrgState } from "../components/no-org";
 import { ExportCsvButton } from "../components/export-csv-button";
 import { Card, PageHeader } from "../ui/misc";
+import { Tooltip } from "../ui/tooltip";
+import { HrefLink } from "../lib/router-search";
 
 const RANGE_PRESETS: {
   label: string;
@@ -36,11 +38,15 @@ function rangeButtonClass(active: boolean): string {
 
 function RangePicker({
   presets,
+  hiddenRanges,
   activeDays,
   activeBucket,
   onChoose,
 }: {
   presets: typeof RANGE_PRESETS;
+  /** The windows this plan cannot reach, named so the picker can say the
+      history is hidden rather than missing (#163). */
+  hiddenRanges: string[];
   activeDays: number;
   activeBucket: "day" | "hour";
   onChoose: (days: number, bucket?: "day" | "hour") => void;
@@ -59,6 +65,15 @@ function RangePicker({
           {p.label}
         </button>
       ))}
+      {hiddenRanges.length > 0 && (
+        <Tooltip
+          content={`Clicks are kept for 400 days. ${hiddenRanges.join(" and ")} come back the moment you upgrade, nothing was deleted.`}
+        >
+          <HrefLink href="/billing" className={rangeButtonClass(false)}>
+            Upgrade for {hiddenRanges[hiddenRanges.length - 1]}
+          </HrefLink>
+        </Tooltip>
+      )}
     </div>
   );
 }
@@ -154,6 +169,7 @@ export function Analytics() {
   const s = stats.data;
   const maxDays = PLAN_LIMITS[org.plan].analyticsDays;
   const presets = RANGE_PRESETS.filter((p) => p.days <= maxDays);
+  const hiddenRanges = RANGE_PRESETS.filter((p) => p.days > maxDays).map((p) => p.label);
   const activeDays = range.days ?? s.rangeDays;
   const activeBucket = range.bucket ?? s.bucket;
   const chooseRange = (days: number, bucket?: "day" | "hour") => {
@@ -173,6 +189,7 @@ export function Analytics() {
           <div className="flex items-center gap-2">
             <RangePicker
               presets={presets}
+              hiddenRanges={hiddenRanges}
               activeDays={activeDays}
               activeBucket={activeBucket}
               onChoose={chooseRange}

--- a/src/app/routes/domains.tsx
+++ b/src/app/routes/domains.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, LazyMotion, MotionConfig, domAnimation, m } from "moti
 import { Trash2, RefreshCw, Star } from "lucide-react";
 import { useCurrentUser, useConfig, useDomains, useDomainMutations } from "../lib/hooks";
 import { useCurrentOrg } from "../lib/current-org";
-import { PLAN_LIMITS, type DomainDTO, type OrgRole } from "@/shared/types";
+import { PLAN_LIMITS, type DomainDTO, type OrgRole, type UserOrg } from "@/shared/types";
 import { Button, IconButton } from "../ui/button";
 import { buttonClass } from "../ui/button-class";
 import { Input } from "../ui/field";
@@ -17,6 +17,8 @@ import { Badge, Card, PageHeader } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
 import { DomainsPageSkeleton, DomainsSkeleton, HeaderSkeleton } from "../components/skeletons";
 import { NoOrgState } from "../components/no-org";
+import { LockedPanel } from "../components/over-limit";
+import { graceLabel } from "../lib/grace";
 import { CopyButton } from "../ui/copy-button";
 import { useToast } from "../ui/toast";
 import { cn } from "../ui/cn";
@@ -182,21 +184,28 @@ function DeleteDomainDialog({
   );
 }
 
-function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | "pro" }) {
-  const domains = useDomains(orgId);
-  const { add, refresh, setRootRedirect, remove, setDefault } = useDomainMutations(orgId);
-  const { org } = useCurrentOrg();
-  const config = useConfig();
-  const appHost = config.data?.appHost ?? window.location.host;
-  const toast = useToast();
-  const limits = PLAN_LIMITS[plan];
-  const [deleting, setDeleting] = useState<DomainDTO | null>(null);
-  const [redirectDraft, setRedirectDraft] = useState<Record<string, string>>({});
-  const { register, handleSubmit, reset } = useForm<{ hostname: string }>({
-    resolver: valibotResolver(hostnameSchema),
-    defaultValues: { hostname: "" },
-  });
-
+/**
+ * Every write the domains card can make, with its toast and its analytics
+ * event. Split out of DomainsCard so that component is about what the page
+ * shows and this is about what its buttons do.
+ */
+function useDomainActions({
+  mutations: { add, refresh, setRootRedirect, remove, setDefault },
+  org,
+  toast,
+  reset,
+  deleting,
+  setDeleting,
+  redirectDraft,
+}: {
+  mutations: ReturnType<typeof useDomainMutations>;
+  org: UserOrg | null;
+  toast: ReturnType<typeof useToast>;
+  reset: () => void;
+  deleting: DomainDTO | null;
+  setDeleting: (d: DomainDTO | null) => void;
+  redirectDraft: Record<string, string>;
+}) {
   const copy = (text: string) => copyToClipboard(text, toast);
 
   const addDomain = useCallback(
@@ -261,7 +270,41 @@ function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | 
     });
   };
 
-  if (limits.domains === 0) return <UpgradeDomainsCard />;
+  return { copy, addDomain, recheck, saveRedirect, toggleDefault, confirmDelete };
+}
+
+function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | "pro" }) {
+  const domains = useDomains(orgId);
+  const { add, refresh, setRootRedirect, remove, setDefault } = useDomainMutations(orgId);
+  const { org } = useCurrentOrg();
+  const config = useConfig();
+  const appHost = config.data?.appHost ?? window.location.host;
+  const toast = useToast();
+  const limits = PLAN_LIMITS[plan];
+  const [deleting, setDeleting] = useState<DomainDTO | null>(null);
+  const [redirectDraft, setRedirectDraft] = useState<Record<string, string>>({});
+  const { register, handleSubmit, reset } = useForm<{ hostname: string }>({
+    resolver: valibotResolver(hostnameSchema),
+    defaultValues: { hostname: "" },
+  });
+
+  const { copy, addDomain, recheck, saveRedirect, toggleDefault, confirmDelete } = useDomainActions(
+    {
+      mutations: { add, refresh, setRootRedirect, remove, setDefault },
+      org,
+      toast,
+      reset,
+      deleting,
+      setDeleting,
+      redirectDraft,
+    },
+  );
+
+  // A plan with no domains still lists the ones the org already has (#159).
+  // Hiding them was the bug: an owner who downgrades and finds an upgrade
+  // pitch where their domains used to be concludes we deleted them.
+  const hasDomains = !!domains.data?.length;
+  if (limits.domains === 0 && !hasDomains) return <UpgradeDomainsCard />;
 
   return (
     <>
@@ -274,31 +317,28 @@ function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | 
               <DomainsSkeleton />
             ) : (
               <div className="flex flex-col gap-4">
-                <MotionConfig reducedMotion="user">
-                  <LazyMotion features={domAnimation}>
-                    {domains.data?.map((d) => (
-                      <DomainRow
-                        key={d.id}
-                        domain={d}
-                        appHost={appHost}
-                        refreshing={refresh.isPending}
-                        savingRedirect={setRootRedirect.isPending}
-                        isDefault={org?.defaultDomainId === d.id}
-                        savingDefault={setDefault.isPending}
-                        onToggleDefault={() => toggleDefault(d)}
-                        redirectDraft={redirectDraft[d.id] ?? d.rootRedirect}
-                        onRecheck={() => recheck(d)}
-                        onDelete={() => setDeleting(d)}
-                        onRedirectDraft={(v) => setRedirectDraft({ ...redirectDraft, [d.id]: v })}
-                        onSaveRedirect={() => saveRedirect(d)}
-                        onCopy={copy}
-                      />
-                    ))}
-                  </LazyMotion>
-                </MotionConfig>
+                <DomainList
+                  domains={domains.data}
+                  org={org}
+                  appHost={appHost}
+                  pending={{
+                    refreshing: refresh.isPending,
+                    savingRedirect: setRootRedirect.isPending,
+                    savingDefault: setDefault.isPending,
+                  }}
+                  redirectDraft={redirectDraft}
+                  onToggleDefault={toggleDefault}
+                  onRecheck={recheck}
+                  onDelete={setDeleting}
+                  onRedirectDraft={(id, v) => setRedirectDraft({ ...redirectDraft, [id]: v })}
+                  onSaveRedirect={saveRedirect}
+                  onCopy={copy}
+                />
 
-                <AddDomainForm
-                  hasDomains={!!domains.data?.length}
+                <DomainsFooter
+                  canAdd={limits.domains > 0}
+                  hasDomains={hasDomains}
+                  graceEndsAt={org?.graceEndsAt ?? null}
                   register={register}
                   onSubmit={handleSubmit(addDomain, (errors) =>
                     toast(errors.hostname?.message ?? "Enter a valid hostname", "error"),
@@ -403,6 +443,102 @@ function DefaultDomainButton({
   );
 }
 
+/**
+ * What sits under the list: the form on a plan that may add a domain, and
+ * the explanation on one that may not (#159).
+ *
+ * Exactly one of the two, always. A plan with no domains that still holds
+ * some needs the second, which is what makes the read-only list make sense
+ * rather than look like a bug.
+ */
+function DomainsFooter({
+  canAdd,
+  hasDomains,
+  graceEndsAt,
+  register,
+  onSubmit,
+  pending,
+}: {
+  canAdd: boolean;
+  hasDomains: boolean;
+  graceEndsAt: number | null;
+  register: UseFormRegister<{ hostname: string }>;
+  onSubmit: (e: FormEvent) => void;
+  pending: boolean;
+}) {
+  if (!canAdd)
+    return (
+      <LockedPanel
+        title="Your custom domains are locked"
+        reason="Custom domains need Hobby or Pro. Nothing was deleted: the DNS record, the certificate and every link on these domains are still here."
+        until={graceEndsAt}
+        cta="Upgrade to keep them"
+      />
+    );
+  return (
+    <AddDomainForm
+      hasDomains={hasDomains}
+      register={register}
+      onSubmit={onSubmit}
+      pending={pending}
+    />
+  );
+}
+
+/** Every connected domain, in one animated list. Split out of DomainsCard so
+ * that component is about the page's state and this one is about its rows. */
+function DomainList({
+  domains,
+  org,
+  appHost,
+  pending,
+  redirectDraft,
+  onToggleDefault,
+  onRecheck,
+  onDelete,
+  onRedirectDraft,
+  onSaveRedirect,
+  onCopy,
+}: {
+  domains: DomainDTO[] | undefined;
+  org: UserOrg | null;
+  appHost: string;
+  pending: { refreshing: boolean; savingRedirect: boolean; savingDefault: boolean };
+  redirectDraft: Record<string, string>;
+  onToggleDefault: (d: DomainDTO) => void;
+  onRecheck: (d: DomainDTO) => void;
+  onDelete: (d: DomainDTO) => void;
+  onRedirectDraft: (id: string, value: string) => void;
+  onSaveRedirect: (d: DomainDTO) => void;
+  onCopy: (text: string) => void;
+}) {
+  return (
+    <MotionConfig reducedMotion="user">
+      <LazyMotion features={domAnimation}>
+        {(domains ?? []).map((d) => (
+          <DomainRow
+            key={d.id}
+            domain={d}
+            appHost={appHost}
+            refreshing={pending.refreshing}
+            savingRedirect={pending.savingRedirect}
+            isDefault={org?.defaultDomainId === d.id}
+            savingDefault={pending.savingDefault}
+            onToggleDefault={() => onToggleDefault(d)}
+            redirectDraft={redirectDraft[d.id] ?? d.rootRedirect}
+            onRecheck={() => onRecheck(d)}
+            onDelete={() => onDelete(d)}
+            onRedirectDraft={(v) => onRedirectDraft(d.id, v)}
+            onSaveRedirect={() => onSaveRedirect(d)}
+            onCopy={onCopy}
+            graceEndsAt={org?.graceEndsAt ?? null}
+          />
+        ))}
+      </LazyMotion>
+    </MotionConfig>
+  );
+}
+
 function DomainRow({
   domain: d,
   appHost,
@@ -417,6 +553,7 @@ function DomainRow({
   onRedirectDraft,
   onSaveRedirect,
   onCopy,
+  graceEndsAt,
 }: {
   domain: DomainDTO;
   appHost: string;
@@ -431,35 +568,52 @@ function DomainRow({
   onRedirectDraft: (v: string) => void;
   onSaveRedirect: () => void;
   onCopy: (text: string) => void;
+  /** When the org's grace period ends, for a locked domain's countdown. */
+  graceEndsAt: number | null;
 }) {
+  const locked = d.lockedAt !== null;
   return (
     <div className="rounded-lg border border-border p-3">
       <div className="flex items-center justify-between gap-2">
         <span className="font-bold">{d.hostname}</span>
         <div className="relative flex items-center gap-1">
-          {isDefault && <Badge color="mint">default</Badge>}
-          <DomainStatusBadge domain={d} refreshing={refreshing} onRecheck={onRecheck} />
-          <DefaultDomainButton
-            domain={d}
-            isDefault={isDefault}
-            pending={savingDefault}
-            onToggle={onToggleDefault}
-          />
+          {isDefault && !locked && <Badge color="mint">default</Badge>}
+          {locked ? (
+            <Badge color="butter">locked</Badge>
+          ) : (
+            <>
+              <DomainStatusBadge domain={d} refreshing={refreshing} onRecheck={onRecheck} />
+              <DefaultDomainButton
+                domain={d}
+                isDefault={isDefault}
+                pending={savingDefault}
+                onToggle={onToggleDefault}
+              />
+            </>
+          )}
           <IconButton label={`Delete ${d.hostname}`} danger onClick={onDelete}>
             <Trash2 size={14} />
           </IconButton>
         </div>
       </div>
 
-      <DomainStatusDetail
-        domain={d}
-        appHost={appHost}
-        redirectDraft={redirectDraft}
-        savingRedirect={savingRedirect}
-        onRedirectDraft={onRedirectDraft}
-        onSaveRedirect={onSaveRedirect}
-        onCopy={onCopy}
-      />
+      {locked ? (
+        <p className="tnum mt-2 text-xs text-muted">
+          {graceEndsAt !== null
+            ? `Still redirecting until ${new Date(graceEndsAt).toLocaleDateString()} (${graceLabel(graceEndsAt)}), then it stops.`
+            : "This domain has stopped redirecting."}
+        </p>
+      ) : (
+        <DomainStatusDetail
+          domain={d}
+          appHost={appHost}
+          redirectDraft={redirectDraft}
+          savingRedirect={savingRedirect}
+          onRedirectDraft={onRedirectDraft}
+          onSaveRedirect={onSaveRedirect}
+          onCopy={onCopy}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/routes/domains.tsx
+++ b/src/app/routes/domains.tsx
@@ -18,7 +18,7 @@ import { BusyContent } from "../ui/spinner";
 import { DomainsPageSkeleton, DomainsSkeleton, HeaderSkeleton } from "../components/skeletons";
 import { NoOrgState } from "../components/no-org";
 import { LockedPanel } from "../components/over-limit";
-import { graceLabel } from "../lib/grace";
+import { graceLabel, graceRunning } from "../lib/grace";
 import { CopyButton } from "../ui/copy-button";
 import { useToast } from "../ui/toast";
 import { cn } from "../ui/cn";
@@ -304,6 +304,8 @@ function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | 
   // Hiding them was the bug: an owner who downgrades and finds an upgrade
   // pitch where their domains used to be concludes we deleted them.
   const hasDomains = !!domains.data?.length;
+  // A locked org accepts no writes from anyone, its owner included (#160).
+  const canWrite = !org?.locked;
   if (limits.domains === 0 && !hasDomains) return <UpgradeDomainsCard />;
 
   return (
@@ -333,10 +335,11 @@ function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | 
                   onRedirectDraft={(id, v) => setRedirectDraft({ ...redirectDraft, [id]: v })}
                   onSaveRedirect={saveRedirect}
                   onCopy={copy}
+                  canWrite={canWrite}
                 />
 
                 <DomainsFooter
-                  canAdd={limits.domains > 0}
+                  canAdd={limits.domains > 0 && canWrite}
                   hasDomains={hasDomains}
                   graceEndsAt={org?.graceEndsAt ?? null}
                   register={register}
@@ -499,6 +502,7 @@ function DomainList({
   onRedirectDraft,
   onSaveRedirect,
   onCopy,
+  canWrite,
 }: {
   domains: DomainDTO[] | undefined;
   org: UserOrg | null;
@@ -511,6 +515,9 @@ function DomainList({
   onRedirectDraft: (id: string, value: string) => void;
   onSaveRedirect: (d: DomainDTO) => void;
   onCopy: (text: string) => void;
+  /** False in a locked org, which accepts no writes from anyone (#160). The
+   * list still renders: hiding it is how somebody concludes it was deleted. */
+  canWrite: boolean;
 }) {
   return (
     <MotionConfig reducedMotion="user">
@@ -532,10 +539,64 @@ function DomainList({
             onSaveRedirect={() => onSaveRedirect(d)}
             onCopy={onCopy}
             graceEndsAt={org?.graceEndsAt ?? null}
+            canWrite={canWrite}
           />
         ))}
       </LazyMotion>
     </MotionConfig>
+  );
+}
+
+/** The badges and controls at the right of a domain's row. Split out of
+ * DomainRow so that one is about the row's shape and this is about what state
+ * the domain is in and who may change it. */
+function DomainRowActions({
+  domain: d,
+  locked,
+  isDefault,
+  refreshing,
+  savingDefault,
+  canWrite,
+  onRecheck,
+  onToggleDefault,
+  onDelete,
+}: {
+  domain: DomainDTO;
+  locked: boolean;
+  isDefault: boolean;
+  refreshing: boolean;
+  savingDefault: boolean;
+  canWrite: boolean;
+  onRecheck: () => void;
+  onToggleDefault: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="relative flex items-center gap-1">
+      {isDefault && !locked && <Badge color="mint">default</Badge>}
+      {locked ? (
+        <Badge color="butter">locked</Badge>
+      ) : (
+        <>
+          {/* The status and its re-check are reads, so they stay in a locked
+              org. Only the two controls that write are hidden. */}
+          <DomainStatusBadge domain={d} refreshing={refreshing} onRecheck={onRecheck} />
+          {canWrite && (
+            <DefaultDomainButton
+              domain={d}
+              isDefault={isDefault}
+              pending={savingDefault}
+              onToggle={onToggleDefault}
+            />
+          )}
+        </>
+      )}
+      {canWrite && (
+        <IconButton label={`Delete ${d.hostname}`} danger onClick={onDelete}>
+          <Trash2 size={14} />
+        </IconButton>
+      )}
+    </div>
   );
 }
 
@@ -554,6 +615,7 @@ function DomainRow({
   onSaveRedirect,
   onCopy,
   graceEndsAt,
+  canWrite,
 }: {
   domain: DomainDTO;
   appHost: string;
@@ -570,38 +632,31 @@ function DomainRow({
   onCopy: (text: string) => void;
   /** When the org's grace period ends, for a locked domain's countdown. */
   graceEndsAt: number | null;
+  canWrite: boolean;
 }) {
   const locked = d.lockedAt !== null;
   return (
     <div className="rounded-lg border border-border p-3">
       <div className="flex items-center justify-between gap-2">
         <span className="font-bold">{d.hostname}</span>
-        <div className="relative flex items-center gap-1">
-          {isDefault && !locked && <Badge color="mint">default</Badge>}
-          {locked ? (
-            <Badge color="butter">locked</Badge>
-          ) : (
-            <>
-              <DomainStatusBadge domain={d} refreshing={refreshing} onRecheck={onRecheck} />
-              <DefaultDomainButton
-                domain={d}
-                isDefault={isDefault}
-                pending={savingDefault}
-                onToggle={onToggleDefault}
-              />
-            </>
-          )}
-          <IconButton label={`Delete ${d.hostname}`} danger onClick={onDelete}>
-            <Trash2 size={14} />
-          </IconButton>
-        </div>
+        <DomainRowActions
+          domain={d}
+          locked={locked}
+          isDefault={isDefault}
+          refreshing={refreshing}
+          savingDefault={savingDefault}
+          canWrite={canWrite}
+          onRecheck={onRecheck}
+          onToggleDefault={onToggleDefault}
+          onDelete={onDelete}
+        />
       </div>
 
       {locked ? (
         <p className="tnum mt-2 text-xs text-muted">
-          {graceEndsAt !== null
-            ? `Still redirecting until ${new Date(graceEndsAt).toLocaleDateString()} (${graceLabel(graceEndsAt)}), then it stops.`
-            : "This domain has stopped redirecting."}
+          {graceRunning(graceEndsAt)
+            ? `Still redirecting until ${new Date(graceEndsAt!).toLocaleDateString()} (${graceLabel(graceEndsAt!)}), then it stops.`
+            : "This domain has stopped redirecting. Upgrading brings it straight back, with no DNS to redo."}
         </p>
       ) : (
         <DomainStatusDetail

--- a/src/app/routes/domains.tsx
+++ b/src/app/routes/domains.tsx
@@ -18,6 +18,7 @@ import { BusyContent } from "../ui/spinner";
 import { DomainsPageSkeleton, DomainsSkeleton, HeaderSkeleton } from "../components/skeletons";
 import { NoOrgState } from "../components/no-org";
 import { LockedPanel } from "../components/over-limit";
+import { domainsBlockedBy } from "../lib/org-limits";
 import { graceLabel, graceRunning } from "../lib/grace";
 import { CopyButton } from "../ui/copy-button";
 import { useToast } from "../ui/toast";
@@ -339,7 +340,7 @@ function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | 
                 />
 
                 <DomainsFooter
-                  canAdd={limits.domains > 0 && canWrite}
+                  blockedBy={domainsBlockedBy(limits.domains, !canWrite)}
                   hasDomains={hasDomains}
                   graceEndsAt={org?.graceEndsAt ?? null}
                   register={register}
@@ -455,25 +456,34 @@ function DefaultDomainButton({
  * rather than look like a bug.
  */
 function DomainsFooter({
-  canAdd,
+  blockedBy,
   hasDomains,
   graceEndsAt,
   register,
   onSubmit,
   pending,
 }: {
-  canAdd: boolean;
+  blockedBy: ReturnType<typeof domainsBlockedBy>;
   hasDomains: boolean;
   graceEndsAt: number | null;
   register: UseFormRegister<{ hostname: string }>;
   onSubmit: (e: FormEvent) => void;
   pending: boolean;
 }) {
-  if (!canAdd)
+  // The banner at the top of the page already tells a locked org why it is
+  // locked, so this only says why the form is gone.
+  if (blockedBy === "lock")
+    return (
+      <LockedPanel
+        title="This organization is locked"
+        reason="You cannot add a domain until it is active again. The domains it already has keep redirecting."
+      />
+    );
+  if (blockedBy === "plan")
     return (
       <LockedPanel
         title="Your custom domains are locked"
-        reason="Custom domains need Hobby or Pro. Nothing was deleted: the DNS record, the certificate and every link on these domains are still here."
+        reason="Custom domains need a paid plan. Nothing was deleted: the DNS record, the certificate and every link on these domains are still here."
         until={graceEndsAt}
         cta="Upgrade to keep them"
       />

--- a/src/app/routes/links.tsx
+++ b/src/app/routes/links.tsx
@@ -103,6 +103,7 @@ function LinksBrowser({
   dialogs,
   atLimit,
   limitHint,
+  canWrite,
 }: {
   list: ReturnType<typeof useLinkPage>;
   orgId: string;
@@ -111,6 +112,7 @@ function LinksBrowser({
   dialogs: ReturnType<typeof useLinkDialogs>;
   atLimit: boolean;
   limitHint?: string;
+  canWrite: boolean;
 }) {
   return (
     <LinksListArea
@@ -123,7 +125,7 @@ function LinksBrowser({
       }
       atLimit={atLimit}
       limitHint={limitHint}
-      onCreate={dialogs.openCreate}
+      onCreate={canWrite ? dialogs.openCreate : undefined}
     >
       <LinksToolbar
         search={list.search}
@@ -137,6 +139,7 @@ function LinksBrowser({
         paged={list.rows}
         navigate={navigate}
         onQrClick={dialogs.setQrLink}
+        canWrite={canWrite}
         onEdit={dialogs.openEdit}
         onDelete={dialogs.setDeleting}
         onCreateAlias={dialogs.setAliasLink}
@@ -263,8 +266,17 @@ function useLinkDialogs(atLimit: boolean) {
 }
 
 export function LinksPage() {
-  const { org, orgId, limits, activeDomains, defaultDomainId, orgQr, domains, currentUser } =
-    useOrgLimits();
+  const {
+    org,
+    orgId,
+    limits,
+    canWrite,
+    activeDomains,
+    defaultDomainId,
+    orgQr,
+    domains,
+    currentUser,
+  } = useOrgLimits();
   const quotaUsage = useLinkQuotaUsage(orgId);
   const { create, update, remove } = useLinkMutations(orgId);
   const toast = useToast();
@@ -332,14 +344,16 @@ export function LinksPage() {
             <span className="text-xs tnum text-muted">
               {linkCount} / {limits.links} links
             </span>
-            <Button
-              variant="primary"
-              onClick={dialogs.openCreate}
-              disabled={atLimit}
-              title={limitHint}
-            >
-              <Plus size={15} /> New link
-            </Button>
+            {canWrite && (
+              <Button
+                variant="primary"
+                onClick={dialogs.openCreate}
+                disabled={atLimit}
+                title={limitHint}
+              >
+                <Plus size={15} /> New link
+              </Button>
+            )}
           </div>
         }
       />
@@ -352,6 +366,7 @@ export function LinksPage() {
         dialogs={dialogs}
         atLimit={atLimit}
         limitHint={limitHint}
+        canWrite={canWrite}
       />
 
       <LinkDialogStack
@@ -386,7 +401,9 @@ function LinksListArea({
   hasLinks: boolean;
   atLimit: boolean;
   limitHint: string | undefined;
-  onCreate: () => void;
+  /** Undefined for a viewer, who has no way to make the empty state stop
+   * being empty. The screen then explains rather than offering (#157). */
+  onCreate?: () => void;
   children: ReactNode;
 }) {
   if (isLoading) return <TableSkeleton rows={5} />;
@@ -394,11 +411,17 @@ function LinksListArea({
     return (
       <EmptyState
         title="No links yet"
-        hint="Shorten your first address and it appears here, with its clicks, referrers and QR code."
+        hint={
+          onCreate
+            ? "Shorten your first address and it appears here, with its clicks, referrers and QR code."
+            : "Links this organization creates appear here, with their clicks, referrers and QR codes."
+        }
         action={
-          <Button variant="primary" onClick={onCreate} disabled={atLimit} title={limitHint}>
-            <Plus size={15} /> New link
-          </Button>
+          onCreate ? (
+            <Button variant="primary" onClick={onCreate} disabled={atLimit} title={limitHint}>
+              <Plus size={15} /> New link
+            </Button>
+          ) : undefined
         }
       />
     );

--- a/src/app/routes/links.tsx
+++ b/src/app/routes/links.tsx
@@ -226,6 +226,19 @@ function buildOnSave({
  * made LinksPage the most complex function in the app; here they are one
  * named thing the page reads off.
  */
+/**
+ * What the links counter says when it is worth saying something (#163).
+ *
+ * "Over" and "at" used to read the same, so an org holding 500 links on a
+ * 30-link plan was told to "upgrade for more" as though it were one short.
+ */
+function linkLimitHint(count: number, limit: number): string | undefined {
+  if (count > limit)
+    return `This plan allows ${limit} links. The extras still work, and you can delete some or upgrade.`;
+  if (count === limit) return "Link limit reached: upgrade for more links";
+  return undefined;
+}
+
 function useLinkDialogs(atLimit: boolean) {
   const [editorOpen, setEditorOpen] = useState(false);
   const [editing, setEditing] = useState<LinkDTO | null>(null);
@@ -287,7 +300,8 @@ export function LinksPage() {
   // link plus its kept-forever aliases each count. See useLinkQuotaUsage.
   const linkCount = quotaUsage.data?.count ?? 0;
   const atLimit = linkCount >= limits.links;
-  const limitHint = atLimit ? "Link limit reached: upgrade for more links" : undefined;
+  const overLimit = linkCount > limits.links;
+  const limitHint = linkLimitHint(linkCount, limits.links);
 
   const dialogs = useLinkDialogs(atLimit);
 
@@ -341,8 +355,9 @@ export function LinksPage() {
         sub="Short links, UTM tagging and QR codes"
         action={
           <div className="flex items-center gap-3">
-            <span className="text-xs tnum text-muted">
+            <span className="tnum text-xs text-muted" title={limitHint}>
               {linkCount} / {limits.links} links
+              {overLimit && " (over the limit)"}
             </span>
             {canWrite && (
               <Button

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -23,6 +23,8 @@ import { MenuSelect } from "../ui/menu";
 import { Tooltip } from "../ui/tooltip";
 import { RemoveMemberDialog, InviteMemberDialog } from "../components/member-dialogs";
 import { Table, Th, Td, Badge, Card, PageHeader } from "../ui/misc";
+import { HrefLink } from "../lib/router-search";
+import { buttonClass } from "../ui/button-class";
 import { TableSkeleton } from "../ui/skeleton";
 import { BusyContent } from "../ui/spinner";
 import { useToast } from "../ui/toast";
@@ -394,6 +396,11 @@ export function MembersPage() {
   } = useMemberManagement(orgId, canManage);
 
   const memberLimit = memberLimitFor(org);
+  // An org at or over its cap cannot take another member: the server refuses
+  // the invite with a 402, so offering the form is offering an error (#161).
+  // Counted from the same figure the server uses, members plus open invites.
+  const seatsTaken = (members.data?.length ?? 0) + (invites.data?.length ?? 0);
+  const seatsLeft = Math.max(0, memberLimit - seatsTaken);
 
   if (currentUser.isLoading) return <TableSkeleton rows={4} />;
   if (!org) return <NoOrgState />;
@@ -405,16 +412,34 @@ export function MembersPage() {
         sub="People with access to this organization"
         action={
           canManage && (
-            <Button variant="primary" onClick={() => setInviteOpen(true)}>
-              <UserPlus size={15} /> Invite link
-            </Button>
+            <div className="flex items-center gap-3">
+              <span className="tnum text-xs text-muted">
+                {seatsTaken} / {memberLimit} members
+                {seatsTaken > memberLimit && " (over the limit)"}
+              </span>
+              <Button
+                variant="primary"
+                onClick={() => setInviteOpen(true)}
+                disabled={seatsLeft === 0}
+                title={seatsLeft === 0 ? fullSeatsHint(org, memberLimit) : undefined}
+              >
+                <UserPlus size={15} /> Invite link
+              </Button>
+            </div>
           )
         }
       />
 
-      {canManage && (
-        <InviteByEmailCard org={org} memberLimit={memberLimit} sendEmailInvite={sendEmailInvite} />
-      )}
+      {canManage &&
+        (seatsLeft === 0 ? (
+          <SeatsFullNotice org={org} memberLimit={memberLimit} over={seatsTaken > memberLimit} />
+        ) : (
+          <InviteByEmailCard
+            org={org}
+            memberLimit={memberLimit}
+            sendEmailInvite={sendEmailInvite}
+          />
+        ))}
 
       <MemberTable
         isLoading={members.isLoading}
@@ -454,6 +479,39 @@ export function MembersPage() {
       />
     </div>
   );
+}
+
+/** What the invite form is replaced by once every seat is taken. Says which
+ * of the two situations it is, because "full" and "over" need different
+ * things done about them. */
+function SeatsFullNotice({
+  org,
+  memberLimit,
+  over,
+}: {
+  org: UserOrg;
+  memberLimit: number;
+  over: boolean;
+}) {
+  return (
+    <Card className="mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="max-w-prose text-sm text-muted">
+          {over
+            ? `This organization has more members than the ${org.plan} plan allows (${memberLimit}). Nobody was removed, and nobody new can be invited until you upgrade.`
+            : `Every seat on the ${org.plan} plan is taken (${memberLimit}, counting open invites). Remove someone, or upgrade to invite more.`}
+        </p>
+        <HrefLink href="/billing" className={buttonClass({ variant: "outline", size: "sm" })}>
+          See plans
+        </HrefLink>
+      </div>
+    </Card>
+  );
+}
+
+/** The tooltip on a disabled invite control. */
+function fullSeatsHint(org: UserOrg, memberLimit: number): string {
+  return `The ${org.plan} plan allows ${memberLimit} members, counting open invites`;
 }
 
 function InviteByEmailCard({

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -189,23 +189,6 @@ function MemberRoleCell({
   return <Badge color={roleColor[member.role]}>{member.role}</Badge>;
 }
 
-/**
- * Why somebody who used to be able to edit no longer can (#161).
- *
- * A marker beside the role rather than a sentence under it: the reason is
- * the same on every demoted row, and repeating three lines of it down a
- * 23-person table buries the table it is annotating. The sentence is one
- * hover away, where somebody who does not recognise the word will look.
- */
-function DemotedMarker({ demoted }: { demoted: boolean }) {
-  if (!demoted) return null;
-  return (
-    <Tooltip content="Set to viewer when the plan changed. Upgrading gives back the role they had.">
-      <span className="cursor-help text-xs text-muted">demoted</span>
-    </Tooltip>
-  );
-}
-
 function MemberRemoveCell({
   member,
   isSelf,
@@ -243,10 +226,7 @@ function MemberRow({
       <Td className="truncate">{member.name}</Td>
       <Td className="truncate text-muted">{member.email}</Td>
       <Td>
-        <div className="flex items-center gap-2">
-          <MemberRoleCell member={member} canManage={canManage} onSetRole={onSetRole} />
-          <DemotedMarker demoted={member.demoted} />
-        </div>
+        <MemberRoleCell member={member} canManage={canManage} onSetRole={onSetRole} />
       </Td>
       <Td className="text-xs text-muted">{shortDate(member.createdAt)}</Td>
       {canManage && (

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -8,7 +8,14 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { UserPlus, Trash2, Info } from "lucide-react";
 import { useCurrentUser, useMembers, useInvites } from "../lib/hooks";
 import { api } from "../lib/api";
-import { PLAN_LIMITS, type InviteDTO, type OrgRole, type Sort, type UserOrg } from "@/shared/types";
+import {
+  PLAN_LIMITS,
+  type InviteDTO,
+  type MemberDTO,
+  type OrgRole,
+  type Sort,
+  type UserOrg,
+} from "@/shared/types";
 import { Button, IconButton } from "../ui/button";
 import { CopyButton } from "../ui/copy-button";
 import { Field, Input } from "../ui/field";
@@ -152,7 +159,7 @@ function MemberRoleCell({
   canManage,
   onSetRole,
 }: {
-  member: { name: string; role: OrgRole };
+  member: { name: string; role: OrgRole; demoted: boolean };
   canManage: boolean;
   onSetRole: (role: string) => void;
 }) {
@@ -178,6 +185,17 @@ function MemberRoleCell({
     );
   }
   return <Badge color={roleColor[member.role]}>{member.role}</Badge>;
+}
+
+/** Why somebody who used to be able to edit no longer can (#161). Without
+ * it they report the missing buttons as a bug, and they are right to. */
+function DemotedNote({ member }: { member: { demoted: boolean } }) {
+  if (!member.demoted) return null;
+  return (
+    <p className="mt-0.5 max-w-prose text-xs text-muted">
+      Set to viewer when the plan changed. Upgrading gives back the role they had.
+    </p>
+  );
 }
 
 function MemberRemoveCell({
@@ -206,7 +224,7 @@ function MemberRow({
   onSetRole,
   onRemove,
 }: {
-  member: { userId: string; name: string; email: string; role: OrgRole; createdAt: number };
+  member: MemberDTO;
   canManage: boolean;
   isSelf: boolean;
   onSetRole: (role: string) => void;
@@ -218,6 +236,7 @@ function MemberRow({
       <Td className="truncate text-muted">{member.email}</Td>
       <Td>
         <MemberRoleCell member={member} canManage={canManage} onSetRole={onSetRole} />
+        <DemotedNote member={member} />
       </Td>
       <Td className="text-xs text-muted">{shortDate(member.createdAt)}</Td>
       {canManage && (
@@ -240,7 +259,7 @@ function MemberTable({
   onRemove,
 }: {
   isLoading: boolean;
-  sorted: { userId: string; name: string; email: string; role: OrgRole; createdAt: number }[];
+  sorted: MemberDTO[];
   canManage: boolean;
   sort: Sort;
   setSort: (s: Sort) => void;

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
-import { INVITABLE_ROLES } from "@/shared/types";
+import { type InvitableRole, INVITABLE_ROLES } from "@/shared/types";
 import { oneOf } from "@/shared/lookup";
 import { useForm } from "react-hook-form";
 import { valibotResolver } from "@hookform/resolvers/valibot";
@@ -32,7 +32,16 @@ const roleColor = {
   owner: "accent",
   admin: "mint",
   member: "muted",
+  viewer: "muted",
 } satisfies Record<OrgRole, "accent" | "mint" | "muted">;
+
+/** What each role can do, said once, where the role is chosen. Without it
+ * "viewer" and "member" look like the same word twice. */
+const ROLE_OPTIONS = [
+  { value: "viewer", label: "viewer · read only" },
+  { value: "member", label: "member · manage links" },
+  { value: "admin", label: "admin · manage the org" },
+];
 
 const inviteUrl = (token: string) => `${window.location.origin}/invite/${token}`;
 
@@ -42,7 +51,7 @@ function useMemberManagement(orgId: string, canManage: boolean) {
   const members = useMembers(orgId);
   const invites = useInvites(orgId, canManage);
   const [inviteOpen, setInviteOpen] = useState(false);
-  const [inviteRole, setInviteRole] = useState<"member" | "admin">("member");
+  const [inviteRole, setInviteRole] = useState<InvitableRole>("member");
   const [removing, setRemoving] = useState<{ userId: string; name: string } | null>(null);
   const [sort, setSort] = useState<Sort>({ key: "createdAt", dir: 1 });
 
@@ -81,7 +90,7 @@ function useMemberManagement(orgId: string, canManage: boolean) {
   });
 
   const sendEmailInvite = useMutation({
-    mutationFn: (params: { email: string; role: "member" | "admin" }) =>
+    mutationFn: (params: { email: string; role: InvitableRole }) =>
       api<{ invites: InviteDTO[] }>(`/orgs/${orgId}/invites`, {
         method: "POST",
         body: { role: params.role, emails: [params.email] },
@@ -164,10 +173,7 @@ function MemberRoleCell({
         label={`Role for ${member.name}`}
         value={member.role}
         onChange={onSetRole}
-        options={[
-          { value: "member", label: "member" },
-          { value: "admin", label: "admin" },
-        ]}
+        options={ROLE_OPTIONS}
       />
     );
   }
@@ -439,7 +445,7 @@ function InviteByEmailCard({
   memberLimit: number;
   sendEmailInvite: {
     mutate: (
-      params: { email: string; role: "member" | "admin" },
+      params: { email: string; role: InvitableRole },
       opts?: { onSuccess?: () => void },
     ) => void;
     isPending: boolean;
@@ -448,7 +454,7 @@ function InviteByEmailCard({
   const toast = useToast();
   const { register, handleSubmit, watch, setValue, reset } = useForm<{
     email: string;
-    role: "member" | "admin";
+    role: InvitableRole;
   }>({
     resolver: valibotResolver(inviteEmailSchema),
     defaultValues: { email: "", role: "member" },
@@ -456,7 +462,7 @@ function InviteByEmailCard({
   const selectedRole = watch("role");
 
   const submit = useCallback(
-    ({ email, role }: { email: string; role: "member" | "admin" }) => {
+    ({ email, role }: { email: string; role: InvitableRole }) => {
       sendEmailInvite.mutate(
         { email, role },
         {
@@ -508,10 +514,7 @@ function InviteByEmailCard({
               label="Role"
               value={selectedRole}
               onChange={(role) => setValue("role", oneOf(INVITABLE_ROLES, role, "member"))}
-              options={[
-                { value: "member", label: "member" },
-                { value: "admin", label: "admin" },
-              ]}
+              options={ROLE_OPTIONS}
             />
           </Field>
         </div>

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -486,7 +486,7 @@ function SeatsFullNotice({
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="max-w-prose text-sm text-muted">
           {over
-            ? `This organization has more members than the ${org.plan} plan allows (${memberLimit}). Nobody was removed, and nobody new can be invited until you upgrade.`
+            ? `This organization has more people or open invites than the ${org.plan} plan allows (${memberLimit}). Nobody was removed. Remove a member or revoke an invite to make room, or upgrade to keep everyone.`
             : `Every seat on the ${org.plan} plan is taken (${memberLimit}, counting open invites). Remove someone, or upgrade to invite more.`}
         </p>
         <HrefLink href="/billing" className={buttonClass({ variant: "outline", size: "sm" })}>

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -369,7 +369,8 @@ export function MembersPage() {
   const orgId = org?.id ?? "";
   const currentUser = useCurrentUser();
   const myRole = resolveMyRole(currentUser.data?.user.isAdmin, org?.role);
-  const canManage = canManageOrg(myRole);
+  // A locked org accepts no writes from anyone, its owner included (#160).
+  const canManage = canManageOrg(myRole) && !org?.locked;
 
   const {
     members,

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -47,9 +47,9 @@ const roleColor = {
 /** What each role can do, said once, where the role is chosen. Without it
  * "viewer" and "member" look like the same word twice. */
 const ROLE_OPTIONS = [
-  { value: "viewer", label: "viewer · read only" },
-  { value: "member", label: "member · manage links" },
-  { value: "admin", label: "admin · manage the org" },
+  { value: "viewer", label: "viewer" },
+  { value: "member", label: "member" },
+  { value: "admin", label: "admin" },
 ];
 
 const inviteUrl = (token: string) => `${window.location.origin}/invite/${token}`;
@@ -189,14 +189,20 @@ function MemberRoleCell({
   return <Badge color={roleColor[member.role]}>{member.role}</Badge>;
 }
 
-/** Why somebody who used to be able to edit no longer can (#161). Without
- * it they report the missing buttons as a bug, and they are right to. */
-function DemotedNote({ member }: { member: { demoted: boolean } }) {
-  if (!member.demoted) return null;
+/**
+ * Why somebody who used to be able to edit no longer can (#161).
+ *
+ * A marker beside the role rather than a sentence under it: the reason is
+ * the same on every demoted row, and repeating three lines of it down a
+ * 23-person table buries the table it is annotating. The sentence is one
+ * hover away, where somebody who does not recognise the word will look.
+ */
+function DemotedMarker({ demoted }: { demoted: boolean }) {
+  if (!demoted) return null;
   return (
-    <p className="mt-0.5 max-w-prose text-xs text-muted">
-      Set to viewer when the plan changed. Upgrading gives back the role they had.
-    </p>
+    <Tooltip content="Set to viewer when the plan changed. Upgrading gives back the role they had.">
+      <span className="cursor-help text-xs text-muted">demoted</span>
+    </Tooltip>
   );
 }
 
@@ -237,8 +243,10 @@ function MemberRow({
       <Td className="truncate">{member.name}</Td>
       <Td className="truncate text-muted">{member.email}</Td>
       <Td>
-        <MemberRoleCell member={member} canManage={canManage} onSetRole={onSetRole} />
-        <DemotedNote member={member} />
+        <div className="flex items-center gap-2">
+          <MemberRoleCell member={member} canManage={canManage} onSetRole={onSetRole} />
+          <DemotedMarker demoted={member.demoted} />
+        </div>
       </Td>
       <Td className="text-xs text-muted">{shortDate(member.createdAt)}</Td>
       {canManage && (

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -21,6 +21,7 @@ import { Field, Input } from "../ui/field";
 
 import { AppShellSkeleton, RouteSkeleton } from "../components/skeletons";
 import { appNavItems } from "../components/nav-items";
+import { OverLimitBanner } from "../components/over-limit";
 import { NotFound } from "./not-found";
 import { PLAN_LIMITS, type User, type UserOrg } from "@/shared/types";
 import posthog from "../lib/posthog";
@@ -104,7 +105,9 @@ function OrgSwitcherMenu({
             {o.id === org?.id && <Check size={13} className="text-accent" />}
           </span>
           <span className="truncate">{o.name}</span>
-          <span className="ml-auto text-xs text-muted">{o.role}</span>
+          {/* A locked org stays in the list and says so (#160). Hiding it is
+              how somebody concludes their data is gone. */}
+          <span className="ml-auto text-xs text-muted">{o.locked ? "locked" : o.role}</span>
         </MenuItem>
       ))}
       <MenuSeparator />
@@ -432,6 +435,9 @@ export function AppShell() {
 
       <main className="flex min-w-0 flex-1 flex-col px-5 py-8 pt-16 md:ml-60 md:px-8 md:pt-8">
         <div className="mx-auto w-full max-w-5xl flex-1">
+          {/* Above the route, not inside each one: the state belongs to the
+              org, so it says the same thing on every page (#163). */}
+          <OverLimitBanner />
           {/* pages are lazy chunks: keep the shell in place while one loads,
               behind the shape that chunk is about to render */}
           <Suspense fallback={<RouteSkeleton />}>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,11 +19,16 @@ export type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
-export const ORG_ROLES = ["owner", "admin", "member"] as const;
+/** Ordered least to most powerful, which is also the order a role picker
+ * should offer them. `viewer` reads everything an org holds and writes
+ * nothing: an analyst who should see the numbers without touching the links,
+ * and what an over-cap member is demoted to on downgrade (#29). */
+export const ORG_ROLES = ["owner", "admin", "member", "viewer"] as const;
 export type OrgRole = (typeof ORG_ROLES)[number];
 
 /** The roles an invite may hand out: never owner, which only a transfer moves. */
-export const INVITABLE_ROLES = ["member", "admin"] as const;
+export const INVITABLE_ROLES = ["viewer", "member", "admin"] as const;
+export type InvitableRole = (typeof INVITABLE_ROLES)[number];
 
 export const ORG_PLANS = ["free", "hobby", "pro"] as const;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -86,6 +86,36 @@ export const PLAN_LIMITS = {
   },
 } satisfies Record<OrgPlan, PlanLimits>;
 
+/**
+ * How long a downgraded org's custom domains keep serving (#159).
+ *
+ * Stopping a custom domain breaks every link on it, including QR codes
+ * already printed on physical things. Thirty days and two emails is what
+ * turns that into something the owner was warned about twice.
+ */
+export const GRACE_PERIOD_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** How long before the grace ends the second email goes out: day 23 of 30. */
+export const GRACE_WARNING_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * The live count of each resource an org holds more of than its plan allows.
+ * A key is absent when that resource is inside its cap, so `{}` means fine.
+ */
+export interface OverLimits {
+  links?: number;
+  members?: number;
+  domains?: number;
+}
+
+/** Which resources an over-limit banner can name, in the order it names them. */
+export const OVER_LIMIT_KEYS = ["links", "members", "domains"] as const;
+
+/** Whether an org is over any of its caps. */
+export function isOverLimit(over: OverLimits): boolean {
+  return OVER_LIMIT_KEYS.some((key) => over[key] !== undefined);
+}
+
 /** Display prices for the paid plans; the charge itself is set in Polar. */
 export const PLAN_PRICES = {
   hobby: "$4",
@@ -168,6 +198,15 @@ export interface UserOrg extends QrOverrides {
    * domains rather than trusting it (`resolveDefaultDomainId`).
    */
   defaultDomainId: string | null;
+  /**
+   * This org is beyond its owner's `orgs` cap, so it is read-only until they
+   * upgrade or pick it as the one to keep (#160). Its links keep redirecting.
+   */
+  locked: boolean;
+  /** What this org holds more of than its plan allows (#158). `{}` means fine. */
+  over: OverLimits;
+  /** Epoch ms the 30-day grace ends, or null when nothing is over (#159). */
+  graceEndsAt: number | null;
 }
 
 export interface CurrentUser {
@@ -200,6 +239,12 @@ export interface DomainDTO {
   statusReason: string;
   rootRedirect: string;
   createdAt: number;
+  /**
+   * Epoch ms this domain went beyond the org's plan (#159), or null while it
+   * is fine. A locked domain keeps serving until the org's `graceEndsAt`,
+   * cannot be the org's default, and takes no new links.
+   */
+  lockedAt: number | null;
 }
 
 /** Public deployment config the SPA needs (no secrets). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -220,6 +220,12 @@ export interface MemberDTO {
   email: string;
   role: OrgRole;
   createdAt: number;
+  /**
+   * This member is a viewer because a downgrade demoted them, not because
+   * anyone chose it (#161). The members page says so, and an upgrade puts
+   * their old role back.
+   */
+  demoted: boolean;
 }
 
 export interface InviteDTO {

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -145,7 +145,39 @@ export const orgs = sqliteTable("orgs", {
   // reject writes before the workflow's gather step ever runs. Null means
   // not deleting.
   deletingAt: integer("deleting_at"),
+  // This org is beyond its owner's `orgs` cap, so it is read-only until they
+  // upgrade or pick it as the one to keep (#160). Null means active. Its
+  // links keep redirecting: the lock is between us and the account holder.
+  lockedAt: integer("locked_at"),
 });
+
+/**
+ * What the last reconciliation pass found for one org (#158).
+ *
+ * Written only by reconcile.ts, on every billing event that changes a plan
+ * and by the admin's manual run. Read by the app to explain the state and by
+ * the daily cron to send the day-23 warning. Nothing here decides access on
+ * its own: the marker columns (`orgs.lockedAt`, `domains.lockedAt`,
+ * `orgMembers.previousRole`) are what routes and the redirect path read.
+ */
+export const orgEntitlements = sqliteTable(
+  "org_entitlements",
+  {
+    orgId: text("org_id")
+      .primaryKey()
+      .references(() => orgs.id, { onDelete: "cascade" }),
+    plan: text("plan", { enum: ["free", "hobby", "pro"] }).notNull(),
+    /** JSON `{ links?: n, members?: n, domains?: n }`: the live count of each
+     * resource that is over its cap. `{}` means the org is inside its plan. */
+    overJson: text("over_json").notNull().default("{}"),
+    /** Epoch ms the 30 days run out; null while nothing is over. */
+    graceEndsAt: integer("grace_ends_at"),
+    reconciledAt: integer("reconciled_at").notNull(),
+    notifiedAt: integer("notified_at"),
+    warnedAt: integer("warned_at"),
+  },
+  (t) => [index("idx_org_entitlements_grace").on(t.graceEndsAt)],
+);
 
 export const orgMembers = sqliteTable(
   "org_members",
@@ -157,6 +189,9 @@ export const orgMembers = sqliteTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     role: text("role", { enum: ["owner", "admin", "member", "viewer"] }).notNull(),
+    // What this member was before a downgrade demoted them to viewer (#161).
+    // Null means they hold the role they were given. Re-upgrading restores it.
+    previousRole: text("previous_role", { enum: ["owner", "admin", "member", "viewer"] }),
     createdAt: integer("created_at").notNull(),
   },
   (t) => [primaryKey({ columns: [t.orgId, t.userId] }), index("idx_org_members_user").on(t.userId)],
@@ -199,6 +234,11 @@ export const domains = sqliteTable(
     statusReason: text("status_reason").notNull().default(""),
     rootRedirect: text("root_redirect").notNull().default(""),
     cfHostnameId: text("cf_hostname_id"),
+    // Beyond the org's `domains` cap after a downgrade (#159). It keeps
+    // serving until the org's grace period ends, then stops; the row, the KV
+    // entry and the Cloudflare hostname all stay, so an upgrade restores it
+    // with no re-verification. Null means fine.
+    lockedAt: integer("locked_at"),
     createdAt: integer("created_at").notNull(),
   },
   (t) => [index("idx_domains_org").on(t.orgId)],

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -156,7 +156,7 @@ export const orgMembers = sqliteTable(
     userId: text("user_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
-    role: text("role", { enum: ["owner", "admin", "member"] }).notNull(),
+    role: text("role", { enum: ["owner", "admin", "member", "viewer"] }).notNull(),
     createdAt: integer("created_at").notNull(),
   },
   (t) => [primaryKey({ columns: [t.orgId, t.userId] }), index("idx_org_members_user").on(t.userId)],
@@ -169,7 +169,7 @@ export const invites = sqliteTable(
     orgId: text("org_id")
       .notNull()
       .references(() => orgs.id, { onDelete: "cascade" }),
-    role: text("role", { enum: ["admin", "member"] }).notNull(),
+    role: text("role", { enum: ["admin", "member", "viewer"] }).notNull(),
     // Set when the invite was emailed to a specific address: only that
     // account may accept. Null for copy-only link invites (bearer links).
     email: text("email"),

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -19,8 +19,9 @@ import { billingRoutes, handlePolarWebhook } from "./routes/billing";
 import { domainRoutes } from "./routes/domains";
 import { capRoutes } from "./routes/cap";
 import { revalidateOnRedirect } from "./risk";
+import { sweepGraceWarnings } from "./reconcile";
 import { shortenRoutes, sweepExpiredAnonLinks } from "./routes/shorten";
-import { resolveSlug, resolveDomain, type KVLink } from "./kv";
+import { resolveSlug, resolveDomain, domainServing, type KVLink } from "./kv";
 import { RESERVED_SLUGS } from "./util";
 import { withPageMeta } from "./page-meta";
 import { enforcePublicAuthRateLimit, enforceSignedApiRateLimit } from "./rate-limit";
@@ -132,6 +133,11 @@ app.use("*", async (c, next) => {
   if (!host || host === c.env.APP_HOST.toLowerCase()) return next();
   const domain = await resolveDomain(c.env, host);
   if (!domain) return next();
+  // A locked domain past its 30 days stops resolving, with no D1 read: the
+  // deadline is in the value (#159). A 404 rather than a page explaining the
+  // downgrade, because most of what reaches a dead short link is a machine,
+  // and an honest 404 is the answer a machine can act on.
+  if (!domainServing(domain)) return c.text("Not found", 404);
 
   const path = new URL(c.req.url).pathname;
   // This middleware is a dead end for a host it owns: it never calls next(),
@@ -383,6 +389,10 @@ const wrapped = Sentry.withSentry<Env, StorageMessage | ClickMessage>(
       // Daily: drop anonymous links nobody claimed inside their 24 hours, and
       // the KV keys they were resolving through (Direction A of #96).
       await sweepExpiredAnonLinks(env);
+
+      // Daily: the day-23 email for every org whose 30 days are nearly up
+      // (#158). Day 0 goes out from the reconciliation pass itself.
+      await sweepGraceWarnings(env, drizzle(env.DB, { schema }));
     },
   },
 );

--- a/src/worker/kv.ts
+++ b/src/worker/kv.ts
@@ -24,6 +24,23 @@ export interface KVDomain {
   domainId: string;
   orgId: string;
   rootRedirect: string;
+  /**
+   * Epoch ms this host stops resolving, or null/absent for "keeps serving"
+   * (#159).
+   *
+   * A downgraded org's extra domains keep working for 30 days, and the
+   * redirect path has to know that without a D1 read, so the deadline rides
+   * in the value rather than being looked up per request. Reconciliation
+   * writes it; nothing rewrites it when the day arrives, because a stored
+   * deadline needs no cron to expire.
+   */
+  servesUntil?: number | null;
+}
+
+/** Whether a custom domain still resolves. A value written before
+ * `servesUntil` existed has it undefined, which means "keeps serving". */
+export function domainServing(domain: KVDomain, now = Date.now()): boolean {
+  return domain.servesUntil == null || domain.servesUntil > now;
 }
 
 const slugKey = (hostname: string | null, slug: string) =>
@@ -69,12 +86,19 @@ export async function resolveSlug(
 
 export async function publishDomain(
   env: Env,
-  domain: { id: string; orgId: string; hostname: string; rootRedirect: string },
+  domain: {
+    id: string;
+    orgId: string;
+    hostname: string;
+    rootRedirect: string;
+    servesUntil?: number | null;
+  },
 ): Promise<void> {
   const value: KVDomain = {
     domainId: domain.id,
     orgId: domain.orgId,
     rootRedirect: domain.rootRedirect,
+    servesUntil: domain.servesUntil ?? null,
   };
   await env.LINKS.put(`domain:${domain.hostname}`, JSON.stringify(value));
 }

--- a/src/worker/org-role.ts
+++ b/src/worker/org-role.ts
@@ -5,7 +5,10 @@ import * as schema from "./db/schema";
 import type { AppEnv, DB, SessionUser } from "./env";
 import type { OrgRole } from "@/shared/types";
 
-const ROLE_RANK = { member: 0, admin: 1, owner: 2 } satisfies Record<OrgRole, number>;
+/** Least to most powerful. `requireOrgRole(min)` compares against this, so a
+ * route's minimum is the whole of its authorization: a GET every member may
+ * read asks for "viewer", a write asks for "member". */
+const ROLE_RANK = { viewer: 0, member: 1, admin: 2, owner: 3 } satisfies Record<OrgRole, number>;
 
 /**
  * Resolves the caller's role in the :orgId route param. Platform admins pass

--- a/src/worker/org-role.ts
+++ b/src/worker/org-role.ts
@@ -35,26 +35,37 @@ export function requireOrgRole(
     const role = await orgRole(c.var.db, user, orgId);
     if (!role || ROLE_RANK[role] < ROLE_RANK[min])
       throw new HTTPException(403, { message: "Insufficient role" });
-    if (c.req.method === "GET") return next();
-    const state = await orgState(c.var.db, orgId);
-    // Reads stay allowed while an org tears down; only block writes, so a
-    // link or domain created in that window is never missed by the teardown
-    // workflow's gather step. See deleteOrg in routes/orgs.ts. The delete
-    // route itself opts out: deleteOrg already makes a repeat DELETE a
-    // no-op, and blocking it here would surface that as a 409 instead.
-    if (!opts?.allowWhileDeleting && state.deletingAt != null)
-      throw new HTTPException(409, { message: "Organization is being deleted" });
-    // A locked org is read-only for everyone in it, its owner included
-    // (#160): it is beyond the owner's plan, so it keeps serving its links
-    // and accepts no changes. Here rather than in each route, for the same
-    // reason the teardown check is: no route has to remember.
-    if (!opts?.allowWhileLocked && state.lockedAt != null)
-      throw new HTTPException(403, {
-        message: "This organization is locked: upgrade to Pro to use it again",
-        cause: { code: "org_locked" },
-      });
+    if (c.req.method !== "GET") await assertOrgWritable(c.var.db, orgId, opts);
     await next();
   });
+}
+
+/**
+ * The two states that stop an org accepting writes while leaving its reads
+ * open. Both are checked here rather than in each route, for the same
+ * reason: no route has to remember.
+ *
+ * Teardown: a link or domain created in that window would be missed by the
+ * workflow's gather step. The delete route itself opts out, because
+ * deleteOrg already makes a repeat DELETE a no-op and blocking it here would
+ * surface that as a 409 instead.
+ *
+ * Locked: the org is beyond its owner's plan (#160), so it keeps serving its
+ * links and accepts no changes, its owner included.
+ */
+async function assertOrgWritable(
+  db: DB,
+  orgId: string,
+  opts?: { allowWhileDeleting?: boolean; allowWhileLocked?: boolean },
+): Promise<void> {
+  const state = await orgState(db, orgId);
+  if (!opts?.allowWhileDeleting && state.deletingAt != null)
+    throw new HTTPException(409, { message: "Organization is being deleted" });
+  if (!opts?.allowWhileLocked && state.lockedAt != null)
+    throw new HTTPException(403, {
+      message: "This organization is locked: upgrade to Pro to use it again",
+      cause: { code: "org_locked" },
+    });
 }
 
 async function orgState(

--- a/src/worker/org-role.ts
+++ b/src/worker/org-role.ts
@@ -23,7 +23,10 @@ export async function orgRole(db: DB, user: SessionUser, orgId: string): Promise
   return rows[0]?.role ?? null;
 }
 
-export function requireOrgRole(min: OrgRole, opts?: { allowWhileDeleting?: boolean }) {
+export function requireOrgRole(
+  min: OrgRole,
+  opts?: { allowWhileDeleting?: boolean; allowWhileLocked?: boolean },
+) {
   return createMiddleware<AppEnv>(async (c, next) => {
     const user = c.var.user;
     if (!user) throw new HTTPException(401, { message: "Not signed in" });
@@ -32,21 +35,38 @@ export function requireOrgRole(min: OrgRole, opts?: { allowWhileDeleting?: boole
     const role = await orgRole(c.var.db, user, orgId);
     if (!role || ROLE_RANK[role] < ROLE_RANK[min])
       throw new HTTPException(403, { message: "Insufficient role" });
+    if (c.req.method === "GET") return next();
+    const state = await orgState(c.var.db, orgId);
     // Reads stay allowed while an org tears down; only block writes, so a
     // link or domain created in that window is never missed by the teardown
     // workflow's gather step. See deleteOrg in routes/orgs.ts. The delete
     // route itself opts out: deleteOrg already makes a repeat DELETE a
     // no-op, and blocking it here would surface that as a 409 instead.
-    if (!opts?.allowWhileDeleting && c.req.method !== "GET" && (await orgDeleting(c.var.db, orgId)))
+    if (!opts?.allowWhileDeleting && state.deletingAt != null)
       throw new HTTPException(409, { message: "Organization is being deleted" });
+    // A locked org is read-only for everyone in it, its owner included
+    // (#160): it is beyond the owner's plan, so it keeps serving its links
+    // and accepts no changes. Here rather than in each route, for the same
+    // reason the teardown check is: no route has to remember.
+    if (!opts?.allowWhileLocked && state.lockedAt != null)
+      throw new HTTPException(403, {
+        message: "This organization is locked: upgrade to Pro to use it again",
+        cause: { code: "org_locked" },
+      });
     await next();
   });
 }
 
-async function orgDeleting(db: DB, orgId: string): Promise<boolean> {
+async function orgState(
+  db: DB,
+  orgId: string,
+): Promise<{
+  deletingAt: number | null;
+  lockedAt: number | null;
+}> {
   const rows = await db
-    .select({ deletingAt: schema.orgs.deletingAt })
+    .select({ deletingAt: schema.orgs.deletingAt, lockedAt: schema.orgs.lockedAt })
     .from(schema.orgs)
     .where(eq(schema.orgs.id, orgId));
-  return rows[0]?.deletingAt != null;
+  return rows[0] ?? { deletingAt: null, lockedAt: null };
 }

--- a/src/worker/plan.ts
+++ b/src/worker/plan.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import * as schema from "./db/schema";
 import type { DB, Env } from "./env";
-import { PLAN_LIMITS, type OrgPlan, type PlanLimits } from "@/shared/types";
+import { INVITABLE_ROLES, PLAN_LIMITS, type OrgPlan, type PlanLimits } from "@/shared/types";
 
 /**
  * Runs one raw D1 statement and reports whether it wrote a row. Meant for a
@@ -86,7 +86,7 @@ export async function acceptInviteAtomically(
   args: {
     orgId: string;
     userId: string;
-    role: "admin" | "member";
+    role: (typeof INVITABLE_ROLES)[number];
     ts: number;
     memberLimit: number;
     token: string;

--- a/src/worker/plan.ts
+++ b/src/worker/plan.ts
@@ -286,6 +286,83 @@ export async function insertDomainWithinLimit(
 }
 
 /**
+ * Makes one org the active one and locks whatever has to give way, in a
+ * single D1 transaction (#160).
+ *
+ * Two requests picking two different locked orgs could otherwise both clear
+ * `locked_at`, then both lock the org the other had just chosen, leaving an
+ * owner with everything locked and no org they can write to. Batching the two
+ * statements means the second one counts what the first one wrote, and no
+ * concurrent request can interleave between them.
+ *
+ * The surplus is recomputed inside the statement rather than passed in, for
+ * the same reason: a count read before the batch is a count that can be stale
+ * by the time it is used.
+ */
+export async function keepOrgActive(
+  env: Env,
+  args: { orgId: string; userId: string; ownedOrgLimit: number; ts: number },
+): Promise<void> {
+  const ownedActive = `
+    select o.id from orgs o
+    join org_members m on m.org_id = o.id
+    where m.user_id = ? and m.role = 'owner' and o.locked_at is null`;
+  await env.DB.batch([
+    env.DB.prepare(`update orgs set locked_at = null where id = ?`).bind(args.orgId),
+    // Newest first, and never the org being kept, which is what makes the
+    // pick stick where reconciliation's by-age default would overrule it.
+    env.DB.prepare(
+      `update orgs set locked_at = ?
+       where id in (
+         ${ownedActive} and o.id != ?
+         order by o.created_at desc, o.id desc
+         limit max(0, (select count(*) from (${ownedActive})) - ?)
+       )`,
+    ).bind(args.ts, args.userId, args.orgId, args.userId, args.ownedOrgLimit),
+  ]);
+}
+
+/**
+ * Changes a member's role, refusing to hand out write access an org over its
+ * member cap has no room for (#161).
+ *
+ * Guarded inside the statement, not from a count read first: two admins
+ * promoting two different viewers at once would both find room and both take
+ * it. Demoting to viewer is always allowed, and so is changing the role of
+ * somebody who already writes, since neither adds a writer.
+ *
+ * `previous_role` is cleared only when the role actually moves. Confirming a
+ * demoted member as `viewer` used to erase the record of what they were, so a
+ * later upgrade silently left them a viewer: #29's "never delete" applies to
+ * that record too.
+ *
+ * Returns false when the cap refused it, which is the only reason a matched
+ * row goes unwritten: the caller has already checked the membership exists.
+ */
+export async function setMemberRoleWithinLimit(
+  env: Env,
+  args: {
+    orgId: string;
+    userId: string;
+    role: (typeof INVITABLE_ROLES)[number];
+    memberLimit: number;
+  },
+): Promise<boolean> {
+  return runGuarded(
+    env,
+    `update org_members
+     set role = ?, previous_role = case when role = ? then previous_role else null end
+     where org_id = ? and user_id = ?
+       and (
+         ? = 'viewer'
+         or role != 'viewer'
+         or (select count(*) from org_members where org_id = ? and role != 'viewer') < ?
+       )`,
+    [args.role, args.role, args.orgId, args.userId, args.role, args.orgId, args.memberLimit],
+  );
+}
+
+/**
  * An org's plan = its owner's plan. Billing is per-user (a person holds one
  * Free/Hobby/Pro subscription), so an org's effective limits come from whoever owns
  * it: resolve the owner membership and read that user's plan.

--- a/src/worker/reconcile.ts
+++ b/src/worker/reconcile.ts
@@ -1,3 +1,4 @@
+import * as v from "valibot";
 import { and, asc, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
 import * as schema from "./db/schema";
 import type { DB, Env } from "./env";
@@ -15,6 +16,7 @@ import {
   type OrgPlan,
   type OverLimits,
   type PlanLimits,
+  type JsonValue,
 } from "@/shared/types";
 
 /**
@@ -33,18 +35,30 @@ import {
  * one sees. Running it twice for the same plan changes nothing.
  */
 
-/** The over-limit map as stored, parsed back with anything unrecognised dropped. */
+/** The shape `over_json` holds. Parsed rather than asserted, because the
+ * column is text and a row written by an older version of this file (or by
+ * hand) must read back as "nothing over" rather than as fiction. */
+const overSchema = v.object({
+  links: v.optional(v.number()),
+  members: v.optional(v.number()),
+  domains: v.optional(v.number()),
+});
+
+/** The over-limit map as stored, with anything unrecognised dropped. */
 export function parseOver(json: string): OverLimits {
-  // SAFETY: written by writeEntitlement below, which stringifies an
-  // OverLimits. A row hand-edited into something else reads back as a
-  // partial object of numbers, and each field is checked before use.
-  const raw = JSON.parse(json || "{}") as Record<string, unknown>;
-  const over: OverLimits = {};
-  for (const key of ["links", "members", "domains"] as const) {
-    const value = raw[key];
-    if (typeof value === "number" && Number.isFinite(value)) over[key] = value;
+  const parsed = v.safeParse(overSchema, jsonOrNull(json));
+  return parsed.success ? parsed.output : {};
+}
+
+function jsonOrNull(json: string): JsonValue {
+  try {
+    // SAFETY: JSON.parse's return is typed `any`; JsonValue is what a parsed
+    // JSON document can be, and overSchema is what checks it means what this
+    // file needs.
+    return JSON.parse(json || "{}") as JsonValue;
+  } catch {
+    return null;
   }
-  return over;
 }
 
 /** The orgs a user owns, oldest first, which is the order every default here
@@ -82,18 +96,18 @@ async function reconcileOrgLocks(
   now: number,
 ): Promise<void> {
   const active = orgs.filter((o) => o.lockedAt === null);
-  if (active.length > limit) {
-    for (const org of active.slice(limit)) {
-      await setOrgLock(db, org.id, now);
-      org.lockedAt = now;
-    }
-    return;
-  }
-  const locked = orgs.filter((o) => o.lockedAt !== null);
-  for (const org of locked.slice(0, limit - active.length)) {
-    await setOrgLock(db, org.id, null);
-    org.lockedAt = null;
-  }
+  const [moving, lockedAt] =
+    active.length > limit
+      ? [active.slice(limit), now]
+      : [orgs.filter((o) => o.lockedAt !== null).slice(0, limit - active.length), null];
+  // Independent single-row updates, so they go out together rather than one
+  // round trip at a time.
+  await Promise.all(
+    moving.map(async (org) => {
+      await setOrgLock(db, org.id, lockedAt);
+      org.lockedAt = lockedAt;
+    }),
+  );
 }
 
 /**
@@ -119,14 +133,19 @@ async function reconcileDomainLocks(
     .where(eq(schema.domains.orgId, orgId))
     .orderBy(asc(schema.domains.createdAt), asc(schema.domains.id));
 
-  const changed: string[] = [];
-  for (const [index, row] of rows.entries()) {
+  const moving = rows.flatMap((row, index) => {
     const lockedAt = index < limit ? null : (row.lockedAt ?? now);
-    if (lockedAt === row.lockedAt) continue;
-    await db.update(schema.domains).set({ lockedAt }).where(eq(schema.domains.id, row.id));
-    changed.push(row.hostname);
-  }
-  return { count: rows.length, changed };
+    return lockedAt === row.lockedAt ? [] : [{ ...row, lockedAt }];
+  });
+  await Promise.all(
+    moving.map((row) =>
+      db
+        .update(schema.domains)
+        .set({ lockedAt: row.lockedAt })
+        .where(eq(schema.domains.id, row.id)),
+    ),
+  );
+  return { count: rows.length, changed: moving.map((row) => row.hostname) };
 }
 
 /**
@@ -159,27 +178,32 @@ async function reconcileMemberRoles(
     ...rest.slice(0, Math.max(0, limit - (owner ? 1 : 0))).map((r) => r.userId),
   ]);
 
-  const demoted: string[] = [];
-  for (const row of rows) {
-    if (keep.has(row.userId)) {
-      // Back inside the cap: whatever they were before the demotion, they are
-      // again. A role an admin set by hand since has no previousRole, so this
-      // never writes over a deliberate change.
-      if (row.previousRole === null) continue;
-      await db
+  // Back inside the cap: whatever they were before the demotion, they are
+  // again. A role an admin set by hand since has no previousRole, so a
+  // restore never writes over a deliberate change.
+  const restored = rows.flatMap((row) =>
+    keep.has(row.userId) && row.previousRole !== null
+      ? [{ userId: row.userId, role: row.previousRole }]
+      : [],
+  );
+  const demoted = rows.filter((row) => !keep.has(row.userId) && row.role !== "viewer");
+  const where = (userId: string) =>
+    and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, userId));
+  await Promise.all([
+    ...restored.map((row) =>
+      db
         .update(schema.orgMembers)
-        .set({ role: row.previousRole, previousRole: null })
-        .where(and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, row.userId)));
-      continue;
-    }
-    if (row.role === "viewer") continue;
-    await db
-      .update(schema.orgMembers)
-      .set({ role: "viewer", previousRole: row.role })
-      .where(and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, row.userId)));
-    demoted.push(row.userId);
-  }
-  return { count: rows.length, demoted };
+        .set({ role: row.role, previousRole: null })
+        .where(where(row.userId)),
+    ),
+    ...demoted.map((row) =>
+      db
+        .update(schema.orgMembers)
+        .set({ role: "viewer", previousRole: row.role })
+        .where(where(row.userId)),
+    ),
+  ]);
+  return { count: rows.length, demoted: demoted.map((row) => row.userId) };
 }
 
 async function readEntitlement(db: DB, orgId: string) {
@@ -191,7 +215,7 @@ async function readEntitlement(db: DB, orgId: string) {
 }
 
 /** One org's state after a pass, as the app reads it. */
-export interface OrgEntitlement {
+interface OrgEntitlement {
   over: OverLimits;
   graceEndsAt: number | null;
   /** When the day-0 email for this grace period went out; null while unsent. */
@@ -201,7 +225,7 @@ export interface OrgEntitlement {
 /**
  * Reconciles one org against its owner's plan. Returns the state it wrote.
  */
-export async function reconcileOrg(
+async function reconcileOrg(
   env: Env,
   db: DB,
   org: { id: string; name: string },
@@ -215,24 +239,20 @@ export async function reconcileOrg(
   // that is already counting down.
   const planChanged = orgPlanOf(previous?.plan) !== plan || previous === null;
 
-  const links = await countActiveAddresses(db, org.id);
-  const domains = await reconcileDomainLocks(db, org.id, limits.domains, now);
-  const members = await reconcileMemberRoles(db, org.id, limits.members);
+  // Three independent resources: neither read nor write of one depends on
+  // another, so they go out together.
+  const [links, domains, members] = await Promise.all([
+    countActiveAddresses(db, org.id),
+    reconcileDomainLocks(db, org.id, limits.domains, now),
+    reconcileMemberRoles(db, org.id, limits.members),
+  ]);
 
   const over: OverLimits = {};
   if (links > limits.links) over.links = links;
   if (members.count > limits.members) over.members = members.count;
   if (domains.count > limits.domains) over.domains = domains.count;
 
-  const stillOver = isOverLimit(over);
-  const graceEndsAt = !stillOver
-    ? null
-    : planChanged || previous?.graceEndsAt == null
-      ? now + GRACE_PERIOD_MS
-      : previous.graceEndsAt;
-  // The two emails belong to one grace period, so a new one starts unsent.
-  const keepNotices = !planChanged && graceEndsAt !== null;
-  const notifiedAt = keepNotices ? (previous?.notifiedAt ?? null) : null;
+  const { graceEndsAt, notifiedAt, warnedAt } = graceFor(over, previous, planChanged, now);
 
   await writeEntitlement(db, {
     orgId: org.id,
@@ -241,7 +261,7 @@ export async function reconcileOrg(
     graceEndsAt,
     reconciledAt: now,
     notifiedAt,
-    warnedAt: keepNotices ? (previous?.warnedAt ?? null) : null,
+    warnedAt,
   });
 
   // After the row is written, so the KV value the sync reads carries this
@@ -252,6 +272,35 @@ export async function reconcileOrg(
   );
 
   return { over, graceEndsAt, notifiedAt };
+}
+
+/**
+ * When this org's grace period ends, and which of its two emails have gone
+ * out for it.
+ *
+ * The clock only restarts on a plan change, which is what makes a repeat run
+ * a no-op: a second pass on the same plan finds the same stored deadline and
+ * writes it back. A new grace period starts unsent, because its two emails
+ * describe the new deadline, not the one they were sent about.
+ */
+function graceFor(
+  over: OverLimits,
+  previous: {
+    graceEndsAt: number | null;
+    notifiedAt: number | null;
+    warnedAt: number | null;
+  } | null,
+  planChanged: boolean,
+  now: number,
+) {
+  if (!isOverLimit(over)) return { graceEndsAt: null, notifiedAt: null, warnedAt: null };
+  if (planChanged || previous?.graceEndsAt == null)
+    return { graceEndsAt: now + GRACE_PERIOD_MS, notifiedAt: null, warnedAt: null };
+  return {
+    graceEndsAt: previous.graceEndsAt,
+    notifiedAt: previous.notifiedAt,
+    warnedAt: previous.warnedAt,
+  };
 }
 
 async function writeEntitlement(
@@ -288,10 +337,14 @@ export async function reconcileUser(
 
     const orgs = await ownedOrgs(db, userId);
     await reconcileOrgLocks(db, orgs, limits.orgs, now);
-    for (const org of orgs) {
-      const state = await reconcileOrg(env, db, org, plan, limits, now);
-      await notifyDowngrade(env, db, org, plan, state, now);
-    }
+    // Each org is reconciled against the same plan and touches only its own
+    // rows, so they run together.
+    await Promise.all(
+      orgs.map(async (org) => {
+        const state = await reconcileOrg(env, db, org, plan, limits, now);
+        await notifyDowngrade(env, db, org, plan, state, now);
+      }),
+    );
   } catch (error) {
     captureAlert([{ event: "reconcile_failed", userId }]);
     console.error("reconcile_failed", userId, error);
@@ -403,28 +456,29 @@ export async function sweepGraceWarnings(env: Env, db: DB, now = Date.now()): Pr
       ),
     );
 
-  let sent = 0;
-  for (const row of rows) {
-    const state = {
-      over: parseOver(row.overJson),
-      graceEndsAt: row.graceEndsAt,
-      notifiedAt: null,
-    };
-    const org = { id: row.orgId, name: row.name };
-    const delivered = await sendDowngradeEmail(
-      env,
-      db,
-      org,
-      orgPlanOf(row.plan),
-      state,
-      "warning",
-    ).catch(() => false);
-    if (!delivered) continue;
-    await db
-      .update(schema.orgEntitlements)
-      .set({ warnedAt: now })
-      .where(eq(schema.orgEntitlements.orgId, row.orgId));
-    sent++;
-  }
-  return sent;
+  const results = await Promise.all(
+    rows.map(async (row) => {
+      const state = {
+        over: parseOver(row.overJson),
+        graceEndsAt: row.graceEndsAt,
+        notifiedAt: null,
+      };
+      const org = { id: row.orgId, name: row.name };
+      const delivered = await sendDowngradeEmail(
+        env,
+        db,
+        org,
+        orgPlanOf(row.plan),
+        state,
+        "warning",
+      ).catch(() => false);
+      if (!delivered) return false;
+      await db
+        .update(schema.orgEntitlements)
+        .set({ warnedAt: now })
+        .where(eq(schema.orgEntitlements.orgId, row.orgId));
+      return true;
+    }),
+  );
+  return results.filter(Boolean).length;
 }

--- a/src/worker/reconcile.ts
+++ b/src/worker/reconcile.ts
@@ -280,19 +280,18 @@ async function reconcileOrg(
     warnedAt,
   });
 
-  // Every locked domain when the deadline moved, only the ones whose lock
-  // moved otherwise. `servesUntil` in KV is built from the org's
-  // `graceEndsAt` (see desiredKvValue), so a restarted grace that republished
-  // nothing left already-locked hosts carrying the *old* deadline: pro to
-  // hobby, thirty days, then hobby to free, and two domains 404 through a
-  // grace period D1 says is still running.
+  // Republish every locked domain on every pass. `servesUntil` in KV is built
+  // from the org's `graceEndsAt` (see desiredKvValue), so a restarted grace
+  // that republished nothing left already-locked hosts carrying the *old*
+  // deadline: pro to hobby, thirty days, then hobby to free, and two domains
+  // 404 through a grace period D1 says is still running. More importantly,
+  // the D1 writes above commit before queue submission. If that submission
+  // fails, the next reconciliation has no lock change to discover, so it must
+  // still enqueue the locked hosts and repair the stale KV values.
   //
   // After the row is written, so the KV value the sync reads carries this
   // pass's deadline rather than the one it replaced.
-  const republish =
-    graceEndsAt === (previous?.graceEndsAt ?? null)
-      ? domains.changed
-      : [...new Set([...domains.changed, ...domains.locked])];
+  const republish = [...new Set([...domains.changed, ...domains.locked])];
   await enqueueStorage(
     env,
     republish.map((hostname) => syncDomainMsg(hostname)),

--- a/src/worker/reconcile.ts
+++ b/src/worker/reconcile.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { and, asc, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
+import { and, asc, eq, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
 import * as schema from "./db/schema";
 import type { DB, Env } from "./env";
 import { countActiveAddresses } from "./plan";
@@ -91,10 +91,10 @@ async function setOrgLock(db: DB, orgId: string, lockedAt: number | null): Promi
  */
 async function reconcileOrgLocks(
   db: DB,
-  orgs: { id: string; lockedAt: number | null }[],
+  orgs: { id: string; name: string; lockedAt: number | null }[],
   limit: number,
   now: number,
-): Promise<void> {
+): Promise<{ id: string; name: string }[]> {
   const active = orgs.filter((o) => o.lockedAt === null);
   const [moving, lockedAt] =
     active.length > limit
@@ -108,30 +108,42 @@ async function reconcileOrgLocks(
       org.lockedAt = lockedAt;
     }),
   );
+  // Only the ones newly locked. An unlock is good news nobody needs an email
+  // about, and a repeat pass moves nothing, so it sends nothing.
+  return lockedAt === null ? [] : moving.map((org) => ({ id: org.id, name: org.name }));
 }
 
 /**
  * Locks the domains beyond the org's cap, oldest kept (#159).
  *
- * Returns the hostnames whose verdict changed, so only those get a KV
- * republish: the value carries the deadline, so a domain whose lock did not
- * move needs no write.
+ * Returns the hostnames whose lock moved, and every hostname that is locked
+ * now. The caller needs both: the KV value carries the *deadline* as well as
+ * the lock, so a domain whose lock did not move still needs a republish when
+ * the org's grace period restarts under it.
  */
 async function reconcileDomainLocks(
   db: DB,
   orgId: string,
   limit: number,
   now: number,
-): Promise<{ count: number; changed: string[] }> {
+): Promise<{ count: number; changed: string[]; locked: string[] }> {
   const rows = await db
     .select({
       id: schema.domains.id,
       hostname: schema.domains.hostname,
       lockedAt: schema.domains.lockedAt,
+      status: schema.domains.status,
     })
     .from(schema.domains)
     .where(eq(schema.domains.orgId, orgId))
-    .orderBy(asc(schema.domains.createdAt), asc(schema.domains.id));
+    // Serving domains first, then oldest. "Oldest keeps working" only holds
+    // if the oldest actually works: an org whose first domain never finished
+    // DNS would otherwise keep that one and lock the one carrying its links.
+    .orderBy(
+      sql`case when ${schema.domains.status} = 'active' then 0 else 1 end`,
+      asc(schema.domains.createdAt),
+      asc(schema.domains.id),
+    );
 
   const moving = rows.flatMap((row, index) => {
     const lockedAt = index < limit ? null : (row.lockedAt ?? now);
@@ -145,7 +157,11 @@ async function reconcileDomainLocks(
         .where(eq(schema.domains.id, row.id)),
     ),
   );
-  return { count: rows.length, changed: moving.map((row) => row.hostname) };
+  return {
+    count: rows.length,
+    changed: moving.map((row) => row.hostname),
+    locked: rows.flatMap((row, index) => (index < limit ? [] : [row.hostname])),
+  };
 }
 
 /**
@@ -264,11 +280,22 @@ async function reconcileOrg(
     warnedAt,
   });
 
+  // Every locked domain when the deadline moved, only the ones whose lock
+  // moved otherwise. `servesUntil` in KV is built from the org's
+  // `graceEndsAt` (see desiredKvValue), so a restarted grace that republished
+  // nothing left already-locked hosts carrying the *old* deadline: pro to
+  // hobby, thirty days, then hobby to free, and two domains 404 through a
+  // grace period D1 says is still running.
+  //
   // After the row is written, so the KV value the sync reads carries this
   // pass's deadline rather than the one it replaced.
+  const republish =
+    graceEndsAt === (previous?.graceEndsAt ?? null)
+      ? domains.changed
+      : [...new Set([...domains.changed, ...domains.locked])];
   await enqueueStorage(
     env,
-    domains.changed.map((hostname) => syncDomainMsg(hostname)),
+    republish.map((hostname) => syncDomainMsg(hostname)),
   );
 
   return { over, graceEndsAt, notifiedAt };
@@ -336,7 +363,7 @@ export async function reconcileUser(
     const limits = PLAN_LIMITS[plan];
 
     const orgs = await ownedOrgs(db, userId);
-    await reconcileOrgLocks(db, orgs, limits.orgs, now);
+    const newlyLocked = await reconcileOrgLocks(db, orgs, limits.orgs, now);
     // Each org is reconciled against the same plan and touches only its own
     // rows, so they run together.
     await Promise.all(
@@ -345,10 +372,50 @@ export async function reconcileUser(
         await notifyDowngrade(env, db, org, plan, state, now);
       }),
     );
+    // Being over the *owned-org* cap is a fact about the user, not about any
+    // one org, so it has no `over` entry and no per-org email would ever
+    // mention it (#160). Without this an owner whose only breach is the org
+    // cap heard nothing at all: two of their orgs went read-only and the
+    // first they knew of it was opening the app.
+    await notifyOrgsLocked(env, db, userId, plan, newlyLocked);
   } catch (error) {
     captureAlert([{ event: "reconcile_failed", userId }]);
     console.error("reconcile_failed", userId, error);
   }
+}
+
+/** Tells an owner which orgs went read-only, and that they may pick a
+ * different one. Best-effort: a failed send must not turn a reconciliation
+ * whose D1 writes all landed into a `reconcile_failed` alert. */
+async function notifyOrgsLocked(
+  env: Env,
+  db: DB,
+  userId: string,
+  plan: OrgPlan,
+  locked: { id: string; name: string }[],
+): Promise<void> {
+  if (!locked.length) return;
+  const rows = await db
+    .select({ email: schema.user.email })
+    .from(schema.user)
+    .where(eq(schema.user.id, userId));
+  const to = rows[0]?.email;
+  if (!to) return;
+  const limit = PLAN_LIMITS[plan].orgs;
+  const names = locked.map((org) => org.name).join(", ");
+  const heading =
+    locked.length === 1 ? `${names} is read-only` : `Some organizations are read-only`;
+  const body = renderEmail({
+    preheader: `Your plan covers ${limit === 1 ? "one organization" : `${limit} organizations`}.`,
+    heading,
+    paragraphs: [
+      `Your plan covers ${limit === 1 ? "one organization" : `${limit} organizations`}, and you own more, so ${names} ${locked.length === 1 ? "is" : "are"} now read-only.`,
+      "Nothing was deleted, and every link in them keeps redirecting.",
+      "Upgrade to unlock all of them, or open one and choose to keep it active instead.",
+    ],
+    cta: { label: "See your plan", url: `${env.APP_URL}/billing` },
+  });
+  await sendEmail(env, to, heading, body).catch(() => {});
 }
 
 /* ---------------- the two emails ---------------- */
@@ -394,8 +461,13 @@ async function sendDowngradeEmail(
   const to = await ownerEmail(db, org.id);
   if (!to) return false;
   const limits = PLAN_LIMITS[plan];
+  // Named for what is actually over. "loses its custom domains soon" went to
+  // every org with a grace period, including ones whose only breach was links
+  // or members and which lose nothing at all when the deadline passes.
   const heading =
-    kind === "now" ? `${org.name} is over its plan` : `${org.name} loses its custom domains soon`;
+    kind === "warning" && state.over.domains !== undefined
+      ? `${org.name} loses its custom domains soon`
+      : `${org.name} is over its plan`;
   const body = renderEmail({
     preheader: overSentence(state.over, limits),
     heading,
@@ -422,7 +494,11 @@ async function notifyDowngrade(
   now: number,
 ): Promise<void> {
   if (!isOverLimit(state.over) || state.notifiedAt !== null) return;
-  if (!(await sendDowngradeEmail(env, db, org, plan, state, "now"))) return;
+  // Best-effort, and unmarked on failure: the daily sweep retries it, and a
+  // dead Resend must not make a pass whose D1 writes all landed report
+  // `reconcile_failed`.
+  const sent = await sendDowngradeEmail(env, db, org, plan, state, "now").catch(() => false);
+  if (!sent) return;
   await db
     .update(schema.orgEntitlements)
     .set({ notifiedAt: now })
@@ -430,12 +506,25 @@ async function notifyDowngrade(
 }
 
 /**
- * The day-23 email, from the daily cron: every org whose grace has a week
- * left and has not been warned yet.
+ * The grace-period emails the daily cron owns: the day-23 warning, and any
+ * day-0 notice whose send failed at reconciliation time.
  *
- * A send failure leaves `warnedAt` null, so tomorrow's run tries again, and
- * the window is a week wide rather than a single day for the same reason.
+ * Reconciliation only runs on a plan change, so without the second of those a
+ * transient Resend outage meant the owner heard nothing for 23 days. A send
+ * failure leaves the marker null, so tomorrow's run tries again, and the
+ * warning window is a week wide rather than a single day for the same reason.
  */
+/**
+ * One pass emails at most this many orgs, in chunks this wide.
+ *
+ * A Workers invocation has a cap on concurrent subrequests, so a downgrade
+ * wave that started every send at once would fail the whole sweep. The
+ * warning window is a week wide, so a backlog drains over the following days
+ * instead of in one invocation.
+ */
+const EMAIL_BATCH = 50;
+const EMAIL_CONCURRENCY = 5;
+
 export async function sweepGraceWarnings(env: Env, db: DB, now = Date.now()): Promise<number> {
   const rows = await db
     .select({
@@ -444,41 +533,74 @@ export async function sweepGraceWarnings(env: Env, db: DB, now = Date.now()): Pr
       plan: schema.orgEntitlements.plan,
       overJson: schema.orgEntitlements.overJson,
       graceEndsAt: schema.orgEntitlements.graceEndsAt,
+      notifiedAt: schema.orgEntitlements.notifiedAt,
+      warnedAt: schema.orgEntitlements.warnedAt,
     })
     .from(schema.orgEntitlements)
     .innerJoin(schema.orgs, eq(schema.orgEntitlements.orgId, schema.orgs.id))
     .where(
       and(
-        isNull(schema.orgEntitlements.warnedAt),
         isNotNull(schema.orgEntitlements.graceEndsAt),
-        lte(schema.orgEntitlements.graceEndsAt, now + GRACE_WARNING_MS),
         sql`${schema.orgEntitlements.graceEndsAt} > ${now}`,
+        or(
+          // A day-0 send that failed at reconciliation time. Reconciliation
+          // only runs on a plan change, so nothing else would retry it.
+          isNull(schema.orgEntitlements.notifiedAt),
+          and(
+            isNull(schema.orgEntitlements.warnedAt),
+            lte(schema.orgEntitlements.graceEndsAt, now + GRACE_WARNING_MS),
+          ),
+        ),
       ),
-    );
+    )
+    .limit(EMAIL_BATCH);
 
-  const results = await Promise.all(
-    rows.map(async (row) => {
-      const state = {
-        over: parseOver(row.overJson),
-        graceEndsAt: row.graceEndsAt,
-        notifiedAt: null,
-      };
-      const org = { id: row.orgId, name: row.name };
-      const delivered = await sendDowngradeEmail(
-        env,
-        db,
-        org,
-        orgPlanOf(row.plan),
-        state,
-        "warning",
-      ).catch(() => false);
-      if (!delivered) return false;
-      await db
-        .update(schema.orgEntitlements)
-        .set({ warnedAt: now })
-        .where(eq(schema.orgEntitlements.orgId, row.orgId));
-      return true;
-    }),
-  );
-  return results.filter(Boolean).length;
+  let sent = 0;
+  for (let i = 0; i < rows.length; i += EMAIL_CONCURRENCY) {
+    const results = await Promise.all(
+      rows.slice(i, i + EMAIL_CONCURRENCY).map((row) => sweepOne(env, db, row, now)),
+    );
+    sent += results.filter(Boolean).length;
+  }
+  return sent;
+}
+
+/**
+ * Sends one org's outstanding email and marks it.
+ *
+ * Every failure is caught here, the marker included: a row whose update threw
+ * would otherwise take the rest of its chunk down with it, and rows already
+ * emailed in this pass would lose their marker and be emailed again tomorrow.
+ */
+async function sweepOne(
+  env: Env,
+  db: DB,
+  row: {
+    orgId: string;
+    name: string;
+    plan: string;
+    overJson: string;
+    graceEndsAt: number | null;
+    notifiedAt: number | null;
+  },
+  now: number,
+): Promise<boolean> {
+  const kind = row.notifiedAt === null ? "now" : "warning";
+  try {
+    const state = {
+      over: parseOver(row.overJson),
+      graceEndsAt: row.graceEndsAt,
+      notifiedAt: row.notifiedAt,
+    };
+    const org = { id: row.orgId, name: row.name };
+    if (!(await sendDowngradeEmail(env, db, org, orgPlanOf(row.plan), state, kind))) return false;
+    await db
+      .update(schema.orgEntitlements)
+      .set(kind === "now" ? { notifiedAt: now } : { warnedAt: now })
+      .where(eq(schema.orgEntitlements.orgId, row.orgId));
+    return true;
+  } catch {
+    // Left unmarked on purpose, so tomorrow's run tries again.
+    return false;
+  }
 }

--- a/src/worker/reconcile.ts
+++ b/src/worker/reconcile.ts
@@ -475,7 +475,7 @@ async function sendDowngradeEmail(
       `${org.name} is on the ${plan} plan and holds ${overSentence(state.over, limits)}.`,
       "Nothing was deleted. Your links, members and numbers are all still there.",
       ...graceSentence(state.graceEndsAt, state.over.domains !== undefined),
-      "Upgrade to put everything back, or leave it: over-limit resources stay read-only until you do.",
+      "Upgrade to put it all back. If you leave it, you keep what you have and cannot add more.",
     ],
     cta: { label: "See your plan", url: `${env.APP_URL}/billing` },
   });

--- a/src/worker/reconcile.ts
+++ b/src/worker/reconcile.ts
@@ -1,0 +1,430 @@
+import { and, asc, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
+import * as schema from "./db/schema";
+import type { DB, Env } from "./env";
+import { countActiveAddresses } from "./plan";
+import { enqueueStorage, syncDomainMsg } from "./storage";
+import { sendEmail } from "./email";
+import { renderEmail } from "./email-layout";
+import { captureAlert } from "./sentry";
+import {
+  GRACE_PERIOD_MS,
+  GRACE_WARNING_MS,
+  PLAN_LIMITS,
+  isOverLimit,
+  orgPlanOf,
+  type OrgPlan,
+  type OverLimits,
+  type PlanLimits,
+} from "@/shared/types";
+
+/**
+ * What a plan change means for the orgs a user owns (#158).
+ *
+ * Nothing here deletes and nothing here demotes an owner. It records what is
+ * over cap, marks which resources are locked, and lets the later slices act
+ * on those marks: `orgs.lockedAt` refuses writes in requireOrgRole,
+ * `domains.lockedAt` plus the org's `graceEndsAt` become the redirect path's
+ * verdict in KV, and `orgMembers.previousRole` is what an upgrade reads to
+ * put everybody back.
+ *
+ * Idempotent by construction. Every decision is recomputed from the live
+ * rows, and the one value that could drift — when the grace ends — is only
+ * moved when the plan the last pass compared against is not the plan this
+ * one sees. Running it twice for the same plan changes nothing.
+ */
+
+/** The over-limit map as stored, parsed back with anything unrecognised dropped. */
+export function parseOver(json: string): OverLimits {
+  // SAFETY: written by writeEntitlement below, which stringifies an
+  // OverLimits. A row hand-edited into something else reads back as a
+  // partial object of numbers, and each field is checked before use.
+  const raw = JSON.parse(json || "{}") as Record<string, unknown>;
+  const over: OverLimits = {};
+  for (const key of ["links", "members", "domains"] as const) {
+    const value = raw[key];
+    if (typeof value === "number" && Number.isFinite(value)) over[key] = value;
+  }
+  return over;
+}
+
+/** The orgs a user owns, oldest first, which is the order every default here
+ * follows: longest-standing keeps working. */
+async function ownedOrgs(db: DB, userId: string) {
+  return db
+    .select({
+      id: schema.orgs.id,
+      name: schema.orgs.name,
+      lockedAt: schema.orgs.lockedAt,
+    })
+    .from(schema.orgMembers)
+    .innerJoin(schema.orgs, eq(schema.orgMembers.orgId, schema.orgs.id))
+    .where(and(eq(schema.orgMembers.userId, userId), eq(schema.orgMembers.role, "owner")))
+    .orderBy(asc(schema.orgs.createdAt), asc(schema.orgs.id));
+}
+
+async function setOrgLock(db: DB, orgId: string, lockedAt: number | null): Promise<void> {
+  await db.update(schema.orgs).set({ lockedAt }).where(eq(schema.orgs.id, orgId));
+}
+
+/**
+ * Which of the user's orgs stay active (#160).
+ *
+ * The owner's own choice is what is already in the column, so this only ever
+ * moves the count: lock the newest active orgs when there are too many,
+ * unlock the oldest locked ones when the plan allows more again. An owner who
+ * unlocked their second org and locked their first keeps that arrangement
+ * through every later pass.
+ */
+async function reconcileOrgLocks(
+  db: DB,
+  orgs: { id: string; lockedAt: number | null }[],
+  limit: number,
+  now: number,
+): Promise<void> {
+  const active = orgs.filter((o) => o.lockedAt === null);
+  if (active.length > limit) {
+    for (const org of active.slice(limit)) {
+      await setOrgLock(db, org.id, now);
+      org.lockedAt = now;
+    }
+    return;
+  }
+  const locked = orgs.filter((o) => o.lockedAt !== null);
+  for (const org of locked.slice(0, limit - active.length)) {
+    await setOrgLock(db, org.id, null);
+    org.lockedAt = null;
+  }
+}
+
+/**
+ * Locks the domains beyond the org's cap, oldest kept (#159).
+ *
+ * Returns the hostnames whose verdict changed, so only those get a KV
+ * republish: the value carries the deadline, so a domain whose lock did not
+ * move needs no write.
+ */
+async function reconcileDomainLocks(
+  db: DB,
+  orgId: string,
+  limit: number,
+  now: number,
+): Promise<{ count: number; changed: string[] }> {
+  const rows = await db
+    .select({
+      id: schema.domains.id,
+      hostname: schema.domains.hostname,
+      lockedAt: schema.domains.lockedAt,
+    })
+    .from(schema.domains)
+    .where(eq(schema.domains.orgId, orgId))
+    .orderBy(asc(schema.domains.createdAt), asc(schema.domains.id));
+
+  const changed: string[] = [];
+  for (const [index, row] of rows.entries()) {
+    const lockedAt = index < limit ? null : (row.lockedAt ?? now);
+    if (lockedAt === row.lockedAt) continue;
+    await db.update(schema.domains).set({ lockedAt }).where(eq(schema.domains.id, row.id));
+    changed.push(row.hostname);
+  }
+  return { count: rows.length, changed };
+}
+
+/**
+ * Demotes the members beyond the org's cap to viewer, and restores whoever
+ * fits again (#161).
+ *
+ * Longest-standing keeps write access and the owner is always among them, so
+ * the outcome does not depend on who happened to log in. Nobody is removed:
+ * a viewer keeps their membership, their seat and everything they could read.
+ */
+async function reconcileMemberRoles(
+  db: DB,
+  orgId: string,
+  limit: number,
+): Promise<{ count: number; demoted: string[] }> {
+  const rows = await db
+    .select({
+      userId: schema.orgMembers.userId,
+      role: schema.orgMembers.role,
+      previousRole: schema.orgMembers.previousRole,
+    })
+    .from(schema.orgMembers)
+    .where(eq(schema.orgMembers.orgId, orgId))
+    .orderBy(asc(schema.orgMembers.createdAt), asc(schema.orgMembers.userId));
+
+  const owner = rows.find((r) => r.role === "owner");
+  const rest = rows.filter((r) => r !== owner);
+  const keep = new Set([
+    ...(owner ? [owner.userId] : []),
+    ...rest.slice(0, Math.max(0, limit - (owner ? 1 : 0))).map((r) => r.userId),
+  ]);
+
+  const demoted: string[] = [];
+  for (const row of rows) {
+    if (keep.has(row.userId)) {
+      // Back inside the cap: whatever they were before the demotion, they are
+      // again. A role an admin set by hand since has no previousRole, so this
+      // never writes over a deliberate change.
+      if (row.previousRole === null) continue;
+      await db
+        .update(schema.orgMembers)
+        .set({ role: row.previousRole, previousRole: null })
+        .where(and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, row.userId)));
+      continue;
+    }
+    if (row.role === "viewer") continue;
+    await db
+      .update(schema.orgMembers)
+      .set({ role: "viewer", previousRole: row.role })
+      .where(and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, row.userId)));
+    demoted.push(row.userId);
+  }
+  return { count: rows.length, demoted };
+}
+
+async function readEntitlement(db: DB, orgId: string) {
+  const rows = await db
+    .select()
+    .from(schema.orgEntitlements)
+    .where(eq(schema.orgEntitlements.orgId, orgId));
+  return rows[0] ?? null;
+}
+
+/** One org's state after a pass, as the app reads it. */
+export interface OrgEntitlement {
+  over: OverLimits;
+  graceEndsAt: number | null;
+  /** When the day-0 email for this grace period went out; null while unsent. */
+  notifiedAt: number | null;
+}
+
+/**
+ * Reconciles one org against its owner's plan. Returns the state it wrote.
+ */
+export async function reconcileOrg(
+  env: Env,
+  db: DB,
+  org: { id: string; name: string },
+  plan: OrgPlan,
+  limits: PlanLimits,
+  now: number,
+): Promise<OrgEntitlement> {
+  const previous = await readEntitlement(db, org.id);
+  // A plan change is what restarts the clock. Comparing the stored plan (not
+  // a timestamp) is what keeps a repeat run from extending a grace period
+  // that is already counting down.
+  const planChanged = orgPlanOf(previous?.plan) !== plan || previous === null;
+
+  const links = await countActiveAddresses(db, org.id);
+  const domains = await reconcileDomainLocks(db, org.id, limits.domains, now);
+  const members = await reconcileMemberRoles(db, org.id, limits.members);
+
+  const over: OverLimits = {};
+  if (links > limits.links) over.links = links;
+  if (members.count > limits.members) over.members = members.count;
+  if (domains.count > limits.domains) over.domains = domains.count;
+
+  const stillOver = isOverLimit(over);
+  const graceEndsAt = !stillOver
+    ? null
+    : planChanged || previous?.graceEndsAt == null
+      ? now + GRACE_PERIOD_MS
+      : previous.graceEndsAt;
+  // The two emails belong to one grace period, so a new one starts unsent.
+  const keepNotices = !planChanged && graceEndsAt !== null;
+  const notifiedAt = keepNotices ? (previous?.notifiedAt ?? null) : null;
+
+  await writeEntitlement(db, {
+    orgId: org.id,
+    plan,
+    overJson: JSON.stringify(over),
+    graceEndsAt,
+    reconciledAt: now,
+    notifiedAt,
+    warnedAt: keepNotices ? (previous?.warnedAt ?? null) : null,
+  });
+
+  // After the row is written, so the KV value the sync reads carries this
+  // pass's deadline rather than the one it replaced.
+  await enqueueStorage(
+    env,
+    domains.changed.map((hostname) => syncDomainMsg(hostname)),
+  );
+
+  return { over, graceEndsAt, notifiedAt };
+}
+
+async function writeEntitlement(
+  db: DB,
+  row: typeof schema.orgEntitlements.$inferInsert,
+): Promise<void> {
+  await db
+    .insert(schema.orgEntitlements)
+    .values(row)
+    .onConflictDoUpdate({ target: schema.orgEntitlements.orgId, set: row });
+}
+
+/**
+ * Runs a pass over every org a user owns. Called after any billing event
+ * that changes `plan`, and by the admin's manual run.
+ *
+ * Never throws into its caller: a webhook that 500s earns a retry, and ten
+ * of those disable the endpoint. A reconciliation that failed is worth an
+ * alert and another pass, not a lost billing event.
+ */
+export async function reconcileUser(
+  env: Env,
+  db: DB,
+  userId: string,
+  now = Date.now(),
+): Promise<void> {
+  try {
+    const rows = await db
+      .select({ plan: schema.user.plan })
+      .from(schema.user)
+      .where(eq(schema.user.id, userId));
+    const plan = orgPlanOf(rows[0]?.plan);
+    const limits = PLAN_LIMITS[plan];
+
+    const orgs = await ownedOrgs(db, userId);
+    await reconcileOrgLocks(db, orgs, limits.orgs, now);
+    for (const org of orgs) {
+      const state = await reconcileOrg(env, db, org, plan, limits, now);
+      await notifyDowngrade(env, db, org, plan, state, now);
+    }
+  } catch (error) {
+    captureAlert([{ event: "reconcile_failed", userId }]);
+    console.error("reconcile_failed", userId, error);
+  }
+}
+
+/* ---------------- the two emails ---------------- */
+
+function overSentence(over: OverLimits, limits: PlanLimits): string {
+  const parts: string[] = [];
+  if (over.links !== undefined) parts.push(`${over.links} links (the plan allows ${limits.links})`);
+  if (over.members !== undefined)
+    parts.push(`${over.members} members (the plan allows ${limits.members})`);
+  if (over.domains !== undefined)
+    parts.push(
+      limits.domains === 0
+        ? `${over.domains} custom ${over.domains === 1 ? "domain" : "domains"} (this plan has none)`
+        : `${over.domains} custom domains (the plan allows ${limits.domains})`,
+    );
+  return parts.join(", ");
+}
+
+function graceSentence(graceEndsAt: number | null, hasDomains: boolean): string[] {
+  if (!graceEndsAt || !hasDomains) return [];
+  const date = new Date(graceEndsAt).toUTCString().slice(0, 16);
+  return [`Your custom domains keep redirecting until ${date}, then they stop.`];
+}
+
+/** Who to write to about an org: its owner. */
+async function ownerEmail(db: DB, orgId: string): Promise<string | null> {
+  const rows = await db
+    .select({ email: schema.user.email })
+    .from(schema.orgMembers)
+    .innerJoin(schema.user, eq(schema.orgMembers.userId, schema.user.id))
+    .where(and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.role, "owner")));
+  return rows[0]?.email ?? null;
+}
+
+async function sendDowngradeEmail(
+  env: Env,
+  db: DB,
+  org: { id: string; name: string },
+  plan: OrgPlan,
+  state: OrgEntitlement,
+  kind: "now" | "warning",
+): Promise<boolean> {
+  const to = await ownerEmail(db, org.id);
+  if (!to) return false;
+  const limits = PLAN_LIMITS[plan];
+  const heading =
+    kind === "now" ? `${org.name} is over its plan` : `${org.name} loses its custom domains soon`;
+  const body = renderEmail({
+    preheader: overSentence(state.over, limits),
+    heading,
+    paragraphs: [
+      `${org.name} is on the ${plan} plan and holds ${overSentence(state.over, limits)}.`,
+      "Nothing was deleted. Your links, members and numbers are all still there.",
+      ...graceSentence(state.graceEndsAt, state.over.domains !== undefined),
+      "Upgrade to put everything back, or leave it: over-limit resources stay read-only until you do.",
+    ],
+    cta: { label: "See your plan", url: `${env.APP_URL}/billing` },
+  });
+  await sendEmail(env, to, heading, body);
+  return true;
+}
+
+/** The day-0 email: sent once per grace period, right after the pass that
+ * started it. */
+async function notifyDowngrade(
+  env: Env,
+  db: DB,
+  org: { id: string; name: string },
+  plan: OrgPlan,
+  state: OrgEntitlement,
+  now: number,
+): Promise<void> {
+  if (!isOverLimit(state.over) || state.notifiedAt !== null) return;
+  if (!(await sendDowngradeEmail(env, db, org, plan, state, "now"))) return;
+  await db
+    .update(schema.orgEntitlements)
+    .set({ notifiedAt: now })
+    .where(eq(schema.orgEntitlements.orgId, org.id));
+}
+
+/**
+ * The day-23 email, from the daily cron: every org whose grace has a week
+ * left and has not been warned yet.
+ *
+ * A send failure leaves `warnedAt` null, so tomorrow's run tries again, and
+ * the window is a week wide rather than a single day for the same reason.
+ */
+export async function sweepGraceWarnings(env: Env, db: DB, now = Date.now()): Promise<number> {
+  const rows = await db
+    .select({
+      orgId: schema.orgEntitlements.orgId,
+      name: schema.orgs.name,
+      plan: schema.orgEntitlements.plan,
+      overJson: schema.orgEntitlements.overJson,
+      graceEndsAt: schema.orgEntitlements.graceEndsAt,
+    })
+    .from(schema.orgEntitlements)
+    .innerJoin(schema.orgs, eq(schema.orgEntitlements.orgId, schema.orgs.id))
+    .where(
+      and(
+        isNull(schema.orgEntitlements.warnedAt),
+        isNotNull(schema.orgEntitlements.graceEndsAt),
+        lte(schema.orgEntitlements.graceEndsAt, now + GRACE_WARNING_MS),
+        sql`${schema.orgEntitlements.graceEndsAt} > ${now}`,
+      ),
+    );
+
+  let sent = 0;
+  for (const row of rows) {
+    const state = {
+      over: parseOver(row.overJson),
+      graceEndsAt: row.graceEndsAt,
+      notifiedAt: null,
+    };
+    const org = { id: row.orgId, name: row.name };
+    const delivered = await sendDowngradeEmail(
+      env,
+      db,
+      org,
+      orgPlanOf(row.plan),
+      state,
+      "warning",
+    ).catch(() => false);
+    if (!delivered) continue;
+    await db
+      .update(schema.orgEntitlements)
+      .set({ warnedAt: now })
+      .where(eq(schema.orgEntitlements.orgId, row.orgId));
+    sent++;
+  }
+  return sent;
+}

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -21,6 +21,7 @@ import {
 import { fillSeries, computeDelta, deleteOrg } from "./orgs";
 import { orgPlan } from "../plan";
 import { effectivePlanSql, subscriptionGrantsAccess } from "../entitlement";
+import { reconcileUser } from "../reconcile";
 import { jsonBodyLimit } from "../body-limit";
 import { adminLinkRoutes } from "./admin-links";
 import { recordAdminAction } from "../audit";
@@ -812,6 +813,13 @@ async function writeComp(
   if (result.meta.changes === 0) throw new HTTPException(404, { message: "User not found" });
 }
 
+/** Grant and revoke both change `plan`, so both owe the owner's orgs a pass
+ * (#158). Manual too: an admin fixing a stuck org runs this route. */
+adminRoutes.post("/users/:userId/reconcile", async (c) => {
+  await reconcileUser(c.env, c.var.db, c.req.param("userId"));
+  return c.json({ ok: true });
+});
+
 /** What the comp route reads off its request body. */
 interface CompBody {
   plan?: string;
@@ -837,6 +845,7 @@ adminRoutes.post("/users/:userId/comp", async (c) => {
     reason,
     grantedBy: c.var.user!.id,
   });
+  await reconcileUser(c.env, c.var.db, c.req.param("userId"));
   await recordAdminAction(c.env, {
     actorUserId: c.var.user!.id,
     action: "user.comp_grant",
@@ -851,6 +860,7 @@ adminRoutes.post("/users/:userId/comp", async (c) => {
  * `plan` re-derives from the columns the webhook owns. */
 adminRoutes.delete("/users/:userId/comp", async (c) => {
   await writeComp(c.var.db, c.req.param("userId"), null);
+  await reconcileUser(c.env, c.var.db, c.req.param("userId"));
   await recordAdminAction(c.env, {
     actorUserId: c.var.user!.id,
     action: "user.comp_revoke",

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -606,6 +606,9 @@ adminRoutes.get("/orgs/:orgId", async (c) => {
         email: schema.user.email,
         role: schema.orgMembers.role,
         createdAt: schema.orgMembers.createdAt,
+        // A downgrade demoted this member to viewer (#161), rather than
+        // anybody choosing it. Worth seeing from admin too.
+        demoted: sql<boolean>`${schema.orgMembers.previousRole} is not null`,
       })
       .from(schema.orgMembers)
       .innerJoin(schema.user, eq(schema.orgMembers.userId, schema.user.id))

--- a/src/worker/routes/auth.ts
+++ b/src/worker/routes/auth.ts
@@ -7,6 +7,7 @@ import { requireUser } from "../guards";
 import { jsonBodyLimit } from "../body-limit";
 import type { AppConfig, CurrentUser } from "@/shared/types";
 import { orgPlanOf } from "@/shared/types";
+import { parseOver } from "../reconcile";
 
 // Signup/login/logout/verification live under /api/auth/* (BetterAuth).
 // This router only exposes the app-level session view, mounted at /api.
@@ -38,9 +39,14 @@ async function currentUserFor(
         qrEyeColor: schema.orgs.qrEyeColor,
         qrLogoSize: schema.orgs.qrLogoSize,
         defaultDomainId: schema.orgs.defaultDomainId,
+        lockedAt: schema.orgs.lockedAt,
+        overJson: schema.orgEntitlements.overJson,
+        graceEndsAt: schema.orgEntitlements.graceEndsAt,
       })
       .from(schema.orgMembers)
       .innerJoin(schema.orgs, eq(schema.orgMembers.orgId, schema.orgs.id))
+      // Left join: an org nothing has reconciled yet has no row, and is fine.
+      .leftJoin(schema.orgEntitlements, eq(schema.orgEntitlements.orgId, schema.orgs.id))
       .leftJoin(
         ownerMember,
         and(eq(ownerMember.orgId, schema.orgs.id), eq(ownerMember.role, "owner")),
@@ -69,6 +75,9 @@ async function currentUserFor(
     qrEyeColor: r.qrEyeColor,
     qrLogoSize: r.qrLogoSize,
     defaultDomainId: r.defaultDomainId,
+    locked: r.lockedAt != null,
+    over: parseOver(r.overJson ?? "{}"),
+    graceEndsAt: r.graceEndsAt,
   }));
   return {
     user: {

--- a/src/worker/routes/billing.ts
+++ b/src/worker/routes/billing.ts
@@ -345,11 +345,19 @@ export async function handlePolarWebhook(req: Request, env: Env): Promise<Respon
   // which is a success as far as Polar is concerned — anything other than a
   // 2xx here earns a retry, and ten consecutive non-2xx responses disable
   // the endpoint outright.
+  // Read *before* the mutation, because `subscription.revoked` clears
+  // `polar_subscription_id`, which is the only thing `subjectOf` has to go on
+  // for an event that carries no metadata.userId. Resolving afterwards
+  // matched no row, so the plan dropped to free and no org was ever locked or
+  // demoted: exactly the case #158 exists for.
+  const subjectId = PLAN_EVENTS.has(event.type) ? await subjectIdOf(db, event) : null;
   const mutation = await mutationFor(db, env, event);
   if (mutation) {
     const result = await mutation;
     if (result.meta.changes === 0) await alertIfNoSuchSubject(db, event);
-    else if (PLAN_EVENTS.has(event.type)) await reconcileSubject(db, env, event);
+    // `reconcileUser` swallows its own failures: a webhook that 500s earns a
+    // retry, and ten of those disable the endpoint.
+    else if (subjectId) await reconcileUser(env, db, subjectId);
   }
   return Response.json({ received: true });
 }
@@ -366,18 +374,12 @@ const PLAN_EVENTS = new Set([
   "subscription.updated",
 ]);
 
-/**
- * Runs the pass for whoever the event addressed, once the write landed.
- *
- * The subject is re-read rather than taken from the event, because
- * `subjectOf` resolves through the subscription id for events that carry no
- * metadata. `reconcileUser` swallows its own failures: a webhook that 500s
- * earns a retry, and ten of those disable the endpoint.
- */
-async function reconcileSubject(db: Db, env: Env, event: PolarEvent): Promise<void> {
+/** Which user this event addresses, resolved against the row as it stands
+ * now. Read before any mutation writes over the columns `subjectOf` matches
+ * on (see handlePolarWebhook). */
+async function subjectIdOf(db: Db, event: PolarEvent): Promise<string | null> {
   const rows = await db.select({ id: schema.user.id }).from(schema.user).where(subjectOf(event));
-  const userId = rows[0]?.id;
-  if (userId) await reconcileUser(env, db, userId);
+  return rows[0]?.id ?? null;
 }
 
 /**

--- a/src/worker/routes/billing.ts
+++ b/src/worker/routes/billing.ts
@@ -5,11 +5,12 @@ import { Polar } from "@polar-sh/sdk";
 import { Webhook } from "standardwebhooks";
 import { drizzle } from "drizzle-orm/d1";
 import * as schema from "../db/schema";
-import type { AppEnv, Env } from "../env";
+import type { AppEnv, DB, Env } from "../env";
 import type { JsonValue } from "../../shared/types";
 import { requireUser } from "../guards";
 import { captureAlert } from "../sentry";
 import { effectivePlanSql } from "../entitlement";
+import { reconcileUser } from "../reconcile";
 import { jsonBodyLimit } from "../body-limit";
 import type { BillingProvider } from "../billing-provider";
 
@@ -105,7 +106,9 @@ interface PolarEvent {
   };
 }
 
-type Db = ReturnType<typeof drizzle>;
+// The schema-bound client `handlePolarWebhook` builds; the mutations below
+// and the reconciliation pass share it.
+type Db = DB;
 
 /**
  * When the state an event describes was set at Polar. Events without either
@@ -346,8 +349,35 @@ export async function handlePolarWebhook(req: Request, env: Env): Promise<Respon
   if (mutation) {
     const result = await mutation;
     if (result.meta.changes === 0) await alertIfNoSuchSubject(db, event);
+    else if (PLAN_EVENTS.has(event.type)) await reconcileSubject(db, env, event);
   }
   return Response.json({ received: true });
+}
+
+/**
+ * The events that can move `plan`, and so the ones that owe the user's orgs
+ * a reconciliation pass (#158). `subscription.canceled` and
+ * `subscription.uncanceled` only flip the period-end flags, so they cannot
+ * put an org over its caps.
+ */
+const PLAN_EVENTS = new Set([
+  "subscription.active",
+  "subscription.revoked",
+  "subscription.updated",
+]);
+
+/**
+ * Runs the pass for whoever the event addressed, once the write landed.
+ *
+ * The subject is re-read rather than taken from the event, because
+ * `subjectOf` resolves through the subscription id for events that carry no
+ * metadata. `reconcileUser` swallows its own failures: a webhook that 500s
+ * earns a retry, and ten of those disable the endpoint.
+ */
+async function reconcileSubject(db: Db, env: Env, event: PolarEvent): Promise<void> {
+  const rows = await db.select({ id: schema.user.id }).from(schema.user).where(subjectOf(event));
+  const userId = rows[0]?.id;
+  if (userId) await reconcileUser(env, db, userId);
 }
 
 /**

--- a/src/worker/routes/domains.ts
+++ b/src/worker/routes/domains.ts
@@ -272,6 +272,7 @@ function toDTO(row: typeof schema.domains.$inferSelect): DomainDTO {
     statusReason: row.statusReason,
     rootRedirect: row.rootRedirect,
     createdAt: row.createdAt,
+    lockedAt: row.lockedAt,
   };
 }
 
@@ -352,6 +353,7 @@ domainRoutes.post("/", async (c) => {
     statusReason: "",
     rootRedirect: "",
     cfHostnameId: null,
+    lockedAt: null,
     createdAt: Date.now(),
   };
   // Atomic: the org's domains cap is re-checked at write time inside one D1

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -38,6 +38,7 @@ import type {
   LinkInput,
   OrgPlan,
   PlanLimits,
+  QrOverrides,
   QuotaUsage,
   TopEntry,
 } from "@/shared/types";
@@ -198,17 +199,29 @@ async function assertAliasQuota(db: DB, linkId: string): Promise<void> {
     });
 }
 
-/** True when the body carries any QR appearance override (a paid feature). */
-function hasQrOverride(body: LinkInput): boolean {
-  return !!(
-    body.qrLogo ||
-    body.qrStyle ||
-    body.qrColor ||
-    body.qrCorner ||
-    body.qrBg ||
-    body.qrEyeColor ||
-    body.qrLogoSize != null
-  );
+const QR_FIELDS = ["qrLogo", "qrStyle", "qrColor", "qrCorner", "qrBg", "qrEyeColor"] as const;
+
+/**
+ * True when the body would *set* a QR appearance field to something other
+ * than what is already stored (#162).
+ *
+ * Not "carries QR fields": the editor loads a link's styling and sends it
+ * back with every save, so a plain title edit on a downgraded org's link
+ * arrives carrying the same logo and colours it has always had. Refusing
+ * that used to leave the client only one way out, which was to wipe the
+ * fields — so fixing a typo destroyed styling somebody paid for.
+ *
+ * Clearing is always allowed. Giving up a paid look needs no plan, and an
+ * owner who wants their downgraded link plain should not have to upgrade to
+ * say so.
+ */
+function changesQr(body: LinkInput, existing: Partial<QrOverrides> | null): boolean {
+  for (const field of QR_FIELDS) {
+    const next = body[field];
+    if (!next) continue;
+    if (next !== (existing?.[field] ?? "")) return true;
+  }
+  return body.qrLogoSize != null && body.qrLogoSize !== (existing?.qrLogoSize ?? null);
 }
 
 /** Fetch a link inside an org or 404. */
@@ -464,10 +477,17 @@ async function domainHostname(
 ): Promise<string | null> {
   if (!domainId) return null;
   const rows = await db
-    .select({ hostname: schema.domains.hostname })
+    .select({ hostname: schema.domains.hostname, lockedAt: schema.domains.lockedAt })
     .from(schema.domains)
     .where(and(eq(schema.domains.id, domainId), eq(schema.domains.orgId, orgId)));
   if (!rows[0]) throw new HTTPException(400, { message: "Unknown domain for this org" });
+  // A locked domain stops serving when the org's grace period ends (#159), so
+  // it takes no new links: one that landed here would die on a known date.
+  if (rows[0].lockedAt !== null)
+    throw new HTTPException(402, {
+      message: "That domain is locked: upgrade to use it again",
+      cause: { code: "domain_locked" },
+    });
   return rows[0].hostname;
 }
 
@@ -481,10 +501,15 @@ function assertLinkQuota(count: number, plan: OrgPlan, limits: PlanLimits): void
     });
 }
 
-function assertQrAllowed(body: LinkInput, limits: PlanLimits): void {
-  if (hasQrOverride(body) && !limits.qrCustom)
+function assertQrAllowed(
+  body: LinkInput,
+  limits: PlanLimits,
+  existing: Partial<QrOverrides> | null,
+): void {
+  if (changesQr(body, existing) && !limits.qrCustom)
     throw new HTTPException(402, {
-      message: "QR customization is a paid feature: upgrade to use it",
+      message: "Changing the QR code's look is a paid feature: upgrade to use it",
+      cause: { code: "qr_locked" },
     });
 }
 
@@ -740,7 +765,7 @@ linkRoutes.post("/", requireOrgRole("member"), async (c) => {
     orgPlan(db, orgId),
     countActiveAddresses(db, orgId),
   ]);
-  assertQrAllowed(body, limits);
+  assertQrAllowed(body, limits, null);
 
   const domainId = body.domainId ?? null;
   // Slugs on the shared domain are always random (every plan): chosen slugs
@@ -906,8 +931,10 @@ linkRoutes.patch("/:linkId", requireOrgRole("member"), async (c) => {
   validateInput(body, orgId, true);
   const db = c.var.db;
   const { limits } = await orgPlan(db, orgId);
-  assertQrAllowed(body, limits);
   const existing = await findLink(db, orgId, c.req.param("linkId")!);
+  // After the row is read: what the plan gates is a *change* to the styling,
+  // not the styling arriving back unchanged with an edit to some other field.
+  assertQrAllowed(body, limits, existing);
 
   const domainId = body.domainId !== undefined ? body.domainId : existing.domainId;
   // A link's domain is fixed after creation (see `#38`): its aliases are

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -484,7 +484,7 @@ function assertQrAllowed(
 ): void {
   if (changesQr(body, existing) && !limits.qrCustom)
     throw new HTTPException(402, {
-      message: "Changing the QR code's look is a paid feature: upgrade to use it",
+      message: "Changing how QR codes look needs a paid plan",
       cause: { code: "qr_locked" },
     });
 }

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -930,8 +930,11 @@ linkRoutes.patch("/:linkId", requireOrgRole("member"), async (c) => {
   const orgId = c.req.param("orgId")!;
   validateInput(body, orgId, true);
   const db = c.var.db;
-  const { limits } = await orgPlan(db, orgId);
-  const existing = await findLink(db, orgId, c.req.param("linkId")!);
+  // The plan and the row are independent reads, so they go out together.
+  const [{ limits }, existing] = await Promise.all([
+    orgPlan(db, orgId),
+    findLink(db, orgId, c.req.param("linkId")!),
+  ]);
   // After the row is read: what the plan gates is a *change* to the styling,
   // not the styling arriving back unchanged with an edit to some other field.
   assertQrAllowed(body, limits, existing);

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -26,6 +26,7 @@ import {
   resolveUtm,
   stripUtmParams,
   validateQrFields,
+  changesQr,
   ALIAS_TTL_MS,
 } from "../util";
 import { jsonBodyLimit } from "../body-limit";
@@ -197,31 +198,6 @@ async function assertAliasQuota(db: DB, linkId: string): Promise<void> {
       message: `This link already has ${MAX_ALIASES_PER_LINK} aliases, the most allowed. Remove one before adding another.`,
       cause: { code: "alias_limit_reached" },
     });
-}
-
-const QR_FIELDS = ["qrLogo", "qrStyle", "qrColor", "qrCorner", "qrBg", "qrEyeColor"] as const;
-
-/**
- * True when the body would *set* a QR appearance field to something other
- * than what is already stored (#162).
- *
- * Not "carries QR fields": the editor loads a link's styling and sends it
- * back with every save, so a plain title edit on a downgraded org's link
- * arrives carrying the same logo and colours it has always had. Refusing
- * that used to leave the client only one way out, which was to wipe the
- * fields — so fixing a typo destroyed styling somebody paid for.
- *
- * Clearing is always allowed. Giving up a paid look needs no plan, and an
- * owner who wants their downgraded link plain should not have to upgrade to
- * say so.
- */
-function changesQr(body: LinkInput, existing: Partial<QrOverrides> | null): boolean {
-  for (const field of QR_FIELDS) {
-    const next = body[field];
-    if (!next) continue;
-    if (next !== (existing?.[field] ?? "")) return true;
-  }
-  return body.qrLogoSize != null && body.qrLogoSize !== (existing?.qrLogoSize ?? null);
 }
 
 /** Fetch a link inside an org or 404. */

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -843,7 +843,11 @@ function mergedLinkUpdate(
     qrCorner: body.qrCorner ?? existing.qrCorner,
     qrBg: body.qrBg ?? existing.qrBg,
     qrEyeColor: body.qrEyeColor ?? existing.qrEyeColor,
-    qrLogoSize: body.qrLogoSize ?? existing.qrLogoSize,
+    // `undefined`, not nullish: `null` is how the client clears the logo
+    // size, and `??` swallowed it, so a reset silently kept the old value.
+    // The five fields above take "" for the same job, which is why only this
+    // one needed spelling out.
+    qrLogoSize: body.qrLogoSize !== undefined ? body.qrLogoSize : existing.qrLogoSize,
     ...riskAfterDestinationChange(existing, fields.destination),
   };
 }

--- a/src/worker/routes/links.ts
+++ b/src/worker/routes/links.ts
@@ -544,7 +544,7 @@ async function resolveRenamedSlug(
  * sorted here rather than in the browser: see links-page.ts for why the
  * browser cannot do either job once it only holds one page.
  */
-linkRoutes.get("/", requireOrgRole("member"), async (c) => {
+linkRoutes.get("/", requireOrgRole("viewer"), async (c) => {
   const params = readLinkPageParams(new URL(c.req.url));
   const query = linkPageQuery(c.req.param("orgId")!, params);
 
@@ -597,7 +597,7 @@ linkRoutes.post("/claim", requireOrgRole("member"), async (c) => {
   return c.json(await linkToDTO(c.var.db, c.req.param("orgId")!, link), 201);
 });
 
-linkRoutes.get("/quota-usage", requireOrgRole("member"), async (c) => {
+linkRoutes.get("/quota-usage", requireOrgRole("viewer"), async (c) => {
   const { quotaUsage, quotaUsageAt } = await quotaUsageFields(c.var.db, c.req.param("orgId")!);
   return c.json({ count: quotaUsage, at: quotaUsageAt });
 });
@@ -1029,7 +1029,7 @@ linkRoutes.delete("/:linkId", requireOrgRole("member"), async (c) => {
 
 /* ---------------- addresses (aliases + primary) ---------------- */
 
-linkRoutes.get("/:linkId/addresses", requireOrgRole("member"), async (c) => {
+linkRoutes.get("/:linkId/addresses", requireOrgRole("viewer"), async (c) => {
   const { db, link } = await linkFromRequest(c);
   const rows = await db
     .select({ address: schema.linkAddresses, hostname: schema.domains.hostname })

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -195,7 +195,7 @@ async function applyQrPatch(
   const existing = rows[0] ?? null;
   if (!limits.qrCustom && changesQr(body, existing))
     throw new HTTPException(402, {
-      message: "Changing the QR code's look is a paid feature: upgrade to use it",
+      message: "Changing how QR codes look needs a paid plan",
       cause: { code: "qr_locked" },
     });
   Object.assign(set, qrPatchFields(body));

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -250,7 +250,7 @@ orgRoutes.delete("/:orgId", requireOrgRole("owner", { allowWhileDeleting: true }
 
 /* ---------------- members ---------------- */
 
-orgRoutes.get("/:orgId/members", requireOrgRole("member"), async (c) => {
+orgRoutes.get("/:orgId/members", requireOrgRole("viewer"), async (c) => {
   const rows = await c.var.db
     .select({
       userId: schema.orgMembers.userId,
@@ -610,7 +610,7 @@ async function lookupInvite(db: DB, token: string) {
   return invite;
 }
 
-orgRoutes.get("/:orgId/stats", requireOrgRole("member"), async (c) => {
+orgRoutes.get("/:orgId/stats", requireOrgRole("viewer"), async (c) => {
   const db = c.var.db;
   const orgId = c.req.param("orgId");
   const { limits } = await orgPlan(db, orgId);
@@ -833,7 +833,7 @@ orgRoutes.get("/:orgId/stats", requireOrgRole("member"), async (c) => {
 
 /* ---------------- recent clicks feed (dashboard) ---------------- */
 
-orgRoutes.get("/:orgId/clicks", requireOrgRole("member"), async (c) => {
+orgRoutes.get("/:orgId/clicks", requireOrgRole("viewer"), async (c) => {
   const raw = parseInt(c.req.query("limit") ?? "", 10);
   const limit = Math.min(Math.max(Number.isFinite(raw) ? raw : 8, 1), 50);
   const rows = await c.var.db
@@ -862,7 +862,7 @@ orgRoutes.get("/:orgId/clicks", requireOrgRole("member"), async (c) => {
 
 /* ---------------- per-link stats ---------------- */
 
-orgRoutes.get("/:orgId/links/stats/:slug", requireOrgRole("member"), async (c) => {
+orgRoutes.get("/:orgId/links/stats/:slug", requireOrgRole("viewer"), async (c) => {
   const db = c.var.db;
   const orgId = c.req.param("orgId");
   const slug = c.req.param("slug");

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -317,11 +317,17 @@ orgRoutes.get("/:orgId/members", requireOrgRole("viewer"), async (c) => {
       email: schema.user.email,
       role: schema.orgMembers.role,
       createdAt: schema.orgMembers.createdAt,
+      previousRole: schema.orgMembers.previousRole,
     })
     .from(schema.orgMembers)
     .innerJoin(schema.user, eq(schema.orgMembers.userId, schema.user.id))
     .where(eq(schema.orgMembers.orgId, c.req.param("orgId")));
-  return c.json(rows satisfies MemberDTO[]);
+  return c.json(
+    rows.map(({ previousRole, ...row }) => ({
+      ...row,
+      demoted: previousRole !== null,
+    })) satisfies MemberDTO[],
+  );
 });
 
 /**

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import * as v from "valibot";
 import type { JsonValue } from "../../shared/types";
 import { HTTPException } from "hono/http-exception";
-import { eq, and, gte, desc, sql, isNull } from "drizzle-orm";
+import { eq, and, gte, desc, ne, sql, isNull } from "drizzle-orm";
 import * as schema from "../db/schema";
 import type { AppEnv, DB, Env } from "../env";
 import { requireUser } from "../guards";
@@ -15,6 +15,7 @@ import { uid, referrerHost, validateQrFields } from "../util";
 import { jsonBodyLimit } from "../body-limit";
 import { parseBody, inviteBodySchema } from "../schemas";
 import type {
+  UserOrg,
   MemberDTO,
   InviteDTO,
   OrgStats,
@@ -23,6 +24,7 @@ import type {
   InvitePreview,
   RecentClick,
 } from "@/shared/types";
+import { INVITABLE_ROLES } from "@/shared/types";
 
 export const orgRoutes = new Hono<AppEnv>();
 orgRoutes.use("*", jsonBodyLimit());
@@ -64,10 +66,54 @@ orgRoutes.post("/", requireUser, async (c) => {
       qrBg: "",
       qrEyeColor: "",
       qrLogoSize: null,
-    },
+      defaultDomainId: null,
+      locked: false,
+      over: {},
+      graceEndsAt: null,
+    } satisfies UserOrg,
     201,
   );
 });
+
+/**
+ * Keeps this org active, and locks whichever other one has to give way (#160).
+ *
+ * The owner is over their `orgs` cap and picks which one keeps working. The
+ * pick is reversible: calling this on the other org swaps them back. Runs on
+ * a locked org, which is the whole point, so it opts out of the lock guard.
+ */
+orgRoutes.post(
+  "/:orgId/keep-active",
+  requireOrgRole("owner", { allowWhileLocked: true }),
+  async (c) => {
+    const db = c.var.db;
+    const orgId = c.req.param("orgId");
+    const userId = c.var.user!.id;
+    const { limits } = await userPlan(db, userId);
+    const now = Date.now();
+
+    await db.update(schema.orgs).set({ lockedAt: null }).where(eq(schema.orgs.id, orgId));
+    // Now one too many are active, so the newest of the *others* gives way.
+    // Newest first, and never this one, which is what makes the pick stick
+    // where reconciliation's by-age default would have overruled it.
+    const active = await db
+      .select({ id: schema.orgs.id })
+      .from(schema.orgMembers)
+      .innerJoin(schema.orgs, eq(schema.orgMembers.orgId, schema.orgs.id))
+      .where(
+        and(
+          eq(schema.orgMembers.userId, userId),
+          eq(schema.orgMembers.role, "owner"),
+          isNull(schema.orgs.lockedAt),
+        ),
+      )
+      .orderBy(desc(schema.orgs.createdAt), desc(schema.orgs.id));
+    const surplus = active.length - limits.orgs;
+    for (const org of active.filter((o) => o.id !== orgId).slice(0, Math.max(0, surplus)))
+      await db.update(schema.orgs).set({ lockedAt: now }).where(eq(schema.orgs.id, org.id));
+    return c.json({ ok: true });
+  },
+);
 
 type OrgQrPatchBody = {
   qrLogo?: string;
@@ -160,10 +206,17 @@ async function resolveDefaultDomain(
 ): Promise<string | null> {
   if (domainId === null) return null;
   const rows = await db
-    .select({ status: schema.domains.status })
+    .select({ status: schema.domains.status, lockedAt: schema.domains.lockedAt })
     .from(schema.domains)
     .where(and(eq(schema.domains.id, domainId), eq(schema.domains.orgId, orgId)));
   if (!rows.length) throw new HTTPException(404, { message: "Unknown domain" });
+  // A locked domain stops serving when the grace period ends, so pointing new
+  // links at it would build a backlog of links that die on a known date (#159).
+  if (rows[0].lockedAt !== null)
+    throw new HTTPException(402, {
+      message: "That domain is locked: upgrade to use it again",
+      cause: { code: "domain_locked" },
+    });
   if (rows[0].status !== "active")
     throw new HTTPException(400, {
       message: "That domain is not serving yet, so it cannot be the default",
@@ -243,10 +296,16 @@ export async function deleteOrg(db: DB, env: Env, orgId: string): Promise<void> 
   }
 }
 
-orgRoutes.delete("/:orgId", requireOrgRole("owner", { allowWhileDeleting: true }), async (c) => {
-  await deleteOrg(c.var.db, c.env, c.req.param("orgId"));
-  return c.json({ ok: true });
-});
+// A locked org can still be deleted: deleting it is one of the two ways out
+// of the lock, and refusing would trap the owner.
+orgRoutes.delete(
+  "/:orgId",
+  requireOrgRole("owner", { allowWhileDeleting: true, allowWhileLocked: true }),
+  async (c) => {
+    await deleteOrg(c.var.db, c.env, c.req.param("orgId"));
+    return c.json({ ok: true });
+  },
+);
 
 /* ---------------- members ---------------- */
 
@@ -265,18 +324,52 @@ orgRoutes.get("/:orgId/members", requireOrgRole("viewer"), async (c) => {
   return c.json(rows satisfies MemberDTO[]);
 });
 
+/**
+ * How many of an org's members may write: everyone who is not a viewer.
+ *
+ * The member cap counts people in the org, viewers included, so a downgraded
+ * org stays over it however many are demoted. What the cap does bound is who
+ * may change anything, which is what the owner re-picks after a downgrade
+ * (#161).
+ */
+async function writingMembers(db: DB, orgId: string): Promise<number> {
+  const rows = await db
+    .select({ n: sql<number>`count(*)` })
+    .from(schema.orgMembers)
+    .where(and(eq(schema.orgMembers.orgId, orgId), ne(schema.orgMembers.role, "viewer")));
+  return rows[0]?.n ?? 0;
+}
+
 orgRoutes.patch("/:orgId/members/:userId", requireOrgRole("admin"), async (c) => {
-  const body = await c.req.json<{ role?: "admin" | "member" }>();
-  if (body.role !== "admin" && body.role !== "member")
-    throw new HTTPException(400, { message: "Role must be admin or member" });
+  const body = await c.req.json<{ role?: string }>();
+  const role = INVITABLE_ROLES.find((r) => r === body.role);
+  if (!role) throw new HTTPException(400, { message: "Role must be admin, member or viewer" });
   const { orgId, targetId } = await resolveMember(
     c.var.db,
     c.req.param("orgId"),
     c.req.param("userId"),
   );
+  const [current] = await c.var.db
+    .select({ role: schema.orgMembers.role })
+    .from(schema.orgMembers)
+    .where(memberWhere(orgId, targetId));
+  // Handing write access to somebody in an org that is already over its
+  // member cap has to take it from somebody else first, or the cap means
+  // nothing after a downgrade. Demoting is always allowed, which is what
+  // makes the swap possible.
+  if (role !== "viewer" && current?.role === "viewer") {
+    const { limits } = await orgPlan(c.var.db, orgId);
+    if ((await writingMembers(c.var.db, orgId)) >= limits.members)
+      throw new HTTPException(402, {
+        message: `This plan allows ${limits.members} members who can make changes: set someone else to viewer first`,
+        cause: { code: "member_limit" },
+      });
+  }
   await c.var.db
     .update(schema.orgMembers)
-    .set({ role: body.role })
+    // The role an admin sets by hand is the current one, so a later upgrade
+    // has nothing of its own to restore over it (#161).
+    .set({ role, previousRole: null })
     .where(memberWhere(orgId, targetId));
   return c.json({ ok: true });
 });

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -109,8 +109,14 @@ orgRoutes.post(
       )
       .orderBy(desc(schema.orgs.createdAt), desc(schema.orgs.id));
     const surplus = active.length - limits.orgs;
-    for (const org of active.filter((o) => o.id !== orgId).slice(0, Math.max(0, surplus)))
-      await db.update(schema.orgs).set({ lockedAt: now }).where(eq(schema.orgs.id, org.id));
+    const giveWay = active.filter((o) => o.id !== orgId).slice(0, Math.max(0, surplus));
+    // Independent single-row updates, so they go out together rather than one
+    // round trip at a time.
+    await Promise.all(
+      giveWay.map((org) =>
+        db.update(schema.orgs).set({ lockedAt: now }).where(eq(schema.orgs.id, org.id)),
+      ),
+    );
     return c.json({ ok: true });
   },
 );

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -2,16 +2,23 @@ import { Hono } from "hono";
 import * as v from "valibot";
 import type { JsonValue } from "../../shared/types";
 import { HTTPException } from "hono/http-exception";
-import { eq, and, gte, desc, ne, sql, isNull } from "drizzle-orm";
+import { eq, and, gte, desc, sql, isNull } from "drizzle-orm";
 import * as schema from "../db/schema";
 import type { AppEnv, DB, Env } from "../env";
 import { requireUser } from "../guards";
 import { requireOrgRole, orgRole } from "../org-role";
-import { orgPlan, userPlan, createOwnedOrg, acceptInviteAtomically } from "../plan";
+import {
+  orgPlan,
+  userPlan,
+  createOwnedOrg,
+  acceptInviteAtomically,
+  keepOrgActive,
+  setMemberRoleWithinLimit,
+} from "../plan";
 import { sendEmail } from "../email";
 import { renderEmail } from "../email-layout";
 import { deleteQrLogoMsg, enqueueStorage } from "../storage";
-import { uid, referrerHost, validateQrFields } from "../util";
+import { uid, referrerHost, validateQrFields, changesQr } from "../util";
 import { jsonBodyLimit } from "../body-limit";
 import { parseBody, inviteBodySchema } from "../schemas";
 import type {
@@ -75,6 +82,16 @@ orgRoutes.post("/", requireUser, async (c) => {
   );
 });
 
+/** Who owns this org. Every owned-org decision belongs to them, whoever is
+ * making the request. */
+async function orgOwnerId(db: DB, orgId: string): Promise<string | null> {
+  const rows = await db
+    .select({ userId: schema.orgMembers.userId })
+    .from(schema.orgMembers)
+    .where(and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.role, "owner")));
+  return rows[0]?.userId ?? null;
+}
+
 /**
  * Keeps this org active, and locks whichever other one has to give way (#160).
  *
@@ -86,37 +103,21 @@ orgRoutes.post(
   "/:orgId/keep-active",
   requireOrgRole("owner", { allowWhileLocked: true }),
   async (c) => {
-    const db = c.var.db;
-    const orgId = c.req.param("orgId");
-    const userId = c.var.user!.id;
-    const { limits } = await userPlan(db, userId);
-    const now = Date.now();
-
-    await db.update(schema.orgs).set({ lockedAt: null }).where(eq(schema.orgs.id, orgId));
-    // Now one too many are active, so the newest of the *others* gives way.
-    // Newest first, and never this one, which is what makes the pick stick
-    // where reconciliation's by-age default would have overruled it.
-    const active = await db
-      .select({ id: schema.orgs.id })
-      .from(schema.orgMembers)
-      .innerJoin(schema.orgs, eq(schema.orgMembers.orgId, schema.orgs.id))
-      .where(
-        and(
-          eq(schema.orgMembers.userId, userId),
-          eq(schema.orgMembers.role, "owner"),
-          isNull(schema.orgs.lockedAt),
-        ),
-      )
-      .orderBy(desc(schema.orgs.createdAt), desc(schema.orgs.id));
-    const surplus = active.length - limits.orgs;
-    const giveWay = active.filter((o) => o.id !== orgId).slice(0, Math.max(0, surplus));
-    // Independent single-row updates, so they go out together rather than one
-    // round trip at a time.
-    await Promise.all(
-      giveWay.map((org) =>
-        db.update(schema.orgs).set({ lockedAt: now }).where(eq(schema.orgs.id, org.id)),
-      ),
-    );
+    // The org's owner, not the caller: a platform admin passes
+    // requireOrgRole("owner") everywhere (see orgRole), and using their id
+    // here would unlock a customer's org against the admin's own plan and
+    // then lock one of the admin's orgs to pay for it.
+    const userId = await orgOwnerId(c.var.db, c.req.param("orgId"));
+    if (!userId) throw new HTTPException(404, { message: "Organization not found" });
+    const { limits } = await userPlan(c.var.db, userId);
+    // One transaction: two requests picking two different locked orgs could
+    // otherwise leave the owner with every org locked. See keepOrgActive.
+    await keepOrgActive(c.env, {
+      orgId: c.req.param("orgId"),
+      userId,
+      ownedOrgLimit: limits.orgs,
+      ts: Date.now(),
+    });
     return c.json({ ok: true });
   },
 );
@@ -182,19 +183,24 @@ async function applyQrPatch(
   set: Partial<typeof schema.orgs.$inferInsert>,
 ): Promise<string> {
   validateQrFields(body, orgId);
-  // QR customization is a paid feature, so are the org-level defaults.
-  const { limits } = await orgPlan(db, orgId);
-  if (!limits.qrCustom)
+  // The same rule the link editor's save follows (#162): what the plan gates
+  // is a *change* to the styling, not the styling arriving back unchanged
+  // alongside an edit to some other field. Org-level and link-level QR behave
+  // the same on a downgrade, which they did not before: one 402'd on any QR
+  // field being present while the other quietly wiped them.
+  const [{ limits }, rows] = await Promise.all([
+    orgPlan(db, orgId),
+    db.select().from(schema.orgs).where(eq(schema.orgs.id, orgId)),
+  ]);
+  const existing = rows[0] ?? null;
+  if (!limits.qrCustom && changesQr(body, existing))
     throw new HTTPException(402, {
-      message: "QR customization is a paid feature: upgrade to use it",
+      message: "Changing the QR code's look is a paid feature: upgrade to use it",
+      cause: { code: "qr_locked" },
     });
   Object.assign(set, qrPatchFields(body));
   if (body.qrLogo === undefined) return "";
-  const rows = await db
-    .select({ qrLogo: schema.orgs.qrLogo })
-    .from(schema.orgs)
-    .where(eq(schema.orgs.id, orgId));
-  return rows[0]?.qrLogo ?? "";
+  return existing?.qrLogo ?? "";
 }
 
 /**
@@ -336,22 +342,6 @@ orgRoutes.get("/:orgId/members", requireOrgRole("viewer"), async (c) => {
   );
 });
 
-/**
- * How many of an org's members may write: everyone who is not a viewer.
- *
- * The member cap counts people in the org, viewers included, so a downgraded
- * org stays over it however many are demoted. What the cap does bound is who
- * may change anything, which is what the owner re-picks after a downgrade
- * (#161).
- */
-async function writingMembers(db: DB, orgId: string): Promise<number> {
-  const rows = await db
-    .select({ n: sql<number>`count(*)` })
-    .from(schema.orgMembers)
-    .where(and(eq(schema.orgMembers.orgId, orgId), ne(schema.orgMembers.role, "viewer")));
-  return rows[0]?.n ?? 0;
-}
-
 orgRoutes.patch("/:orgId/members/:userId", requireOrgRole("admin"), async (c) => {
   const body = await c.req.json<{ role?: string }>();
   const role = INVITABLE_ROLES.find((r) => r === body.role);
@@ -361,28 +351,21 @@ orgRoutes.patch("/:orgId/members/:userId", requireOrgRole("admin"), async (c) =>
     c.req.param("orgId"),
     c.req.param("userId"),
   );
-  const [current] = await c.var.db
-    .select({ role: schema.orgMembers.role })
-    .from(schema.orgMembers)
-    .where(memberWhere(orgId, targetId));
-  // Handing write access to somebody in an org that is already over its
-  // member cap has to take it from somebody else first, or the cap means
-  // nothing after a downgrade. Demoting is always allowed, which is what
-  // makes the swap possible.
-  if (role !== "viewer" && current?.role === "viewer") {
-    const { limits } = await orgPlan(c.var.db, orgId);
-    if ((await writingMembers(c.var.db, orgId)) >= limits.members)
-      throw new HTTPException(402, {
-        message: `This plan allows ${limits.members} members who can make changes: set someone else to viewer first`,
-        cause: { code: "member_limit" },
-      });
-  }
-  await c.var.db
-    .update(schema.orgMembers)
-    // The role an admin sets by hand is the current one, so a later upgrade
-    // has nothing of its own to restore over it (#161).
-    .set({ role, previousRole: null })
-    .where(memberWhere(orgId, targetId));
+  // Guarded inside the statement, not from a count read first: two admins
+  // promoting two different viewers at once would both find room. Demoting is
+  // always allowed, which is what makes the swap possible.
+  const { limits } = await orgPlan(c.var.db, orgId);
+  const written = await setMemberRoleWithinLimit(c.env, {
+    orgId,
+    userId: targetId,
+    role,
+    memberLimit: limits.members,
+  });
+  if (!written)
+    throw new HTTPException(402, {
+      message: `This plan allows ${limits.members} members who can make changes: set someone else to viewer first`,
+      cause: { code: "member_limit" },
+    });
   return c.json({ ok: true });
 });
 

--- a/src/worker/routes/qr-logos.ts
+++ b/src/worker/routes/qr-logos.ts
@@ -65,7 +65,7 @@ qrLogoRoutes.post("/", requireOrgRole("member"), async (c) => {
   const { limits } = await orgPlan(c.var.db, c.req.param("orgId")!);
   if (!limits.qrCustom)
     throw new HTTPException(402, {
-      message: "QR customization is a paid feature: upgrade to use it",
+      message: "Changing how QR codes look needs a paid plan",
     });
 
   const type = c.req.header("content-type")?.split(";")[0].trim().toLowerCase() ?? "";

--- a/src/worker/schemas.ts
+++ b/src/worker/schemas.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import type { JsonValue } from "../shared/types";
+import { INVITABLE_ROLES, type JsonValue } from "../shared/types";
 import { HTTPException } from "hono/http-exception";
 
 /**
@@ -61,6 +61,6 @@ export const optionalFlag = v.optional(v.fallback(v.nullable(v.boolean()), null)
 const MAX_INVITE_EMAILS = 50;
 
 export const inviteBodySchema = v.object({
-  role: v.optional(v.picklist(["admin", "member"]), "member"),
+  role: v.optional(v.picklist(INVITABLE_ROLES), "member"),
   emails: v.optional(v.pipe(v.array(v.string()), v.maxLength(MAX_INVITE_EMAILS)), []),
 });

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -5,6 +5,7 @@ import * as schema from "./db/schema";
 import type { DB, Env } from "./env";
 import { buildDestination, qrLogoKeyFromUrl } from "./util";
 import { captureAlert } from "./sentry";
+import type { KVDomain } from "./kv";
 
 /**
  * Storage recovery. D1 is the source of truth. KV serves redirects and R2
@@ -142,18 +143,29 @@ async function desiredKvValue(db: DB, key: string): Promise<string | null> {
 
   if (key.startsWith("domain:")) {
     const hostname = key.slice("domain:".length);
+    // The org's grace period rides along, because a locked domain's verdict
+    // is "serves until X" and the redirect path may not read D1 to find X
+    // (#159). Left join: an org that has never been reconciled has no row,
+    // and its domains serve.
     const rows = await db
-      .select()
+      .select({
+        domain: schema.domains,
+        graceEndsAt: schema.orgEntitlements.graceEndsAt,
+      })
       .from(schema.domains)
+      .leftJoin(schema.orgEntitlements, eq(schema.orgEntitlements.orgId, schema.domains.orgId))
       .where(eq(schema.domains.hostname, hostname))
       .limit(1);
-    const domain = rows[0];
+    const domain = rows[0]?.domain;
     if (!domain || domain.status !== "active") return null;
     return JSON.stringify({
       domainId: domain.id,
       orgId: domain.orgId,
       rootRedirect: domain.rootRedirect,
-    });
+      // A locked domain with no grace on file has already run out: the
+      // absence of a deadline must not read as "serves forever".
+      servesUntil: domain.lockedAt === null ? null : (rows[0]?.graceEndsAt ?? domain.lockedAt),
+    } satisfies KVDomain);
   }
 
   // Unknown prefix: never enqueued, so leave it alone.

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -282,7 +282,7 @@ export function isValidHttpUrl(value: string): boolean {
 /* ---------------- QR appearance validation ---------------- */
 
 import { HTTPException } from "hono/http-exception";
-import { QR_CORNER_STYLES, QR_DOT_STYLES } from "@/shared/types";
+import { QR_CORNER_STYLES, QR_DOT_STYLES, type QrOverrides } from "@/shared/types";
 
 /**
  * Logo images live in R2; D1 rows store only the serving URL. Upload and
@@ -364,4 +364,32 @@ export function validateQrFields(fields: QrFields, orgId: string) {
   validateQrColor(fields.qrEyeColor, "QR eye color");
   // null = inherit; otherwise a sane footprint ratio (bigger stops scanning).
   validateQrLogoSize(fields.qrLogoSize);
+}
+
+const QR_FIELDS = ["qrLogo", "qrStyle", "qrColor", "qrCorner", "qrBg", "qrEyeColor"] as const;
+
+/**
+ * True when the body would *set* a QR appearance field to something other
+ * than what is already stored (#162).
+ *
+ * Not "carries QR fields": the editor loads a link's styling and sends it
+ * back with every save, so a plain title edit on a downgraded org's link
+ * arrives carrying the same logo and colours it has always had. Refusing
+ * that used to leave the client only one way out, which was to wipe the
+ * fields — so fixing a typo destroyed styling somebody paid for.
+ *
+ * Clearing is always allowed. Giving up a paid look needs no plan, and an
+ * owner who wants their downgraded link plain should not have to upgrade to
+ * say so.
+ */
+export function changesQr(
+  body: Partial<QrOverrides>,
+  existing: Partial<QrOverrides> | null,
+): boolean {
+  for (const field of QR_FIELDS) {
+    const next = body[field];
+    if (!next) continue;
+    if (next !== (existing?.[field] ?? "")) return true;
+  }
+  return body.qrLogoSize != null && body.qrLogoSize !== (existing?.qrLogoSize ?? null);
 }

--- a/tests/e2e/db.ts
+++ b/tests/e2e/db.ts
@@ -139,3 +139,26 @@ export async function compUser(
     `no user with email ${email}`,
   );
 }
+
+/**
+ * Reads one KV value through the dev Explorer.
+ *
+ * The redirect hot path answers from KV alone, so this is how a browser test
+ * checks the verdict the Worker will act on: the value is what a real
+ * reconciliation pass wrote, through the real storage queue, not a fixture.
+ */
+export async function kvValue(page: Page, key: string): Promise<JsonValue | null> {
+  const namespaces = await page.request.get(`${explorerUrl}/storage/kv/namespaces`);
+  expect(namespaces.ok()).toBe(true);
+  const listed = await namespaces.json();
+  const id = listed.result.find((n: { title: string }) => n.title.includes("LINKS"))?.id;
+  expect(id).toBeTruthy();
+  const value = await page.request.get(
+    `${explorerUrl}/storage/kv/namespaces/${id}/values/${encodeURIComponent(key)}`,
+  );
+  if (value.status() === 404) return null;
+  expect(value.ok()).toBe(true);
+  // SAFETY: every value this repo writes to LINKS is JSON it produced; the
+  // caller names the shape it asserts on.
+  return JSON.parse(await value.text()) as JsonValue;
+}

--- a/tests/e2e/db.ts
+++ b/tests/e2e/db.ts
@@ -14,11 +14,31 @@ interface ExplorerRaw {
   }[];
 }
 
-/** Runs raw SQL against the local D1 database via the dev Explorer API. */
+/** What a bound parameter may be at a call site: one SQL scalar. */
+export type SqlParam = string | number | boolean | null;
+
+/**
+ * One bound parameter, as the Explorer will accept it.
+ *
+ * It rejects anything that is not a string and says only "Invalid input",
+ * which reads like a broken statement rather than a rejected argument.
+ * SQLite's column affinity converts a numeric string back on the way in, so
+ * an integer column still holds an integer.
+ */
+function asExplorerParam(value: SqlParam): string | null {
+  return value === null ? null : String(value);
+}
+
+/**
+ * Runs raw SQL against the local D1 database via the dev Explorer API.
+ *
+ * Parameters go through `asExplorerParam`, which is where the Explorer's
+ * string-only rule is handled.
+ */
 export async function rawSql(
   page: Page,
   sql: string,
-  params: JsonValue[] = [],
+  params: SqlParam[] = [],
 ): Promise<ExplorerRaw> {
   const databases = await page.request.get(`${explorerUrl}/d1/database`);
   expect(databases.ok()).toBe(true);
@@ -27,9 +47,11 @@ export async function rawSql(
   expect(databaseId).toBeTruthy();
 
   const response = await page.request.post(`${explorerUrl}/d1/database/${databaseId}/raw`, {
-    data: { sql, params },
+    data: { sql, params: params.map(asExplorerParam) },
   });
-  expect(response.ok()).toBe(true);
+  // The body carries the actual complaint (a failed constraint, a rejected
+  // parameter). Without it a failure here is an opaque "expected true".
+  expect(response.ok(), `${sql}\n${await response.text()}`).toBe(true);
   return response.json();
 }
 
@@ -42,11 +64,7 @@ export async function rawSql(
  * an error, so the mistake surfaces later as a confusing assertion failure.
  * Callers get objects instead.
  */
-export async function queryRows<T>(
-  page: Page,
-  sql: string,
-  params: JsonValue[] = [],
-): Promise<T[]> {
+export async function queryRows<T>(page: Page, sql: string, params: SqlParam[] = []): Promise<T[]> {
   const { columns, rows } = (await rawSql(page, sql, params)).result[0].results;
   // SAFETY: the caller names the columns its own SELECT asks for. A column it
   // did not select reads as undefined and fails whichever assertion wanted it,
@@ -57,7 +75,7 @@ export async function queryRows<T>(
 async function expectOneRowChanged(
   page: Page,
   sql: string,
-  params: JsonValue[],
+  params: SqlParam[],
   what: string,
 ): Promise<void> {
   const result = await rawSql(page, sql, params);

--- a/tests/e2e/downgrade.pw.ts
+++ b/tests/e2e/downgrade.pw.ts
@@ -169,8 +169,8 @@ test("losing seats demotes the newest members to viewer, and says so", async ({
   test.slow();
   const email = await adminAccount(page, "downgrade-members");
 
-  // Pro allows 25 members; free allows 3, so one invited teammate on top of
-  // the owner is still inside the cap and a second is not.
+  // Pro allows 25 members; free allows 3 counting the owner, so two invited
+  // teammates are still inside the cap and a third is not.
   await setComp(page, email, "grant");
   const guests = [];
   for (const prefix of ["seat-a", "seat-b", "seat-c"]) {

--- a/tests/e2e/downgrade.pw.ts
+++ b/tests/e2e/downgrade.pw.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
-import { makePlatformAdmin, queryRows } from "./db";
+import { kvValue, makePlatformAdmin, queryRows } from "./db";
 import { signUpAndVerify } from "./resend";
-import { addActiveCustomDomain, createAdditionalOrg, createQuickLink } from "./orgs";
+import { addActiveCustomDomain, createAdditionalOrg, createQuickLink, guestAccount } from "./orgs";
 
 /**
  * What a downgrade looks like from the account it happens to (#158 to #163).
@@ -103,6 +103,29 @@ test("losing a paid plan locks the custom domain, keeps it redirecting, and says
 
   await setComp(page, email, "grant");
   const hostname = await addActiveCustomDomain(page);
+  // A root redirect, so "is it still serving" has an answer that is not the
+  // same 404 an unconfigured host gives.
+  const [row] = await queryRows<{ id: string; org_id: string }>(
+    page,
+    "select id, org_id from domains where hostname = ?",
+    [hostname],
+  );
+  const patched = await page.request.patch(`/api/orgs/${row.org_id}/domains/${row.id}`, {
+    data: { rootRedirect: "https://example.com/home" },
+  });
+  expect(patched.ok()).toBe(true);
+
+  // The redirect path answers from KV alone. Before the downgrade the value
+  // carries no deadline, so "still serving" below means something.
+  const verdict = async () => {
+    const value = await kvValue(page, `domain:${hostname}`);
+    // SAFETY: this key is written only by publishDomain/desiredKvValue, both
+    // of which stringify a KVDomain, so `servesUntil` is the number or null
+    // they put there. A missing key reads back as null, which is the same
+    // answer as "no deadline".
+    return (value as { servesUntil?: number | null } | null)?.servesUntil ?? null;
+  };
+  expect(await verdict()).toBeNull();
 
   await setComp(page, email, "revoke");
   await page.goto("/domains");
@@ -122,7 +145,83 @@ test("losing a paid plan locks the custom domain, keeps it redirecting, and says
   );
   expect(domain.locked_at).not.toBeNull();
 
+  // And it is really still redirecting, which is the whole promise. A
+  // regression that failed to republish the grace-period KV value would stop
+  // the host dead while every assertion above still passed.
+  // The whole pipeline: reconciliation wrote the lock, the storage queue
+  // republished the key, and the value the Worker will read carries a
+  // deadline that is still ahead. A regression that skipped the republish
+  // leaves this null forever (serves forever) or already past (404s now).
+  // Polled, because the republish rides the storage queue and is consumed
+  // after the request that triggered it has already answered.
+  await expect.poll(verdict, { timeout: 20_000 }).not.toBeNull();
+  expect(await verdict()).toBeGreaterThan(Date.now());
+
   // And the banner names what is over, with a route out.
   await expect(page.getByText(/1 custom domain, and this plan has none/)).toBeVisible();
   await expect(page.getByRole("link", { name: "Upgrade to keep them" })).toBeVisible();
+});
+
+test("losing seats demotes the newest members to viewer, and says so", async ({
+  page,
+  browser,
+}) => {
+  test.slow();
+  const email = await adminAccount(page, "downgrade-members");
+
+  // Pro allows 25 members; free allows 3, so one invited teammate on top of
+  // the owner is still inside the cap and a second is not.
+  await setComp(page, email, "grant");
+  const guests = [];
+  for (const prefix of ["seat-a", "seat-b", "seat-c"]) {
+    await page.goto("/members");
+    await page.getByRole("button", { name: "Invite link" }).click();
+    await page.getByRole("button", { name: "Create invite link" }).click();
+    const [invite] = await queryRows<{ token: string }>(
+      page,
+      `select token from invites
+       where created_by = (select id from user where email = ?)
+       order by created_at desc limit 1`,
+      [email],
+    );
+    const guest = await guestAccount(browser, prefix);
+    await guest.page.goto(`/invite/${invite.token}`);
+    await guest.page.getByRole("button", { name: "Accept invite" }).click();
+    await expect(guest.page).toHaveURL(/\/dashboard$/);
+    guests.push(guest);
+  }
+
+  await setComp(page, email, "revoke");
+
+  // Owner plus the two longest-standing keep their role; the newest is a
+  // viewer. Nobody is removed: four rows, still.
+  const rows = await queryRows<{ email: string; role: string; previous_role: string | null }>(
+    page,
+    `select u.email, m.role, m.previous_role from org_members m
+     join user u on u.id = m.user_id
+     where m.org_id = (
+       select m2.org_id from org_members m2
+       join user u2 on u2.id = m2.user_id
+       where u2.email = ? and m2.role = 'owner'
+     )
+     order by m.created_at`,
+    [email],
+  );
+  expect(rows).toHaveLength(4);
+  expect(rows.map((r) => r.role)).toEqual(["owner", "member", "member", "viewer"]);
+  expect(rows[3].previous_role).toBe("member");
+
+  // The demoted member is told why, rather than left to report the missing
+  // buttons as a bug.
+  await page.goto("/members");
+  await expect(page.getByText(/Set to viewer when the plan changed/)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // And they really cannot write any more.
+  const demoted = guests[2].page;
+  await demoted.goto("/links");
+  await expect(demoted.getByRole("button", { name: "New link" }).first()).toBeHidden();
+
+  for (const guest of guests) await guest.context.close();
 });

--- a/tests/e2e/downgrade.pw.ts
+++ b/tests/e2e/downgrade.pw.ts
@@ -212,11 +212,13 @@ test("losing seats demotes the newest members to viewer, and says so", async ({
   expect(rows[3].previous_role).toBe("member");
 
   // The demoted member is told why, rather than left to report the missing
-  // buttons as a bug.
+  // buttons as a bug. The row carries the marker; the sentence is on hover,
+  // so that the reason does not repeat down every row of a long table.
   await page.goto("/members");
-  await expect(page.getByText(/Set to viewer when the plan changed/)).toBeVisible({
-    timeout: 15_000,
-  });
+  const marker = page.getByText("demoted", { exact: true }).first();
+  await expect(marker).toBeVisible({ timeout: 15_000 });
+  await marker.hover();
+  await expect(page.getByText(/Set to viewer when the plan changed/)).toBeVisible();
 
   // And they really cannot write any more.
   const demoted = guests[2].page;

--- a/tests/e2e/downgrade.pw.ts
+++ b/tests/e2e/downgrade.pw.ts
@@ -1,0 +1,128 @@
+import { expect, test, type Page } from "@playwright/test";
+import { makePlatformAdmin, queryRows } from "./db";
+import { signUpAndVerify } from "./resend";
+import { addActiveCustomDomain, createAdditionalOrg, createQuickLink } from "./orgs";
+
+/**
+ * What a downgrade looks like from the account it happens to (#158 to #163).
+ *
+ * Driven through the admin comp routes, because those are the plan change
+ * this suite can actually cause: granting one runs the same reconciliation
+ * pass a Polar `subscription.active` does, and revoking it runs the one a
+ * `subscription.revoked` does.
+ *
+ * The point of every assertion here is the same: nothing was deleted, the
+ * app says so, and there is a way back on the screen.
+ */
+
+const password = "test-password-123";
+
+/** Signs up an account that is also a platform admin, so it can move its own
+ * plan through the admin screens. */
+async function adminAccount(page: Page, prefix: string) {
+  const email = `${prefix}-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, email, password);
+  await makePlatformAdmin(page, email);
+  return email;
+}
+
+/** Grants or revokes this account's own comp through /admin/users, which is
+ * what triggers the reconciliation pass. */
+async function setComp(page: Page, email: string, action: "grant" | "revoke") {
+  await page.goto("/admin/users");
+  const row = page.getByRole("row", { name: new RegExp(email) });
+  await row.getByRole("button", { name: "Actions for" }).click();
+  if (action === "grant") {
+    await page.getByRole("menuitem", { name: "Comp a paid plan" }).click();
+    const dialog = page.getByRole("dialog", { name: /^Comp / });
+    await dialog.getByLabel("Reason").fill("Downgrade test");
+    await dialog.getByRole("button", { name: "Grant comp" }).click();
+    await expect(page.getByText("Comp granted")).toBeVisible();
+  } else {
+    await page.getByRole("menuitem", { name: "Revoke comp" }).click();
+    await expect(page.getByText("Comp revoked")).toBeVisible();
+  }
+}
+
+test("losing Pro locks the extra org, says why, and lets the owner pick which one stays", async ({
+  page,
+}) => {
+  test.slow();
+  const email = await adminAccount(page, "downgrade-orgs");
+
+  // Pro allows three owned orgs, so a second one can exist to be locked.
+  await setComp(page, email, "grant");
+  await page.goto("/dashboard");
+  await createQuickLink(page, "example.com/keeps-redirecting");
+  // The confirmation dialog owns the screen until it is dismissed, and the
+  // org switcher sits behind its backdrop.
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog", { name: "Link created" })).toBeHidden();
+  await createAdditionalOrg(page, "Second org");
+
+  await setComp(page, email, "revoke");
+  await page.goto("/dashboard");
+
+  // The newest org is the one that gives way, so the app lands on a locked
+  // org and has to explain itself rather than showing an empty screen.
+  await expect(page.getByText(/is locked/)).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(/Nothing was deleted/)).toBeVisible();
+
+  // Locked means read-only for its owner too: no create control anywhere.
+  await page.goto("/links");
+  await expect(page.getByRole("button", { name: "New link" }).first()).toBeHidden();
+
+  // The locked org is still in the switcher, marked, rather than gone.
+  await page.getByTitle("Switch organization").click();
+  await expect(page.getByRole("menuitem", { name: /Second org/ })).toContainText("locked");
+  await page.keyboard.press("Escape");
+
+  // And the choice is a real one: keeping this org active frees the other.
+  await page.getByRole("button", { name: "Use this one" }).click();
+  await expect(page.getByText(/is active again/)).toBeVisible();
+  await expect(page.getByText(/is locked/)).toBeHidden();
+  await expect(page.getByRole("button", { name: "New link" }).first()).toBeVisible();
+
+  const rows = await queryRows<{ n: number }>(
+    page,
+    `select count(*) as n from orgs
+     join org_members on org_members.org_id = orgs.id
+     join user on user.id = org_members.user_id
+     where user.email = ? and org_members.role = 'owner'`,
+    [email],
+  );
+  // Two orgs, still. The lock never deletes one.
+  expect(rows[0].n).toBe(2);
+});
+
+test("losing a paid plan locks the custom domain, keeps it redirecting, and says when it stops", async ({
+  page,
+}) => {
+  test.slow();
+  const email = await adminAccount(page, "downgrade-domains");
+
+  await setComp(page, email, "grant");
+  const hostname = await addActiveCustomDomain(page);
+
+  await setComp(page, email, "revoke");
+  await page.goto("/domains");
+
+  // The domain is still listed. Hiding it behind an upgrade pitch is how an
+  // owner concludes we deleted it.
+  await expect(page.getByText(hostname)).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("locked", { exact: true })).toBeVisible();
+  await expect(page.getByText(/Still redirecting until/)).toBeVisible();
+  await expect(page.getByRole("heading", { name: /custom domains are locked/i })).toBeVisible();
+
+  // The row, the KV entry and the Cloudflare hostname all stay.
+  const [domain] = await queryRows<{ locked_at: number | null; cf_hostname_id: string | null }>(
+    page,
+    "select locked_at, cf_hostname_id from domains where hostname = ?",
+    [hostname],
+  );
+  expect(domain.locked_at).not.toBeNull();
+
+  // And the banner names what is over, with a route out.
+  await expect(page.getByText(/1 custom domain, and this plan has none/)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Upgrade to keep them" })).toBeVisible();
+});

--- a/tests/e2e/downgrade.pw.ts
+++ b/tests/e2e/downgrade.pw.ts
@@ -218,6 +218,9 @@ test("losing seats demotes the newest members to viewer, and says so", async ({
   // swallows the hover. Answer it the way a returning visitor already has.
   await page.addInitScript(() => localStorage.setItem("rdyrct:consent:v2", "granted"));
   await page.goto("/members");
+  await expect(
+    page.getByText(/Nobody was removed\. Remove a member or revoke an invite to make room/),
+  ).toBeVisible();
   const marker = page.getByText("demoted", { exact: true }).first();
   await expect(marker).toBeVisible({ timeout: 15_000 });
   await marker.hover();

--- a/tests/e2e/downgrade.pw.ts
+++ b/tests/e2e/downgrade.pw.ts
@@ -211,20 +211,16 @@ test("losing seats demotes the newest members to viewer, and says so", async ({
   expect(rows.map((r) => r.role)).toEqual(["owner", "member", "member", "viewer"]);
   expect(rows[3].previous_role).toBe("member");
 
-  // The demoted member is told why, rather than left to report the missing
-  // buttons as a bug. The row carries the marker; the sentence is on hover,
-  // so that the reason does not repeat down every row of a long table.
-  // The consent banner sits bottom-right, over the very rows this reads, and
-  // swallows the hover. Answer it the way a returning visitor already has.
+  // The owner sees the member kept in the table with their new viewer role,
+  // while the over-limit notice explains how to make room. A "demoted" marker
+  // would repeat that explanation in every row, so the UI deliberately does
+  // not render one.
   await page.addInitScript(() => localStorage.setItem("rdyrct:consent:v2", "granted"));
   await page.goto("/members");
   await expect(
     page.getByText(/Nobody was removed\. Remove a member or revoke an invite to make room/),
   ).toBeVisible();
-  const marker = page.getByText("demoted", { exact: true }).first();
-  await expect(marker).toBeVisible({ timeout: 15_000 });
-  await marker.hover();
-  await expect(page.getByText(/Set to viewer when the plan changed/)).toBeVisible();
+  await expect(page.locator("tbody tr").filter({ hasText: "viewer" })).toHaveCount(1);
 
   // And they really cannot write any more.
   const demoted = guests[2].page;

--- a/tests/e2e/downgrade.pw.ts
+++ b/tests/e2e/downgrade.pw.ts
@@ -214,6 +214,9 @@ test("losing seats demotes the newest members to viewer, and says so", async ({
   // The demoted member is told why, rather than left to report the missing
   // buttons as a bug. The row carries the marker; the sentence is on hover,
   // so that the reason does not repeat down every row of a long table.
+  // The consent banner sits bottom-right, over the very rows this reads, and
+  // swallows the hover. Answer it the way a returning visitor already has.
+  await page.addInitScript(() => localStorage.setItem("rdyrct:consent:v2", "granted"));
   await page.goto("/members");
   const marker = page.getByText("demoted", { exact: true }).first();
   await expect(marker).toBeVisible({ timeout: 15_000 });

--- a/tests/e2e/invites.pw.ts
+++ b/tests/e2e/invites.pw.ts
@@ -1,43 +1,6 @@
-import { expect, test, type Browser, type Page } from "@playwright/test";
-import { signUpAndVerify } from "./resend";
+import { expect, test } from "@playwright/test";
 import { queryRows } from "./db";
-
-const password = "test-password-123";
-
-/**
- * Signs up an owner, creates a link invite from Members, and returns the
- * owner's address with the token behind it.
- *
- * The token is read back scoped to this owner, not as "the newest invite":
- * the suite runs in parallel shards against one database, so the globally
- * newest row belongs to whichever test wrote last.
- */
-async function ownerWithInviteLink(page: Page, prefix: string) {
-  const owner = `${prefix}-${Date.now()}@gmail.com`;
-  await signUpAndVerify(page, owner, password);
-
-  await page.goto("/members");
-  await page.getByRole("button", { name: "Invite link" }).click();
-  await page.getByRole("button", { name: "Create invite link" }).click();
-  await expect(page.getByText("Pending invites")).toBeVisible();
-
-  const [invite] = await queryRows<{ token: string }>(
-    page,
-    "select token from invites where created_by = (select id from user where email = ?)",
-    [owner],
-  );
-  expect(invite?.token).toBeTruthy();
-  return { owner, token: invite.token };
-}
-
-/** A separate signed-up account in its own browser context, for the half of
- * an invite flow the owner cannot play. */
-async function guestAccount(browser: Browser, prefix: string) {
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  await signUpAndVerify(page, `${prefix}-${Date.now()}@gmail.com`, password);
-  return { context, page };
-}
+import { guestAccount, ownerWithInviteLink } from "./orgs";
 
 /**
  * An accepted invite leaves no row behind (#103).

--- a/tests/e2e/link-addresses.pw.ts
+++ b/tests/e2e/link-addresses.pw.ts
@@ -49,10 +49,11 @@ async function freshOrg(page: Page, name: string): Promise<void> {
   } else {
     defaultOrgSpent = true;
   }
-  // Switching org invalidates the dashboard's queries, which briefly
-  // remounts it into its loading skeleton: settle before touching its form,
-  // so a fill() right after doesn't land in a field about to be replaced.
-  await page.waitForLoadState("networkidle");
+  // Switching org invalidates the dashboard's queries, which briefly remounts
+  // its form. Wait for that form, not network idle: product analytics can
+  // keep an unrelated request open. createQuickLink retries its fill in case
+  // a final query update replaces the field.
+  await expect(page.getByPlaceholder("https://example.com/launch").first()).toBeVisible();
 }
 
 /** Fills the dashboard's quick-create destination field and submits it,

--- a/tests/e2e/orgs.ts
+++ b/tests/e2e/orgs.ts
@@ -1,4 +1,8 @@
-import { expect, type Page } from "@playwright/test";
+import { queryRows } from "./db";
+import { expect, type Browser, type Page } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
+
+const E2E_PASSWORD = "test-password-123";
 
 /** Opens the org switcher and creates another org under the same signed-in
  * account, for tests that share one user (see link-addresses.pw.ts) and so
@@ -52,4 +56,47 @@ export async function createQuickLink(page: Page, destination: string) {
   await field.fill(destination);
   await page.getByRole("button", { name: "Create link" }).click();
   await expect(page.getByRole("dialog", { name: "Link created" })).toBeVisible();
+}
+
+/**
+ * Signs up an owner, creates a link invite from Members, and returns the
+ * owner's address with the token behind it.
+ *
+ * The token is read back scoped to this owner, not as "the newest invite":
+ * the suite runs in parallel shards against one database, so the globally
+ * newest row belongs to whichever test wrote last.
+ */
+export async function ownerWithInviteLink(
+  page: Page,
+  prefix: string,
+  /** Runs on the fresh dashboard, before the page leaves for Members: a
+   * caller that needs the org to hold something has one chance to put it
+   * there while the quick-create field is on screen. */
+  seed?: (page: Page) => Promise<void>,
+) {
+  const owner = `${prefix}-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, owner, E2E_PASSWORD);
+  await seed?.(page);
+
+  await page.goto("/members");
+  await page.getByRole("button", { name: "Invite link" }).click();
+  await page.getByRole("button", { name: "Create invite link" }).click();
+  await expect(page.getByText("Pending invites")).toBeVisible();
+
+  const [invite] = await queryRows<{ token: string }>(
+    page,
+    "select token from invites where created_by = (select id from user where email = ?)",
+    [owner],
+  );
+  expect(invite?.token).toBeTruthy();
+  return { owner, token: invite.token };
+}
+
+/** A separate signed-up account in its own browser context, for the half of
+ * an invite flow the owner cannot play. */
+export async function guestAccount(browser: Browser, prefix: string) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await signUpAndVerify(page, `${prefix}-${Date.now()}@gmail.com`, E2E_PASSWORD);
+  return { context, page };
 }

--- a/tests/e2e/public-pages.pw.ts
+++ b/tests/e2e/public-pages.pw.ts
@@ -472,13 +472,10 @@ test("a first visit does not ask who it is", async ({ page }) => {
   // The header paints before the rest of the page has even mounted, so
   // asserting here caught nothing: the first version of this test passed
   // against a build that still made the call. Every section has to have
-  // mounted, including the ones that ask this to decide where a CTA points,
-  // and the lazy analytics mock has to have landed.
-  await page
-    .getByRole("link", { name: /start pro/i })
-    .first()
-    .scrollIntoViewIfNeeded();
-  await page.waitForLoadState("networkidle");
+  // mounted, including the lazy analytics mock. Waiting for network idle is
+  // wrong here: product analytics can keep an unrelated request open.
+  await page.locator("#analytics").scrollIntoViewIfNeeded();
+  await expect(page.locator("#analytics").getByLabel("Clicks per day")).toBeVisible();
 
   expect(userCalls, "a browser that was never signed in has nothing to ask").toEqual([]);
 });
@@ -496,7 +493,9 @@ test("the charts bundle waits until the visitor scrolls toward it", async ({ pag
 
   await page.goto("/");
   await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
-  await page.waitForLoadState("networkidle");
+  // This CTA is below the fold, so it proves the page hydrated without
+  // scrolling toward the analytics section that owns the lazy bundle.
+  await expect(page.getByRole("link", { name: /start pro/i }).first()).toBeVisible();
   expect(charts, "nothing above the fold needs the charts bundle").toEqual([]);
 
   // Now go to it. The section renders its placeholder either way, so wait for

--- a/tests/e2e/qr-download.pw.ts
+++ b/tests/e2e/qr-download.pw.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { expect, test } from "@playwright/test";
 import { signUpAndVerify } from "./resend";
-import { rawSql, setPlan } from "./db";
+import { queryRows, rawSql, setPlan } from "./db";
 import { createQuickLink } from "./orgs";
 
 const password = "test-password-123";
@@ -111,6 +111,9 @@ test("a downgraded org can still edit a link that has a QR look", async ({ page 
   await page.getByRole("menuitem", { name: "Edit" }).click();
   const reopened = page.getByRole("dialog", { name: "Edit link" });
   await expect(reopened.getByRole("group", { name: "QR customization" })).toBeHidden();
+  // The controls are gone, and the dialog says the look is kept rather than
+  // offering a feature the QR beside it is visibly already using (#162).
+  await expect(reopened.getByText(/keeps the look it already has/)).toBeVisible();
 
   await reopened.getByLabel("Title").fill("Renamed on the free plan");
   await page.getByRole("button", { name: "Save" }).click();
@@ -119,4 +122,15 @@ test("a downgraded org can still edit a link that has a QR look", async ({ page 
   // did not even offer.
   await expect(reopened).toBeHidden();
   await expect(page.getByText("Renamed on the free plan")).toBeVisible();
+
+  // And the styling is still there. The editor used to clear these fields
+  // before sending, so this same save silently destroyed a logo, colours,
+  // dot and corner style somebody had paid for (#162).
+  const [link] = await queryRows<{ qr_style: string; title: string }>(
+    page,
+    "select qr_style, title from links where destination like ?",
+    ["%downgrade%"],
+  );
+  expect(link.qr_style).toBe("dots");
+  expect(link.title).toBe("Renamed on the free plan");
 });

--- a/tests/e2e/qr-generator.pw.ts
+++ b/tests/e2e/qr-generator.pw.ts
@@ -31,9 +31,17 @@ function watchPosts(page: Page): string[] {
   return posted;
 }
 
-/** What the page sent that was not Cap proving the visitor is human. */
-function appPosts(posted: string[]): string[] {
-  return posted.filter((url) => !url.includes("/api/cap/"));
+/** Application POSTs other than Cap proving the visitor is human. */
+function appPosts(page: Page, posted: string[]): string[] {
+  const appOrigin = new URL(page.url()).origin;
+  return posted.filter((url) => {
+    const request = new URL(url);
+    return (
+      request.origin === appOrigin &&
+      request.pathname !== "/api/cap/challenge" &&
+      request.pathname !== "/api/cap/redeem"
+    );
+  });
 }
 
 /**
@@ -112,7 +120,7 @@ test("generates a QR code with no account and no network call", async ({ page })
   await expect(page.getByRole("button", { name: /SVG/ })).toBeEnabled();
   expect((await boxOf(upsell)).y).toBe(settled.y);
 
-  expect(appPosts(posted)).toEqual([]);
+  expect(appPosts(page, posted)).toEqual([]);
 });
 
 test("downloads a printable PNG", async ({ page }) => {
@@ -140,7 +148,7 @@ test("the upsell offers the account rather than making a link", async ({ page })
     "/pricing",
   );
 
-  expect(appPosts(posted)).toEqual([]);
+  expect(appPosts(page, posted)).toEqual([]);
 
   await page.getByRole("link", { name: "Start free" }).click();
   await expect(page).toHaveURL(/\/signup$/);
@@ -177,7 +185,7 @@ test("styling the code is free here, and stays in the browser", async ({ page })
   await page.getByRole("menuitem", { name: "dots" }).click();
   await expect(page.getByRole("button", { name: /PNG/ })).toBeVisible();
 
-  expect(appPosts(posted)).toEqual([]);
+  expect(appPosts(page, posted)).toEqual([]);
 });
 
 test("the page says what it is built on, and carries its own title", async ({ page }) => {

--- a/tests/e2e/viewer-role.pw.ts
+++ b/tests/e2e/viewer-role.pw.ts
@@ -1,9 +1,6 @@
 import { expect, test } from "@playwright/test";
-import { signUpAndVerify } from "./resend";
 import { queryRows } from "./db";
-import { createQuickLink } from "./orgs";
-
-const password = "test-password-123";
+import { createQuickLink, guestAccount, ownerWithInviteLink } from "./orgs";
 
 /**
  * A viewer sees the org and can change none of it (#157).
@@ -17,32 +14,21 @@ test("a viewer reads the links and the numbers, and is offered no way to change 
   page,
   browser,
 }) => {
-  const owner = `vowner-${Date.now()}@gmail.com`;
-  await signUpAndVerify(page, owner, password);
-  await createQuickLink(page, "example.com/viewer-sees-this");
+  const { owner, token } = await ownerWithInviteLink(page, "vowner", async (owned) => {
+    await createQuickLink(owned, "example.com/viewer-sees-this");
+  });
 
-  await page.goto("/members");
-  await page.getByRole("button", { name: "Invite link" }).click();
-  await page.getByRole("button", { name: "Create invite link" }).click();
-  await expect(page.getByText("Pending invites")).toBeVisible();
-
-  // The invite is created as a member by default; make it a viewer directly,
-  // since the point under test is the role, not the picker.
+  // Created as a member by default; make it a viewer directly, since the
+  // point under test is the role, not the picker.
   await queryRows(
     page,
     "update invites set role = 'viewer' where created_by = (select id from user where email = ?)",
     [owner],
   );
-  const [invite] = await queryRows<{ token: string }>(
-    page,
-    "select token from invites where created_by = (select id from user where email = ?)",
-    [owner],
-  );
 
-  const guest = await browser.newContext();
-  const viewer = await guest.newPage();
-  await signUpAndVerify(viewer, `analyst-${Date.now()}@gmail.com`, password);
-  await viewer.goto(`/invite/${invite.token}`);
+  const guest = await guestAccount(browser, "analyst");
+  const viewer = guest.page;
+  await viewer.goto(`/invite/${token}`);
   await viewer.getByRole("button", { name: "Accept invite" }).click();
   await expect(viewer).toHaveURL(/\/dashboard$/);
 
@@ -63,5 +49,5 @@ test("a viewer reads the links and the numbers, and is offered no way to change 
   await viewer.goto("/analytics");
   await expect(viewer.getByRole("heading", { name: /Analytics/i })).toBeVisible();
 
-  await guest.close();
+  await guest.context.close();
 });

--- a/tests/e2e/viewer-role.pw.ts
+++ b/tests/e2e/viewer-role.pw.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
+import { queryRows } from "./db";
+import { createQuickLink } from "./orgs";
+
+const password = "test-password-123";
+
+/**
+ * A viewer sees the org and can change none of it (#157).
+ *
+ * The server refuses their writes with a 403, so the app must not offer them:
+ * a control whose only outcome is an error toast is not a feature. This walks
+ * the screens a viewer actually lands on and asserts the read is there and
+ * the write is not.
+ */
+test("a viewer reads the links and the numbers, and is offered no way to change them", async ({
+  page,
+  browser,
+}) => {
+  const owner = `vowner-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, owner, password);
+  await createQuickLink(page, "example.com/viewer-sees-this");
+
+  await page.goto("/members");
+  await page.getByRole("button", { name: "Invite link" }).click();
+  await page.getByRole("button", { name: "Create invite link" }).click();
+  await expect(page.getByText("Pending invites")).toBeVisible();
+
+  // The invite is created as a member by default; make it a viewer directly,
+  // since the point under test is the role, not the picker.
+  await queryRows(
+    page,
+    "update invites set role = 'viewer' where created_by = (select id from user where email = ?)",
+    [owner],
+  );
+  const [invite] = await queryRows<{ token: string }>(
+    page,
+    "select token from invites where created_by = (select id from user where email = ?)",
+    [owner],
+  );
+
+  const guest = await browser.newContext();
+  const viewer = await guest.newPage();
+  await signUpAndVerify(viewer, `analyst-${Date.now()}@gmail.com`, password);
+  await viewer.goto(`/invite/${invite.token}`);
+  await viewer.getByRole("button", { name: "Accept invite" }).click();
+  await expect(viewer).toHaveURL(/\/dashboard$/);
+
+  // Switch to the org they were invited to, then read what it holds.
+  await viewer.goto("/links");
+  await expect(viewer.getByText("viewer-sees-this")).toBeVisible({ timeout: 15_000 });
+
+  // The read is there; the write is not.
+  await expect(viewer.getByRole("button", { name: "New link" })).toBeHidden();
+
+  await viewer.getByRole("button", { name: /Actions for/ }).click();
+  await expect(viewer.getByRole("menuitem", { name: /View analytics/ })).toBeVisible();
+  await expect(viewer.getByRole("menuitem", { name: /Edit/ })).toBeHidden();
+  await expect(viewer.getByRole("menuitem", { name: /Delete/ })).toBeHidden();
+  await viewer.keyboard.press("Escape");
+
+  // Analytics is a read, so it stays open to them.
+  await viewer.goto("/analytics");
+  await expect(viewer.getByRole("heading", { name: /Analytics/i })).toBeVisible();
+
+  await guest.close();
+});

--- a/tests/grace.test.ts
+++ b/tests/grace.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { graceLabel } from "../src/app/lib/grace";
+
+const DAY = 86_400_000;
+const NOW = 1_700_000_000_000;
+
+describe("graceLabel", () => {
+  test("counts whole days, rounding up", () => {
+    expect(graceLabel(NOW + 30 * DAY, NOW)).toBe("30 days left");
+    // Rounding up is what keeps the last day from reading "0 days left":
+    // somebody with eight hours has a day to act, not none.
+    expect(graceLabel(NOW + DAY / 3, NOW)).toBe("1 day left");
+  });
+
+  test("says so once the deadline has passed", () => {
+    expect(graceLabel(NOW, NOW)).toBe("the grace period has ended");
+    expect(graceLabel(NOW - DAY, NOW)).toBe("the grace period has ended");
+  });
+});

--- a/tests/kv.test.ts
+++ b/tests/kv.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { partialEnv } from "./partial-env";
 import {
+  domainServing,
   publishDomain,
   publishLink,
   resolveDomain,
@@ -98,7 +99,27 @@ describe("domain publishing", () => {
       domainId: "dom1",
       orgId: "org1",
       rootRedirect: "https://brand.com",
+      servesUntil: null,
     });
+  });
+
+  test("a locked domain carries the date it stops serving", async () => {
+    const servesUntil = Date.now() + 1000;
+    await publishDomain(env, {
+      id: "dom1",
+      orgId: "org1",
+      hostname: "go.brand.com",
+      rootRedirect: "https://brand.com",
+      servesUntil,
+    });
+    const value = await resolveDomain(env, "go.brand.com");
+    expect(value?.servesUntil).toBe(servesUntil);
+    expect(domainServing(value!, servesUntil - 1)).toBe(true);
+    expect(domainServing(value!, servesUntil + 1)).toBe(false);
+  });
+
+  test("a value written before servesUntil existed keeps serving", () => {
+    expect(domainServing({ domainId: "d", orgId: "o", rootRedirect: "" })).toBe(true);
   });
 
   test("unpublish removes the domain", async () => {

--- a/tests/org-limits.test.ts
+++ b/tests/org-limits.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { canListOrgDomains } from "../src/app/lib/org-limits";
+import { canListOrgDomains, canWriteOrg } from "../src/app/lib/org-limits";
 
 describe("canListOrgDomains", () => {
   test("platform admins can always list domains", () => {
@@ -15,5 +15,21 @@ describe("canListOrgDomains", () => {
   test("members and org-less users cannot", () => {
     expect(canListOrgDomains(false, "member")).toBe(false);
     expect(canListOrgDomains(false, undefined)).toBe(false);
+  });
+});
+
+describe("canWriteOrg", () => {
+  test("owner, admin and member may write", () => {
+    expect(canWriteOrg("owner")).toBe(true);
+    expect(canWriteOrg("admin")).toBe(true);
+    expect(canWriteOrg("member")).toBe(true);
+  });
+
+  test("a viewer may not", () => {
+    expect(canWriteOrg("viewer")).toBe(false);
+  });
+
+  test("no role yet is not a moment to offer a write", () => {
+    expect(canWriteOrg(undefined)).toBe(false);
   });
 });

--- a/tests/org-limits.test.ts
+++ b/tests/org-limits.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { canListOrgDomains, canWriteOrg } from "../src/app/lib/org-limits";
+import { canListOrgDomains, canWriteOrg, domainsBlockedBy } from "../src/app/lib/org-limits";
 
 describe("canListOrgDomains", () => {
   test("platform admins can always list domains", () => {
@@ -31,5 +31,26 @@ describe("canWriteOrg", () => {
 
   test("no role yet is not a moment to offer a write", () => {
     expect(canWriteOrg(undefined)).toBe(false);
+  });
+});
+
+describe("domainsBlockedBy", () => {
+  test("a plan with domains and no lock blocks nothing", () => {
+    expect(domainsBlockedBy(3, false)).toBe(null);
+  });
+
+  test("a plan with no domains says so", () => {
+    expect(domainsBlockedBy(0, false)).toBe("plan");
+  });
+
+  test("a locked org on a plan that does include domains is blocked by the lock", () => {
+    // The reason this exists. Answering "custom domains need a paid plan"
+    // here tells a Hobby owner to buy what they already have, and points at
+    // an upgrade that would not unlock the org.
+    expect(domainsBlockedBy(3, true)).toBe("lock");
+  });
+
+  test("the lock wins when both are true, because upgrading is not the way out", () => {
+    expect(domainsBlockedBy(0, true)).toBe("lock");
   });
 });

--- a/tests/qr.test.ts
+++ b/tests/qr.test.ts
@@ -5,7 +5,7 @@ import {
   QR_DEFAULT_CORNER,
   QR_DEFAULT_LOGO_SIZE,
 } from "../src/shared/types";
-import { resolveLook } from "../src/app/lib/qr-look";
+import { hasAnyQrValue, resolveLook, type QrValues } from "../src/app/lib/qr-look";
 
 describe("resolveLook", () => {
   test("falls back to every default when nothing is set", () => {
@@ -51,5 +51,36 @@ describe("resolveLook", () => {
 
   test("treats an empty logo string as no logo", () => {
     expect(resolveLook({ logo: "" }).logo).toBeUndefined();
+  });
+});
+
+describe("hasAnyQrValue", () => {
+  const empty: QrValues = {
+    qrStyle: "",
+    qrColor: "",
+    qrLogo: "",
+    qrCorner: "",
+    qrBg: "",
+    qrEyeColor: "",
+    qrLogoSize: "",
+  };
+
+  test("nothing set is nothing set", () => {
+    // An org with no defaults used to answer true here, because the old test
+    // compared qrLogoSize against null and it is "" when unset. That org was
+    // then shown a read-only grid and told its defaults were locked.
+    expect(hasAnyQrValue(empty)).toBe(false);
+  });
+
+  test("an unset logo size does not count as a default", () => {
+    expect(hasAnyQrValue({ ...empty, qrLogoSize: "" })).toBe(false);
+  });
+
+  test("a set logo size does", () => {
+    expect(hasAnyQrValue({ ...empty, qrLogoSize: "30" })).toBe(true);
+  });
+
+  test("any one field is enough", () => {
+    expect(hasAnyQrValue({ ...empty, qrColor: "#ff0000" })).toBe(true);
   });
 });

--- a/tests/worker/entitlement-locks.worker.ts
+++ b/tests/worker/entitlement-locks.worker.ts
@@ -12,7 +12,7 @@ import {
   TEST_PASSWORD,
   testDb,
 } from "./support";
-import type { CurrentUser, DomainDTO } from "../../src/shared/types";
+import type { CurrentUser, DomainDTO, LinkInput } from "../../src/shared/types";
 
 /**
  * What a lock does once reconciliation has written it: the redirect path's
@@ -243,7 +243,7 @@ describe("QR styling on a downgraded plan (#162)", () => {
     return cookie;
   }
 
-  const save = (cookie: string, body: Record<string, unknown>) =>
+  const save = (cookie: string, body: Partial<LinkInput>) =>
     fetchWorker(
       new Request("http://localhost/api/orgs/org-1/links/link-1", {
         method: "PATCH",

--- a/tests/worker/entitlement-locks.worker.ts
+++ b/tests/worker/entitlement-locks.worker.ts
@@ -1,0 +1,322 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { reset } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import * as schema from "../../src/worker/db/schema";
+import { hashPassword } from "../../src/worker/password";
+import {
+  applyTestMigrations,
+  fetchWorker,
+  jsonBody,
+  signInCookie,
+  TEST_PASSWORD,
+  testDb,
+} from "./support";
+import type { CurrentUser, DomainDTO } from "../../src/shared/types";
+
+/**
+ * What a lock does once reconciliation has written it: the redirect path's
+ * verdict (#159), the org-wide read-only state (#160), who may still be
+ * handed write access (#161), and the QR styling that survives a save (#162).
+ *
+ * The pass itself is covered in reconcile.worker.ts. These are the places
+ * that read what it wrote.
+ */
+
+const HOUR = 60 * 60 * 1000;
+
+async function seedOwner(plan = "free"): Promise<string> {
+  await env.DB.batch([
+    env.DB.prepare(
+      "insert into user (id, name, email, email_verified, is_admin, plan, created_at, updated_at) values ('owner-1', 'Owner', 'owner@example.com', 1, 0, ?, 0, 0)",
+    ).bind(plan),
+    env.DB.prepare(
+      "insert into account (id, account_id, provider_id, user_id, password, created_at, updated_at) values ('acct-1', 'owner-1', 'credential', 'owner-1', ?, 0, 0)",
+    ).bind(await hashPassword(TEST_PASSWORD)),
+    env.DB.prepare("insert into orgs (id, name, created_at) values ('org-1', 'First', 1)"),
+    env.DB.prepare("insert into orgs (id, name, created_at) values ('org-2', 'Second', 2)"),
+    env.DB.prepare(
+      "insert into org_members (org_id, user_id, role, created_at) values ('org-1', 'owner-1', 'owner', 0)",
+    ),
+    env.DB.prepare(
+      "insert into org_members (org_id, user_id, role, created_at) values ('org-2', 'owner-1', 'owner', 0)",
+    ),
+  ]);
+  return signInCookie("owner@example.com", TEST_PASSWORD);
+}
+
+async function lockOrg(orgId: string) {
+  await testDb().update(schema.orgs).set({ lockedAt: 1 }).where(eq(schema.orgs.id, orgId));
+}
+
+beforeEach(async () => {
+  await reset();
+  await applyTestMigrations();
+});
+
+describe("a locked custom domain (#159)", () => {
+  async function publish(servesUntil: number | null) {
+    await env.DB.batch([
+      env.DB.prepare("insert into orgs (id, name, created_at) values ('org-1', 'Test', 0)"),
+      env.DB.prepare(
+        "insert into links (id, org_id, slug, destination, created_at) values ('link-1', 'org-1', 'sale', 'https://example.com/sale', 0)",
+      ),
+    ]);
+    await env.LINKS.put(
+      "domain:go.example.com",
+      JSON.stringify({
+        domainId: "dom-1",
+        orgId: "org-1",
+        rootRedirect: "https://example.com",
+        servesUntil,
+      }),
+    );
+    await env.LINKS.put(
+      "slug:go.example.com:sale",
+      JSON.stringify({ linkId: "link-1", orgId: "org-1", url: "https://example.com/sale" }),
+    );
+  }
+
+  const hit = () =>
+    fetchWorker(new Request("http://go.example.com/sale", { headers: { host: "go.example.com" } }));
+
+  it("keeps redirecting inside the grace period", async () => {
+    await publish(Date.now() + HOUR);
+    expect((await hit()).status).toBe(302);
+  });
+
+  it("stops resolving once the grace period has ended", async () => {
+    await publish(Date.now() - HOUR);
+    const res = await hit();
+    expect(res.status).toBe(404);
+    // The root redirect goes with it: the whole host stops answering, not
+    // just the slug.
+    const root = await fetchWorker(
+      new Request("http://go.example.com/", { headers: { host: "go.example.com" } }),
+    );
+    expect(root.status).toBe(404);
+  });
+
+  it("keeps serving a value written before the field existed", async () => {
+    await publish(null);
+    await env.LINKS.put(
+      "domain:go.example.com",
+      JSON.stringify({ domainId: "dom-1", orgId: "org-1", rootRedirect: "https://example.com" }),
+    );
+    expect((await hit()).status).toBe(302);
+  });
+});
+
+describe("a locked org (#160)", () => {
+  it("refuses every write and still serves every read", async () => {
+    const cookie = await seedOwner();
+    await lockOrg("org-2");
+
+    const read = await fetchWorker(
+      new Request("http://localhost/api/orgs/org-2/links", { headers: { cookie } }),
+    );
+    expect(read.status).toBe(200);
+
+    const write = await fetchWorker(
+      new Request("http://localhost/api/orgs/org-2", {
+        method: "PATCH",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ name: "Renamed" }),
+      }),
+    );
+    expect(write.status).toBe(403);
+    expect(await jsonBody<{ code: string }>(write)).toMatchObject({ code: "org_locked" });
+  });
+
+  it("can still be deleted, which is one of the two ways out", async () => {
+    const cookie = await seedOwner();
+    await lockOrg("org-2");
+    const res = await fetchWorker(
+      new Request("http://localhost/api/orgs/org-2", { method: "DELETE", headers: { cookie } }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("reports itself as locked to the app", async () => {
+    const cookie = await seedOwner();
+    await lockOrg("org-2");
+    const res = await fetchWorker(
+      new Request("http://localhost/api/user", { headers: { cookie } }),
+    );
+    const body = await jsonBody<CurrentUser>(res);
+    expect(body.orgs.map((o) => [o.id, o.locked])).toEqual([
+      ["org-1", false],
+      ["org-2", true],
+    ]);
+  });
+
+  it("swaps which org is active when the owner picks the locked one", async () => {
+    const cookie = await seedOwner();
+    await lockOrg("org-2");
+    const res = await fetchWorker(
+      new Request("http://localhost/api/orgs/org-2/keep-active", {
+        method: "POST",
+        headers: { cookie },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const rows = await testDb().select().from(schema.orgs).orderBy(schema.orgs.createdAt);
+    expect(rows.map((o) => [o.id, o.lockedAt !== null])).toEqual([
+      ["org-1", true],
+      ["org-2", false],
+    ]);
+  });
+});
+
+describe("who may write in an over-cap org (#161)", () => {
+  async function seedDemoted() {
+    const cookie = await seedOwner();
+    await env.DB.batch([
+      env.DB.prepare(
+        "insert into user (id, name, email, email_verified, is_admin, plan, created_at, updated_at) values ('m1', 'One', 'one@example.com', 1, 0, 'free', 0, 0)",
+      ),
+      env.DB.prepare(
+        "insert into user (id, name, email, email_verified, is_admin, plan, created_at, updated_at) values ('m2', 'Two', 'two@example.com', 1, 0, 'free', 0, 0)",
+      ),
+      env.DB.prepare(
+        "insert into user (id, name, email, email_verified, is_admin, plan, created_at, updated_at) values ('m3', 'Three', 'three@example.com', 1, 0, 'free', 0, 0)",
+      ),
+      env.DB.prepare(
+        "insert into org_members (org_id, user_id, role, created_at) values ('org-1', 'm1', 'member', 1)",
+      ),
+      env.DB.prepare(
+        "insert into org_members (org_id, user_id, role, created_at) values ('org-1', 'm2', 'member', 2)",
+      ),
+      env.DB.prepare(
+        "insert into org_members (org_id, user_id, role, previous_role, created_at) values ('org-1', 'm3', 'viewer', 'member', 3)",
+      ),
+    ]);
+    return cookie;
+  }
+
+  const promote = (cookie: string, userId: string, role: string) =>
+    fetchWorker(
+      new Request(`http://localhost/api/orgs/org-1/members/${userId}`, {
+        method: "PATCH",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ role }),
+      }),
+    );
+
+  it("refuses to hand out write access the plan has no room for", async () => {
+    const cookie = await seedDemoted();
+    const res = await promote(cookie, "m3", "member");
+    expect(res.status).toBe(402);
+    expect(await jsonBody<{ code: string }>(res)).toMatchObject({ code: "member_limit" });
+  });
+
+  it("lets the owner swap who writes, by demoting first", async () => {
+    const cookie = await seedDemoted();
+    expect((await promote(cookie, "m1", "viewer")).status).toBe(200);
+    expect((await promote(cookie, "m3", "member")).status).toBe(200);
+    const rows = await testDb()
+      .select()
+      .from(schema.orgMembers)
+      .where(eq(schema.orgMembers.orgId, "org-1"))
+      .orderBy(schema.orgMembers.createdAt);
+    expect(rows.map((r) => [r.userId, r.role, r.previousRole])).toEqual([
+      ["owner-1", "owner", null],
+      ["m1", "viewer", null],
+      ["m2", "member", null],
+      // An explicit choice replaces the recorded one, so a later upgrade has
+      // nothing of its own to restore over it.
+      ["m3", "member", null],
+    ]);
+  });
+});
+
+describe("QR styling on a downgraded plan (#162)", () => {
+  async function seedStyledLink(cookie: string) {
+    await env.DB.batch([
+      env.DB.prepare(
+        "insert into links (id, org_id, slug, destination, title, qr_logo, qr_style, qr_color, qr_corner, qr_bg, qr_eye_color, created_at) values ('link-1', 'org-1', 'sale', 'https://example.com', 'Sale', '', 'dots', '#ff0000', '', '', '', 0)",
+      ),
+      env.DB.prepare(
+        "insert into link_addresses (id, link_id, org_id, domain_id, slug, kind, creation_reason, expires_at, retired_at, created_at) values ('addr-1', 'link-1', 'org-1', null, 'sale', 'primary', 'created', null, null, 0)",
+      ),
+    ]);
+    return cookie;
+  }
+
+  const save = (cookie: string, body: Record<string, unknown>) =>
+    fetchWorker(
+      new Request("http://localhost/api/orgs/org-1/links/link-1", {
+        method: "PATCH",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+
+  it("saves another field while the styling rides along unchanged", async () => {
+    const cookie = await seedStyledLink(await seedOwner());
+    const res = await save(cookie, {
+      title: "Autumn sale",
+      qrStyle: "dots",
+      qrColor: "#ff0000",
+      qrLogo: "",
+      qrCorner: "",
+      qrBg: "",
+      qrEyeColor: "",
+      qrLogoSize: null,
+    });
+    expect(res.status).toBe(200);
+    const [row] = await testDb().select().from(schema.links).where(eq(schema.links.id, "link-1"));
+    // The wipe this replaced: a title edit used to blank all of these.
+    expect([row.title, row.qrStyle, row.qrColor]).toEqual(["Autumn sale", "dots", "#ff0000"]);
+  });
+
+  it("still refuses an actual change to the styling", async () => {
+    const cookie = await seedStyledLink(await seedOwner());
+    const res = await save(cookie, { qrColor: "#00ff00" });
+    expect(res.status).toBe(402);
+    expect(await jsonBody<{ code: string }>(res)).toMatchObject({ code: "qr_locked" });
+  });
+
+  it("lets a downgraded org clear its styling without upgrading", async () => {
+    const cookie = await seedStyledLink(await seedOwner());
+    expect((await save(cookie, { qrStyle: "", qrColor: "" })).status).toBe(200);
+  });
+});
+
+describe("a locked domain takes no new links (#159)", () => {
+  it("refuses to be the org's default or to host a new link", async () => {
+    const cookie = await seedOwner("pro");
+    await env.DB.prepare(
+      "insert into domains (id, org_id, hostname, status, locked_at, created_at) values ('dom-1', 'org-1', 'go.example.com', 'active', 1, 0)",
+    ).run();
+
+    const asDefault = await fetchWorker(
+      new Request("http://localhost/api/orgs/org-1", {
+        method: "PATCH",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ defaultDomainId: "dom-1" }),
+      }),
+    );
+    expect(asDefault.status).toBe(402);
+
+    const newLink = await fetchWorker(
+      new Request("http://localhost/api/orgs/org-1/links", {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ destination: "https://example.com", domainId: "dom-1" }),
+      }),
+    );
+    expect(newLink.status).toBe(402);
+  });
+
+  it("reports the lock to the app", async () => {
+    const cookie = await seedOwner("pro");
+    await env.DB.prepare(
+      "insert into domains (id, org_id, hostname, status, locked_at, created_at) values ('dom-1', 'org-1', 'go.example.com', 'active', 1, 0)",
+    ).run();
+    const res = await fetchWorker(
+      new Request("http://localhost/api/orgs/org-1/domains", { headers: { cookie } }),
+    );
+    expect((await jsonBody<DomainDTO[]>(res))[0].lockedAt).toBe(1);
+  });
+});

--- a/tests/worker/entitlement-locks.worker.ts
+++ b/tests/worker/entitlement-locks.worker.ts
@@ -283,6 +283,14 @@ describe("QR styling on a downgraded plan (#162)", () => {
     expect((await save(cookie, { qrStyle: "", qrColor: "" })).status).toBe(200);
   });
 
+  it("clears the logo size when asked, rather than keeping the old one", async () => {
+    const cookie = await seedStyledLink(await seedOwner("pro"));
+    await env.DB.prepare("update links set qr_logo_size = 0.4 where id = 'link-1'").run();
+    expect((await save(cookie, { qrLogoSize: null })).status).toBe(200);
+    const [row] = await testDb().select().from(schema.links).where(eq(schema.links.id, "link-1"));
+    expect(row.qrLogoSize).toBeNull();
+  });
+
   it("treats the org's own QR defaults the same way", async () => {
     const cookie = await seedOwner();
     await env.DB.prepare("update orgs set qr_style = 'dots' where id = 'org-1'").run();

--- a/tests/worker/entitlement-locks.worker.ts
+++ b/tests/worker/entitlement-locks.worker.ts
@@ -144,7 +144,8 @@ describe("a locked org (#160)", () => {
       new Request("http://localhost/api/user", { headers: { cookie } }),
     );
     const body = await jsonBody<CurrentUser>(res);
-    expect(body.orgs.map((o) => [o.id, o.locked])).toEqual([
+    // Sorted: currentUserFor has no ORDER BY, so row order is incidental.
+    expect(body.orgs.map((o) => [o.id, o.locked]).sort()).toEqual([
       ["org-1", false],
       ["org-2", true],
     ]);
@@ -280,6 +281,25 @@ describe("QR styling on a downgraded plan (#162)", () => {
   it("lets a downgraded org clear its styling without upgrading", async () => {
     const cookie = await seedStyledLink(await seedOwner());
     expect((await save(cookie, { qrStyle: "", qrColor: "" })).status).toBe(200);
+  });
+
+  it("treats the org's own QR defaults the same way", async () => {
+    const cookie = await seedOwner();
+    await env.DB.prepare("update orgs set qr_style = 'dots' where id = 'org-1'").run();
+    const patch = (body: Record<string, string>) =>
+      fetchWorker(
+        new Request("http://localhost/api/orgs/org-1", {
+          method: "PATCH",
+          headers: { cookie, "content-type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+      );
+    // Renaming the org while its stored defaults ride along unchanged.
+    expect((await patch({ name: "Renamed", qrStyle: "dots" })).status).toBe(200);
+    // An actual change is still refused, on the same plan.
+    expect((await patch({ qrStyle: "square" })).status).toBe(402);
+    const [row] = await testDb().select().from(schema.orgs).where(eq(schema.orgs.id, "org-1"));
+    expect([row.name, row.qrStyle]).toEqual(["Renamed", "dots"]);
   });
 });
 

--- a/tests/worker/reconcile.worker.ts
+++ b/tests/worker/reconcile.worker.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { reset } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import * as schema from "../../src/worker/db/schema";
+import { reconcileUser, sweepGraceWarnings } from "../../src/worker/reconcile";
+import { GRACE_PERIOD_MS } from "../../src/shared/types";
+import {
+  applyTestMigrations,
+  captureEmails,
+  captureStorageQueue,
+  overrideEnv,
+  testDb,
+} from "./support";
+
+/**
+ * Reconciliation (#158): what a plan change does to the orgs a user owns.
+ *
+ * Every case here is a downgrade the product used to ignore entirely, plus
+ * the two properties the whole design rests on: running the pass twice
+ * changes nothing, and re-upgrading undoes all of it with no manual step.
+ */
+
+const NOW = 1_700_000_000_000;
+
+/** An owner on `plan`, owning `orgs` orgs oldest-first, each with the given
+ * number of extra members and domains. */
+async function seed({
+  plan = "pro",
+  orgs = 1,
+  members = 0,
+  domains = 0,
+}: { plan?: string; orgs?: number; members?: number; domains?: number } = {}) {
+  const statements = [
+    env.DB.prepare(
+      "insert into user (id, name, email, email_verified, is_admin, plan, created_at, updated_at) values ('owner-1', 'Owner', 'owner@example.com', 1, 0, ?, 0, 0)",
+    ).bind(plan),
+  ];
+  for (let i = 0; i < orgs; i++) {
+    const orgId = `org-${i}`;
+    statements.push(
+      env.DB.prepare("insert into orgs (id, name, created_at) values (?, ?, ?)").bind(
+        orgId,
+        `Org ${i}`,
+        i,
+      ),
+      env.DB.prepare(
+        "insert into org_members (org_id, user_id, role, created_at) values (?, 'owner-1', 'owner', 0)",
+      ).bind(orgId),
+    );
+  }
+  for (let i = 0; i < members; i++) {
+    statements.push(
+      env.DB.prepare(
+        "insert into user (id, name, email, email_verified, is_admin, plan, created_at, updated_at) values (?, ?, ?, 1, 0, 'free', 0, 0)",
+      ).bind(`member-${i}`, `Member ${i}`, `member${i}@example.com`),
+      // created_at ascending, so "longest-standing keeps write access" has an
+      // order to be right about.
+      env.DB.prepare(
+        "insert into org_members (org_id, user_id, role, created_at) values ('org-0', ?, 'member', ?)",
+      ).bind(`member-${i}`, i + 1),
+    );
+  }
+  for (let i = 0; i < domains; i++) {
+    statements.push(
+      env.DB.prepare(
+        "insert into domains (id, org_id, hostname, status, created_at) values (?, 'org-0', ?, 'active', ?)",
+      ).bind(`dom-${i}`, `d${i}.example.com`, i),
+    );
+  }
+  await env.DB.batch(statements);
+}
+
+async function setPlan(plan: string) {
+  await env.DB.prepare("update user set plan = ? where id = 'owner-1'").bind(plan).run();
+}
+
+/** An env whose storage queue records instead of delivering, and whose mail
+ * goes nowhere: both fire on every downgrade. */
+function quietEnv() {
+  const { queue, sent } = captureStorageQueue();
+  return { env: overrideEnv({ STORAGE_QUEUE: queue }), storage: sent };
+}
+
+async function entitlement(orgId = "org-0") {
+  const [row] = await testDb()
+    .select()
+    .from(schema.orgEntitlements)
+    .where(eq(schema.orgEntitlements.orgId, orgId));
+  return row;
+}
+
+async function members() {
+  return testDb()
+    .select()
+    .from(schema.orgMembers)
+    .where(eq(schema.orgMembers.orgId, "org-0"))
+    .orderBy(schema.orgMembers.createdAt);
+}
+
+async function domains() {
+  return testDb().select().from(schema.domains).orderBy(schema.domains.createdAt);
+}
+
+async function orgLocks() {
+  return testDb().select().from(schema.orgs).orderBy(schema.orgs.createdAt);
+}
+
+describe("entitlement reconciliation", () => {
+  beforeEach(async () => {
+    await reset();
+    await applyTestMigrations();
+  });
+
+  it("records nothing for an org inside its plan", async () => {
+    await seed({ plan: "free" });
+    const { env: e } = quietEnv();
+    await reconcileUser(e, testDb(), "owner-1", NOW);
+    const row = await entitlement();
+    expect(row.overJson).toBe("{}");
+    expect(row.graceEndsAt).toBeNull();
+  });
+
+  it("locks the domains beyond the cap on hobby-to-free, oldest kept", async () => {
+    await seed({ plan: "hobby", domains: 2 });
+    const { env: e, storage } = quietEnv();
+    await reconcileUser(e, testDb(), "owner-1", NOW);
+    // Hobby allows one domain: the older one keeps serving.
+    expect((await domains()).map((d) => d.lockedAt)).toEqual([null, NOW]);
+
+    await setPlan("free");
+    await reconcileUser(e, testDb(), "owner-1", NOW);
+    expect((await domains()).map((d) => d.lockedAt)).toEqual([NOW, NOW]);
+    const row = await entitlement();
+    expect(JSON.parse(row.overJson)).toEqual({ domains: 2 });
+    expect(row.graceEndsAt).toBe(NOW + GRACE_PERIOD_MS);
+    // Only the domains whose verdict moved get a KV republish.
+    expect(storage.map((m) => ("key" in m ? m.key : ""))).toContain("domain:d0.example.com");
+  });
+
+  it("demotes over-cap members to viewer, longest-standing first, owner exempt", async () => {
+    // Pro allows 25; free allows 3 (owner + 2).
+    await seed({ plan: "pro", members: 4 });
+    await setPlan("free");
+    const { env: e } = quietEnv();
+    await reconcileUser(e, testDb(), "owner-1", NOW);
+
+    const rows = await members();
+    expect(rows.map((r) => [r.userId, r.role])).toEqual([
+      ["owner-1", "owner"],
+      ["member-0", "member"],
+      ["member-1", "member"],
+      ["member-2", "viewer"],
+      ["member-3", "viewer"],
+    ]);
+    // What they were is recorded, and only for the ones that moved.
+    expect(rows.map((r) => r.previousRole)).toEqual([null, null, null, "member", "member"]);
+    expect(JSON.parse((await entitlement()).overJson)).toEqual({ members: 5 });
+  });
+
+  it("locks the extra orgs on pro-to-free, keeping the oldest", async () => {
+    await seed({ plan: "pro", orgs: 3 });
+    await setPlan("free");
+    const { env: e } = quietEnv();
+    await reconcileUser(e, testDb(), "owner-1", NOW);
+    expect((await orgLocks()).map((o) => o.lockedAt)).toEqual([null, NOW, NOW]);
+  });
+
+  it("changes nothing when run twice for the same plan", async () => {
+    await seed({ plan: "pro", orgs: 3, members: 4, domains: 3 });
+    await setPlan("free");
+    const { env: e } = quietEnv();
+    await reconcileUser(e, testDb(), "owner-1", NOW);
+    const first = await entitlement();
+
+    // A day later, same plan: the grace period must not move.
+    await reconcileUser(e, testDb(), "owner-1", NOW + 86_400_000);
+    const second = await entitlement();
+    expect(second.graceEndsAt).toBe(first.graceEndsAt);
+    expect(second.overJson).toBe(first.overJson);
+    expect((await orgLocks()).map((o) => o.lockedAt)).toEqual([null, NOW, NOW]);
+    expect((await domains()).map((d) => d.lockedAt)).toEqual([NOW, NOW, NOW]);
+    expect((await members()).map((r) => r.role)).toEqual([
+      "owner",
+      "member",
+      "member",
+      "viewer",
+      "viewer",
+    ]);
+  });
+
+  it("restores everything on upgrade, with no manual step", async () => {
+    await seed({ plan: "pro", orgs: 3, members: 4, domains: 3 });
+    await setPlan("free");
+    const { env: e } = quietEnv();
+    await reconcileUser(e, testDb(), "owner-1", NOW);
+
+    await setPlan("pro");
+    await reconcileUser(e, testDb(), "owner-1", NOW + 1000);
+
+    expect((await orgLocks()).map((o) => o.lockedAt)).toEqual([null, null, null]);
+    expect((await domains()).map((d) => d.lockedAt)).toEqual([null, null, null]);
+    const rows = await members();
+    expect(rows.map((r) => r.role)).toEqual(["owner", "member", "member", "member", "member"]);
+    expect(rows.every((r) => r.previousRole === null)).toBe(true);
+    const row = await entitlement();
+    expect(row.overJson).toBe("{}");
+    expect(row.graceEndsAt).toBeNull();
+  });
+
+  it("restarts the grace period when the plan drops again", async () => {
+    await seed({ plan: "pro", domains: 3 });
+    await setPlan("hobby");
+    const { env: e } = quietEnv();
+    await reconcileUser(e, testDb(), "owner-1", NOW);
+    expect((await entitlement()).graceEndsAt).toBe(NOW + GRACE_PERIOD_MS);
+
+    const later = NOW + 40 * 86_400_000;
+    await setPlan("free");
+    await reconcileUser(e, testDb(), "owner-1", later);
+    // The domain that only just went over must not inherit an expired clock.
+    expect((await entitlement()).graceEndsAt).toBe(later + GRACE_PERIOD_MS);
+  });
+
+  it("emails the owner once per grace period, then warns at day 23", async () => {
+    await seed({ plan: "hobby", domains: 2 });
+    await setPlan("free");
+    const mail = captureEmails();
+    try {
+      const { env: e } = quietEnv();
+      await reconcileUser(e, testDb(), "owner-1", NOW);
+      expect(mail.sent.map((m) => m.to)).toEqual(["owner@example.com"]);
+      expect(mail.sent[0].subject).toContain("over its plan");
+
+      // A second pass on the same plan sends nothing more.
+      await reconcileUser(e, testDb(), "owner-1", NOW + 1000);
+      expect(mail.sent).toHaveLength(1);
+
+      // Day 23 of 30: one week left.
+      const day23 = NOW + GRACE_PERIOD_MS - 6 * 86_400_000;
+      expect(await sweepGraceWarnings(e, testDb(), day23)).toBe(1);
+      expect(mail.sent).toHaveLength(2);
+      expect(mail.sent[1].subject).toContain("loses its custom domains soon");
+      // And only once.
+      expect(await sweepGraceWarnings(e, testDb(), day23 + 1000)).toBe(0);
+    } finally {
+      mail.restore();
+    }
+  });
+
+  it("leaves a grace with more than a week left alone", async () => {
+    await seed({ plan: "hobby", domains: 2 });
+    await setPlan("free");
+    const mail = captureEmails();
+    try {
+      const { env: e } = quietEnv();
+      await reconcileUser(e, testDb(), "owner-1", NOW);
+      expect(await sweepGraceWarnings(e, testDb(), NOW + 86_400_000)).toBe(0);
+    } finally {
+      mail.restore();
+    }
+  });
+});

--- a/tests/worker/reconcile.worker.ts
+++ b/tests/worker/reconcile.worker.ts
@@ -75,8 +75,14 @@ async function setPlan(plan: string) {
   await env.DB.prepare("update user set plan = ? where id = 'owner-1'").bind(plan).run();
 }
 
-/** An env whose storage queue records instead of delivering, and whose mail
- * goes nowhere: both fire on every downgrade. */
+/**
+ * An env whose storage queue records instead of delivering.
+ *
+ * Outbound mail is deliberately *not* stubbed here. `reconcileUser` catches
+ * every failure, so a send that fails is swallowed and logged, which is what
+ * lets the cases below assert D1 and KV without caring about Resend. The
+ * cases that are about the emails wrap themselves in `withMail`.
+ */
 function quietEnv() {
   const { queue, sent } = captureStorageQueue();
   return { env: overrideEnv({ STORAGE_QUEUE: queue }), storage: sent };
@@ -221,14 +227,23 @@ describe("entitlement reconciliation", () => {
   });
 
   it("restarts the grace period when the plan drops again", async () => {
-    const { env: e } = await downgrade({ plan: "pro", domains: 3 }, "hobby");
+    const { env: e, storage } = await downgrade({ plan: "pro", domains: 3 }, "hobby");
     expect((await entitlement()).graceEndsAt).toBe(NOW + GRACE_PERIOD_MS);
 
     const later = NOW + 40 * 86_400_000;
+    storage.length = 0;
     await setPlan("free");
     await reconcileUser(e, testDb(), "owner-1", later);
     // The domain that only just went over must not inherit an expired clock.
     expect((await entitlement()).graceEndsAt).toBe(later + GRACE_PERIOD_MS);
+    // And every locked domain is republished, not just the one whose lock
+    // moved: the KV value carries the deadline, so the two already locked
+    // would otherwise keep the old one and 404 through the new grace period.
+    expect(storage.map((m) => ("key" in m ? m.key : "")).sort()).toEqual([
+      "domain:d0.example.com",
+      "domain:d1.example.com",
+      "domain:d2.example.com",
+    ]);
   });
 
   it("emails the owner once per grace period, then warns at day 23", async () => {

--- a/tests/worker/reconcile.worker.ts
+++ b/tests/worker/reconcile.worker.ts
@@ -102,6 +102,30 @@ async function domains() {
   return testDb().select().from(schema.domains).orderBy(schema.domains.createdAt);
 }
 
+/** Seeds an account, drops it to a lower plan, and runs the pass: the
+ * opening three lines of nearly every case below. */
+async function downgrade(
+  seedArgs: Parameters<typeof seed>[0],
+  to: string,
+  now = NOW,
+): Promise<ReturnType<typeof quietEnv>> {
+  await seed(seedArgs);
+  await setPlan(to);
+  const quiet = quietEnv();
+  await reconcileUser(quiet.env, testDb(), "owner-1", now);
+  return quiet;
+}
+
+/** Runs `body` with outbound mail captured, and always restores fetch. */
+async function withMail(body: (mail: ReturnType<typeof captureEmails>) => Promise<void>) {
+  const mail = captureEmails();
+  try {
+    await body(mail);
+  } finally {
+    mail.restore();
+  }
+}
+
 async function orgLocks() {
   return testDb().select().from(schema.orgs).orderBy(schema.orgs.createdAt);
 }
@@ -140,10 +164,7 @@ describe("entitlement reconciliation", () => {
 
   it("demotes over-cap members to viewer, longest-standing first, owner exempt", async () => {
     // Pro allows 25; free allows 3 (owner + 2).
-    await seed({ plan: "pro", members: 4 });
-    await setPlan("free");
-    const { env: e } = quietEnv();
-    await reconcileUser(e, testDb(), "owner-1", NOW);
+    await downgrade({ plan: "pro", members: 4 }, "free");
 
     const rows = await members();
     expect(rows.map((r) => [r.userId, r.role])).toEqual([
@@ -159,18 +180,12 @@ describe("entitlement reconciliation", () => {
   });
 
   it("locks the extra orgs on pro-to-free, keeping the oldest", async () => {
-    await seed({ plan: "pro", orgs: 3 });
-    await setPlan("free");
-    const { env: e } = quietEnv();
-    await reconcileUser(e, testDb(), "owner-1", NOW);
+    await downgrade({ plan: "pro", orgs: 3 }, "free");
     expect((await orgLocks()).map((o) => o.lockedAt)).toEqual([null, NOW, NOW]);
   });
 
   it("changes nothing when run twice for the same plan", async () => {
-    await seed({ plan: "pro", orgs: 3, members: 4, domains: 3 });
-    await setPlan("free");
-    const { env: e } = quietEnv();
-    await reconcileUser(e, testDb(), "owner-1", NOW);
+    const { env: e } = await downgrade({ plan: "pro", orgs: 3, members: 4, domains: 3 }, "free");
     const first = await entitlement();
 
     // A day later, same plan: the grace period must not move.
@@ -190,10 +205,7 @@ describe("entitlement reconciliation", () => {
   });
 
   it("restores everything on upgrade, with no manual step", async () => {
-    await seed({ plan: "pro", orgs: 3, members: 4, domains: 3 });
-    await setPlan("free");
-    const { env: e } = quietEnv();
-    await reconcileUser(e, testDb(), "owner-1", NOW);
+    const { env: e } = await downgrade({ plan: "pro", orgs: 3, members: 4, domains: 3 }, "free");
 
     await setPlan("pro");
     await reconcileUser(e, testDb(), "owner-1", NOW + 1000);
@@ -209,10 +221,7 @@ describe("entitlement reconciliation", () => {
   });
 
   it("restarts the grace period when the plan drops again", async () => {
-    await seed({ plan: "pro", domains: 3 });
-    await setPlan("hobby");
-    const { env: e } = quietEnv();
-    await reconcileUser(e, testDb(), "owner-1", NOW);
+    const { env: e } = await downgrade({ plan: "pro", domains: 3 }, "hobby");
     expect((await entitlement()).graceEndsAt).toBe(NOW + GRACE_PERIOD_MS);
 
     const later = NOW + 40 * 86_400_000;
@@ -223,12 +232,8 @@ describe("entitlement reconciliation", () => {
   });
 
   it("emails the owner once per grace period, then warns at day 23", async () => {
-    await seed({ plan: "hobby", domains: 2 });
-    await setPlan("free");
-    const mail = captureEmails();
-    try {
-      const { env: e } = quietEnv();
-      await reconcileUser(e, testDb(), "owner-1", NOW);
+    await withMail(async (mail) => {
+      const { env: e } = await downgrade({ plan: "hobby", domains: 2 }, "free");
       expect(mail.sent.map((m) => m.to)).toEqual(["owner@example.com"]);
       expect(mail.sent[0].subject).toContain("over its plan");
 
@@ -243,21 +248,13 @@ describe("entitlement reconciliation", () => {
       expect(mail.sent[1].subject).toContain("loses its custom domains soon");
       // And only once.
       expect(await sweepGraceWarnings(e, testDb(), day23 + 1000)).toBe(0);
-    } finally {
-      mail.restore();
-    }
+    });
   });
 
   it("leaves a grace with more than a week left alone", async () => {
-    await seed({ plan: "hobby", domains: 2 });
-    await setPlan("free");
-    const mail = captureEmails();
-    try {
-      const { env: e } = quietEnv();
-      await reconcileUser(e, testDb(), "owner-1", NOW);
+    await withMail(async () => {
+      const { env: e } = await downgrade({ plan: "hobby", domains: 2 }, "free");
       expect(await sweepGraceWarnings(e, testDb(), NOW + 86_400_000)).toBe(0);
-    } finally {
-      mail.restore();
-    }
+    });
   });
 });

--- a/tests/worker/reconcile.worker.ts
+++ b/tests/worker/reconcile.worker.ts
@@ -4,12 +4,14 @@ import { reset } from "cloudflare:test";
 import { eq } from "drizzle-orm";
 import * as schema from "../../src/worker/db/schema";
 import { reconcileUser, sweepGraceWarnings } from "../../src/worker/reconcile";
+import type { StorageMessage } from "../../src/worker/storage";
 import { GRACE_PERIOD_MS } from "../../src/shared/types";
 import {
   applyTestMigrations,
   captureEmails,
   captureStorageQueue,
   overrideEnv,
+  stubQueue,
   testDb,
 } from "./support";
 
@@ -166,6 +168,31 @@ describe("entitlement reconciliation", () => {
     expect(row.graceEndsAt).toBe(NOW + GRACE_PERIOD_MS);
     // Only the domains whose verdict moved get a KV republish.
     expect(storage.map((m) => ("key" in m ? m.key : ""))).toContain("domain:d0.example.com");
+  });
+
+  it("requeues locked domains after a storage queue failure", async () => {
+    await seed({ plan: "free", domains: 2 });
+    const failing = overrideEnv({
+      STORAGE_QUEUE: stubQueue<StorageMessage>(() => {
+        throw new Error("injected storage queue failure");
+      }),
+    });
+
+    // D1 commits before queue submission, exactly as it does for a transient
+    // binding failure in production. The first pass therefore leaves both
+    // domains locked while no KV sync was accepted.
+    await reconcileUser(failing, testDb(), "owner-1", NOW);
+    expect((await domains()).map((domain) => domain.lockedAt)).toEqual([NOW, NOW]);
+
+    const { env: retry, storage } = quietEnv();
+    await reconcileUser(retry, testDb(), "owner-1", NOW + 1_000);
+
+    // Nothing in D1 changes on the replay, but it still republishes all
+    // locked hosts so their KV `servesUntil` values recover.
+    expect(storage.map((message) => ("key" in message ? message.key : "")).sort()).toEqual([
+      "domain:d0.example.com",
+      "domain:d1.example.com",
+    ]);
   });
 
   it("demotes over-cap members to viewer, longest-standing first, owner exempt", async () => {

--- a/tests/worker/viewer-role.worker.ts
+++ b/tests/worker/viewer-role.worker.ts
@@ -1,0 +1,147 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { reset } from "cloudflare:test";
+import { hashPassword } from "../../src/worker/password";
+import {
+  applyTestMigrations,
+  fetchWorker,
+  freeOwnerCookie,
+  signInCookie,
+  TEST_PASSWORD,
+} from "./support";
+
+/**
+ * A viewer reads everything the org holds and writes nothing (#157).
+ *
+ * The split is the whole feature, so it is asserted route by route rather
+ * than by spot-check: getting it wrong one way locks a viewer out of the only
+ * thing they exist to do, and the other way hands them a write.
+ */
+async function seedViewer(role = "viewer"): Promise<string> {
+  await env.DB.batch([
+    env.DB.prepare(
+      "insert into user (id, name, email, email_verified, is_admin, plan, created_at, updated_at) values ('viewer-1', 'Viewer', 'viewer@example.com', 1, 0, 'free', 0, 0)",
+    ),
+    env.DB.prepare(
+      "insert into account (id, account_id, provider_id, user_id, password, created_at, updated_at) values ('acct-viewer-1', 'viewer-1', 'credential', 'viewer-1', ?, 0, 0)",
+    ).bind(await hashPassword(TEST_PASSWORD)),
+    env.DB.prepare(
+      "insert into org_members (org_id, user_id, role, created_at) values ('org-1', 'viewer-1', ?, 0)",
+    ).bind(role),
+  ]);
+  return signInCookie("viewer@example.com", TEST_PASSWORD);
+}
+
+async function seedLink() {
+  await env.DB.batch([
+    env.DB.prepare(
+      "insert into links (id, org_id, slug, destination, created_at) values ('link-1', 'org-1', 'sale', 'https://example.com', 0)",
+    ),
+  ]);
+  await env.DB.prepare(
+    "insert into link_addresses (id, link_id, org_id, domain_id, slug, kind, creation_reason, expires_at, retired_at, created_at) values ('addr-1', 'link-1', 'org-1', null, 'sale', 'primary', 'created', null, null, 0)",
+  ).run();
+}
+
+const url = (path: string) => `http://localhost/api/orgs/org-1${path}`;
+
+/** Every read a member can reach. A viewer must reach all of them. */
+const READS = [
+  "/links",
+  "/links/quota-usage",
+  "/links/link-1/addresses",
+  "/members",
+  "/stats",
+  "/clicks",
+  "/links/stats/sale",
+];
+
+/** Every write. A viewer must reach none of them. */
+const WRITES: [string, string, unknown][] = [
+  ["POST", "/links", { destination: "https://example.com/new" }],
+  ["POST", "/links/claim", { slug: "whatever" }],
+  ["PATCH", "/links/link-1", { title: "Renamed" }],
+  ["DELETE", "/links/link-1", null],
+  ["POST", "/links/link-1/addresses", {}],
+  ["PATCH", "/links/link-1/addresses/addr-1", { kind: "permanent" }],
+  ["DELETE", "/links/link-1/addresses/addr-1", null],
+  ["POST", "/qr-logo", null],
+];
+
+beforeEach(applyTestMigrations);
+afterEach(reset);
+
+describe("the viewer role", () => {
+  it("reaches every read a member reaches", async () => {
+    await freeOwnerCookie();
+    await seedLink();
+    const cookie = await seedViewer();
+
+    for (const path of READS) {
+      const res = await fetchWorker(new Request(url(path), { headers: { cookie } }));
+      expect(res.status, `GET ${path} should be readable by a viewer`).toBe(200);
+    }
+  });
+
+  it("is refused every write", async () => {
+    await freeOwnerCookie();
+    await seedLink();
+    const cookie = await seedViewer();
+
+    for (const [method, path, body] of WRITES) {
+      const res = await fetchWorker(
+        new Request(url(path), {
+          method,
+          headers: { cookie, "content-type": "application/json" },
+          body: body === null ? undefined : JSON.stringify(body),
+        }),
+      );
+      expect(res.status, `${method} ${path} should be refused for a viewer`).toBe(403);
+    }
+  });
+
+  it("still lets a member through those same writes", async () => {
+    await freeOwnerCookie();
+    await seedLink();
+    const cookie = await seedViewer("member");
+
+    // The one that proves the refusals above are about the role and not about
+    // the seeding: the same request, from a member, is not a 403.
+    const res = await fetchWorker(
+      new Request(url("/links/link-1"), {
+        method: "PATCH",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ title: "Renamed" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  // The copy-link invite rather than the email one: this is about the role
+  // surviving into the row, and a mail send would only add a dependency on
+  // the email emulator to say so.
+  it("can be invited, and the invite stores the role", async () => {
+    const owner = await freeOwnerCookie();
+    const res = await fetchWorker(
+      new Request(url("/invites"), {
+        method: "POST",
+        headers: { cookie: owner, "content-type": "application/json" },
+        body: JSON.stringify({ role: "viewer", emails: [] }),
+      }),
+    );
+    expect(res.status).toBe(201);
+
+    const row = await env.DB.prepare("select role from invites where org_id = 'org-1'").first<{
+      role: string;
+    }>();
+    expect(row?.role).toBe("viewer");
+  });
+
+  it("survives the rebuild: the migration keeps existing memberships", async () => {
+    await freeOwnerCookie();
+    const row = await env.DB.prepare(
+      "select role, created_at from org_members where org_id = 'org-1' and user_id = 'free-1'",
+    ).first<{ role: string; created_at: number }>();
+    expect(row).toEqual({ role: "owner", created_at: 0 });
+  });
+});


### PR DESCRIPTION
Closes #157, #158, #159, #160, #161, #162, #163. Together these are all of #29 except the policy write-up itself.

## What was wrong

Nothing ran on a plan change. The Polar webhook wrote `user.plan` and stopped, so no org ever learned it was over its caps: every limit was checked at write time against the owner's current plan, and a downgraded account kept 5 branded domains serving, 3 orgs fully usable and 25 members with write access, forever. Buy one month of Pro, keep the lot.

The one place the product *did* act on a downgrade was the one place it should not have: `withoutQrOverrides` cleared a link's QR fields on save, so somebody on Free fixing a typo in a **title** silently destroyed the logo, colours, dot and corner style they had paid for.

And nothing explained any of it. `500 / 30 links` with no sentence around it; "the free plan allows 30 links, upgrade for more" shown to an org holding five hundred; analytics truncating to 7 days as though the history were gone.

## What this does

**#157 · a read-only `viewer` role.** Slots in below `member` in `ROLE_RANK`. Seven GETs drop to `viewer`, eight writes stay at `member`, and both directions are tested at the boundary: leaving a GET at `member` locks viewers out of the only thing they exist to do, and the other way hands a viewer a write.

**#158 · reconciliation.** `reconcileUser()` in `src/worker/reconcile.ts`, run after every plan-changing webhook event, after a comp grant or revoke, and by hand from `POST /api/admin/users/:id/reconcile`. It records what is over cap in `org_entitlements` and marks the resources beyond it. It never deletes and never demotes an owner.

Idempotent by construction: every decision is recomputed from the live rows, and the one value that could drift, when the grace ends, only moves when the plan the last pass compared against is not the plan this one sees. Running it twice for the same plan changes nothing, and that is asserted rather than assumed.

**#159 · domains.** `domains.locked_at` plus the org's `grace_ends_at` become `servesUntil` in the domain's KV value, so the redirect path enforces the 30 days with no D1 read and no cron: a stored deadline needs nothing to expire it. Past the deadline the host 404s, which is honest and cacheable and the right answer for the machines that fetch most dead short links. Nothing is deleted, so re-upgrading restores service with no DNS re-verification and no new certificate.

**#160 · orgs.** `orgs.locked_at`, checked in `requireOrgRole` next to the teardown check, so no route has to remember. A locked org is read-only for everyone in it, its owner included, and **its links keep redirecting**: the lock is between us and the account holder, and the people clicking are not party to it. It still counts against the cap, so nobody locks one and creates a fresh one in its place. The owner picks which org stays active, reversibly.

**#161 · members.** Extras are demoted to `viewer`, longest-standing first, owner exempt, with `org_members.previous_role` recording what each was so an upgrade puts them back. Nobody is removed. Viewers still occupy a seat, deliberately: the cap is on people in the org, not on people who may write.

**#162 · QR.** The editor sends what it loaded. The server only refuses a save that *changes* a QR field, and clearing one never needs a plan. `qr-download.pw.ts` now asserts the styling survives the save, which is the test that would have caught the wipe.

**#163 · the part people see.** One `OverLimitBanner` above the route and one `LockedPanel` for a frozen thing. Copy that reads correctly when you are five hundred over rather than one short. Domains stay listed on a plan with none, marked locked and counting down, because hiding them is how an owner concludes we deleted them. Analytics offers the windows the plan cannot reach and says the clicks are kept for 400 days.

## Decisions worth arguing with

- **The grace period is org-wide, not per-resource.** Only domains use it (they are the only thing that keeps working while locked), so a second timer per resource would be state nothing reads.
- **Which domains lock, and which members are demoted, is by age, not by a choice.** Reconciliation has to produce an answer before anybody is asked, and "oldest keeps working" is predictable in a way that "whoever logged in last" is not. #160 and #161 both then let the owner override.
- **Promoting a demoted member is refused while the org is over its cap**, rather than silently demoting somebody else. The owner demotes first, then promotes: two deliberate steps beat one that quietly takes access from a third person.
- **`canWriteOrg` answers false for a locked org.** That is the same shape as a viewer's access, so every control #157 already hid is hidden here too, with nothing new threaded through the app.

## At release

The migration adds one table and three nullable columns; nothing is dropped and no existing row changes. Until the first plan change for an account, every org reads as "fine", which is what it was before this branch.

`KVDomain` gains `servesUntil`. Values written before it exists read as `undefined`, which means "keeps serving", so no republish is needed for the existing estate and there is a test for that specific case.

Six guards were mutation-tested (break it, watch the test fail, restore): the org-lock check, the domain grace check, the QR change check, the member cap, the member demotion, and the idempotence of the grace period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VfyPU1UrdK8joAUPAzByL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only Viewer role for organization data, analytics, and links.
  * Added plan-limit handling with grace periods, notifications, locked organizations, and domain status messaging.
  * Added upgrade and “keep active” options after plan changes.
  * Added Viewer invitations and automatic role restoration after upgrading.
  * Added seat-limit messaging and controls for full organizations.
* **Bug Fixes**
  * Preserved QR styling when editing links without customization access.
  * Improved permissions, locked-domain handling, and QR defaults access.
  * Clarified analytics availability and upgrade guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->