### PR TITLE
Drop swept clicks from the dedupe index

### DIFF
--- a/migrations/0027_partial_click_dedupe_index.sql
+++ b/migrations/0027_partial_click_dedupe_index.sql
@@ -1,0 +1,5 @@
+-- Swept clicks have no dedupe id and cannot be redelivered. Keep only the
+-- live seven-day dedupe window in the unique index instead of every retained
+-- click. Rebuilding the index does not rewrite the clicks table.
+DROP INDEX idx_clicks_dedupe_id;
+CREATE UNIQUE INDEX idx_clicks_dedupe_id ON clicks(dedupe_id) WHERE dedupe_id IS NOT NULL;

--- a/src/worker/clicks.ts
+++ b/src/worker/clicks.ts
@@ -130,7 +130,11 @@ export async function consumeClickBatch(
             dedupeId: m.body.dedupeId,
           })),
         )
-        .onConflictDoNothing({ target: schema.clicks.dedupeId }),
+        // The dedupe constraint is a partial unique index: swept NULL ids are
+        // deliberately absent from it. SQLite cannot match a column-only
+        // conflict target to that index, so let it handle the one applicable
+        // unique conflict without naming a target.
+        .onConflictDoNothing(),
     );
     const writes = nonEmpty(inserts);
     if (writes) await db.batch(writes);

--- a/src/worker/clicks.ts
+++ b/src/worker/clicks.ts
@@ -217,9 +217,9 @@ async function salvageClickBatch(
   const outcomes = await Promise.all(
     batch.messages.map(async (message) => {
       try {
-        await db.insert(schema.clicks).values(clickRow(message)).onConflictDoNothing({
-          target: schema.clicks.dedupeId,
-        });
+        // Same partial dedupe index as the batch insert above. Naming only the
+        // column cannot match that index, including on this last-delivery path.
+        await db.insert(schema.clicks).values(clickRow(message)).onConflictDoNothing();
         return null;
       } catch (error) {
         // Narrowed here, where it arrives: only an Error carries a message

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -370,9 +370,9 @@ export const clicks = sqliteTable(
     // Set by the click queue producer (crypto.randomUUID()); lets the queue
     // consumer's batch insert dedupe a redelivered message. Null on rows from
     // before this column existed, and on rows the daily sweep has cleared
-    // once no redelivery can reach them (sweepDedupeIds, #70). Either way
-    // SQLite's unique index treats every NULL as distinct, so those rows
-    // never collide with each other or with real dedupe ids.
+    // once no redelivery can reach them (sweepDedupeIds, #70).
+    // The partial unique index from migration 0027 excludes every NULL, so
+    // swept rows carry no index weight and real dedupe ids still cannot clash.
     dedupeId: text("dedupe_id").unique(),
     // Which address the click came in on (primary or an alias). Null on rows
     // from before this column existed: not backfilled, same reasoning as

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -371,9 +371,10 @@ export const clicks = sqliteTable(
     // consumer's batch insert dedupe a redelivered message. Null on rows from
     // before this column existed, and on rows the daily sweep has cleared
     // once no redelivery can reach them (sweepDedupeIds, #70).
-    // The partial unique index from migration 0027 excludes every NULL, so
-    // swept rows carry no index weight and real dedupe ids still cannot clash.
-    dedupeId: text("dedupe_id").unique(),
+    // Migration 0027 owns the partial unique index because Drizzle cannot
+    // express its WHERE clause. It excludes every NULL, so swept rows carry no
+    // index weight and real dedupe ids still cannot clash.
+    dedupeId: text("dedupe_id"),
     // Which address the click came in on (primary or an alias). Null on rows
     // from before this column existed: not backfilled, same reasoning as
     // dedupeId above. Link-level aggregates roll up by linkId regardless.

--- a/tests/worker/clicks.worker.ts
+++ b/tests/worker/clicks.worker.ts
@@ -363,6 +363,14 @@ describe("sweepDedupeIds (#70)", () => {
     return row?.dedupe_id;
   }
 
+  it("indexes only live dedupe ids, not every swept click", async () => {
+    const index = await env.DB.prepare(
+      "select sql from sqlite_master where type = 'index' and name = 'idx_clicks_dedupe_id'",
+    ).first<{ sql: string }>();
+
+    expect(index?.sql.toLowerCase()).toContain("where dedupe_id is not null");
+  });
+
   it("clears ids past the redelivery window and keeps the recent ones", async () => {
     await seedLink();
     await seedClick(1, 30, "dedupe-old");


### PR DESCRIPTION
Closes #70.

Part of native GitHub stack #169. This layer is based on #167.

## What was wrong

The daily sweep clears `clicks.dedupe_id` after seven days, but `idx_clicks_dedupe_id` was a full unique index. SQLite still stored an index entry for every swept `NULL` row, so deduplication kept growing for the full 400-day click-retention window even though queue redelivery lasts only days.

## Fix

- Rebuild the index as `UNIQUE ... WHERE dedupe_id IS NOT NULL`.
- Keep both the normal batch insert and the final-delivery salvage path idempotent with targetless `ON CONFLICT DO NOTHING`.
- Remove Drizzle's full-column uniqueness declaration. Migration 0027 owns the partial index that Drizzle cannot express.
- Pin the migrated index predicate in the Worker test.

The issue discussion described the remaining work as a one-line migration. That was incomplete: SQLite cannot match `ON CONFLICT(dedupe_id)` to a partial unique index unless the conflict target repeats its predicate. With only the migration, every click batch retries and stores nothing. Targetless conflict handling is exact here because `dedupe_id` is the only applicable unique conflict.

## Deliberately not done

No BLOB conversion or separate dedupe table. The seven-day partial index makes both larger designs unnecessary. No table rewrite, and no browser-only scenario: this is an internal index change whose observable queue behavior is covered by the real Worker migration test. The full stacked browser suite still runs in CI.

## Verification

- `bunx vitest run tests/worker/clicks.worker.ts tests/worker/teardown-writes.worker.ts` (31 passed)
- Mutation: restoring `ON CONFLICT(dedupe_id)` fails the redelivery test before the first click lands
- `bun run fallow`
- `bun run verify` at this stacked head (305 app/shared, 398 Worker)

## Merge order

GitHub stack #169 enforces the order: #165, then #167, then this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved click delivery reliability by retrying failed batches and recovering valid rows individually.
  - Deleted-link failures are now handled without blocking successful click processing.
  - Preserved deduplication for active clicks while allowing swept records to be excluded.
- **Tests**
  - Added coverage confirming deduplication applies only to clicks with available deduplication identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->