### PR TITLE
Simplify the app route hotspots

### DIFF
--- a/src/app/routes/analytics.tsx
+++ b/src/app/routes/analytics.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useStats, useCurrentUser } from "../lib/hooks";
 import { useCurrentOrg } from "../lib/current-org";
 import { clicksByWeekday } from "../lib/click-buckets";
-import { PLAN_LIMITS, type HeatmapRow, type SeriesPoint } from "@/shared/types";
+import { PLAN_LIMITS, type HeatmapRow, type OrgStats, type SeriesPoint } from "@/shared/types";
 import {
   AreaChart,
   BarList,
@@ -156,27 +156,28 @@ function ActivityBreakdown({ heatmap, bucket }: { heatmap: HeatmapRow[]; bucket:
   );
 }
 
-export function Analytics() {
-  const { org } = useCurrentOrg();
-  const currentUser = useCurrentUser();
-  const [range, setRange] = useState<{ days?: number; bucket?: "day" | "hour" }>({});
-  const stats = useStats(org?.id ?? "", range.days, range.bucket);
+type AnalyticsRange = { days?: number; bucket?: "day" | "hour" };
 
-  if (currentUser.isLoading) return <AnalyticsSkeleton />;
-  if (!org) return <NoOrgState />;
-  if (stats.isLoading) return <AnalyticsSkeleton />;
-  if (!stats.data) return <p className="text-sm text-danger">Could not load stats.</p>;
-  const s = stats.data;
-  const maxDays = PLAN_LIMITS[org.plan].analyticsDays;
+function AnalyticsReport({
+  stats: s,
+  maxDays,
+  range,
+  onRangeChange,
+}: {
+  stats: OrgStats;
+  maxDays: number;
+  range: AnalyticsRange;
+  onRangeChange: (range: AnalyticsRange) => void;
+}) {
   const presets = RANGE_PRESETS.filter((p) => p.days <= maxDays);
   const hiddenRanges = RANGE_PRESETS.filter((p) => p.days > maxDays).map((p) => p.label);
   const activeDays = range.days ?? s.rangeDays;
   const activeBucket = range.bucket ?? s.bucket;
   const chooseRange = (days: number, bucket?: "day" | "hour") => {
     if (days === s.rangeDays && (bucket ?? "day") === s.bucket) {
-      setRange({});
+      onRangeChange({});
     } else {
-      setRange({ days, bucket });
+      onRangeChange({ days, bucket });
     }
   };
 
@@ -229,5 +230,25 @@ export function Analytics() {
 
       <ActivityBreakdown heatmap={s.heatmap} bucket={s.bucket} />
     </div>
+  );
+}
+
+export function Analytics() {
+  const { org } = useCurrentOrg();
+  const currentUser = useCurrentUser();
+  const [range, setRange] = useState<AnalyticsRange>({});
+  const stats = useStats(org?.id ?? "", range.days, range.bucket);
+
+  if (currentUser.isLoading) return <AnalyticsSkeleton />;
+  if (!org) return <NoOrgState />;
+  if (stats.isLoading) return <AnalyticsSkeleton />;
+  if (!stats.data) return <p className="text-sm text-danger">Could not load stats.</p>;
+  return (
+    <AnalyticsReport
+      stats={stats.data}
+      maxDays={PLAN_LIMITS[org.plan].analyticsDays}
+      range={range}
+      onRangeChange={setRange}
+    />
   );
 }

--- a/src/app/routes/analytics.tsx
+++ b/src/app/routes/analytics.tsx
@@ -2,7 +2,13 @@ import { useState } from "react";
 import { useStats, useCurrentUser } from "../lib/hooks";
 import { useCurrentOrg } from "../lib/current-org";
 import { clicksByWeekday } from "../lib/click-buckets";
-import { PLAN_LIMITS, type HeatmapRow, type OrgStats, type SeriesPoint } from "@/shared/types";
+import {
+  PLAN_LIMITS,
+  type HeatmapRow,
+  type OrgStats,
+  type SeriesPoint,
+  type UserOrg,
+} from "@/shared/types";
 import {
   AreaChart,
   BarList,
@@ -233,14 +239,10 @@ function AnalyticsReport({
   );
 }
 
-export function Analytics() {
-  const { org } = useCurrentOrg();
-  const currentUser = useCurrentUser();
+function AnalyticsForOrg({ org }: { org: UserOrg }) {
   const [range, setRange] = useState<AnalyticsRange>({});
-  const stats = useStats(org?.id ?? "", range.days, range.bucket);
+  const stats = useStats(org.id, range.days, range.bucket);
 
-  if (currentUser.isLoading) return <AnalyticsSkeleton />;
-  if (!org) return <NoOrgState />;
   if (stats.isLoading) return <AnalyticsSkeleton />;
   if (!stats.data) return <p className="text-sm text-danger">Could not load stats.</p>;
   return (
@@ -251,4 +253,13 @@ export function Analytics() {
       onRangeChange={setRange}
     />
   );
+}
+
+export function Analytics() {
+  const { org } = useCurrentOrg();
+  const currentUser = useCurrentUser();
+
+  if (currentUser.isLoading) return <AnalyticsSkeleton />;
+  if (!org) return <NoOrgState />;
+  return <AnalyticsForOrg org={org} />;
 }

--- a/src/app/routes/domains.tsx
+++ b/src/app/routes/domains.tsx
@@ -274,7 +274,7 @@ function useDomainActions({
   return { copy, addDomain, recheck, saveRedirect, toggleDefault, confirmDelete };
 }
 
-function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | "pro" }) {
+function useDomainsCardModel(orgId: string, plan: "free" | "hobby" | "pro") {
   const domains = useDomains(orgId);
   const { add, refresh, setRootRedirect, remove, setDefault } = useDomainMutations(orgId);
   const { org } = useCurrentOrg();
@@ -307,7 +307,38 @@ function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | 
   const hasDomains = !!domains.data?.length;
   // A locked org accepts no writes from anyone, its owner included (#160).
   const canWrite = !org?.locked;
-  if (limits.domains === 0 && !hasDomains) return <UpgradeDomainsCard />;
+  const submit = handleSubmit(addDomain, (errors) =>
+    toast(errors.hostname?.message ?? "Enter a valid hostname", "error"),
+  );
+
+  return {
+    domains,
+    org,
+    appHost,
+    limits,
+    deleting,
+    setDeleting,
+    redirectDraft,
+    setRedirectDraft,
+    register,
+    submit,
+    actions: { copy, recheck, saveRedirect, toggleDefault, confirmDelete },
+    pending: {
+      adding: add.isPending,
+      refreshing: refresh.isPending,
+      savingRedirect: setRootRedirect.isPending,
+      savingDefault: setDefault.isPending,
+      removing: remove.isPending,
+    },
+    hasDomains,
+    canWrite,
+  };
+}
+
+type DomainsCardModel = ReturnType<typeof useDomainsCardModel>;
+
+function DomainsCardContent({ model }: { model: DomainsCardModel }) {
+  const { domains, org, appHost, limits, redirectDraft, actions, pending } = model;
 
   return (
     <>
@@ -325,29 +356,29 @@ function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | 
                   org={org}
                   appHost={appHost}
                   pending={{
-                    refreshing: refresh.isPending,
-                    savingRedirect: setRootRedirect.isPending,
-                    savingDefault: setDefault.isPending,
+                    refreshing: pending.refreshing,
+                    savingRedirect: pending.savingRedirect,
+                    savingDefault: pending.savingDefault,
                   }}
                   redirectDraft={redirectDraft}
-                  onToggleDefault={toggleDefault}
-                  onRecheck={recheck}
-                  onDelete={setDeleting}
-                  onRedirectDraft={(id, v) => setRedirectDraft({ ...redirectDraft, [id]: v })}
-                  onSaveRedirect={saveRedirect}
-                  onCopy={copy}
-                  canWrite={canWrite}
+                  onToggleDefault={actions.toggleDefault}
+                  onRecheck={actions.recheck}
+                  onDelete={model.setDeleting}
+                  onRedirectDraft={(id, value) =>
+                    model.setRedirectDraft({ ...redirectDraft, [id]: value })
+                  }
+                  onSaveRedirect={actions.saveRedirect}
+                  onCopy={actions.copy}
+                  canWrite={model.canWrite}
                 />
 
                 <DomainsFooter
-                  blockedBy={domainsBlockedBy(limits.domains, !canWrite)}
-                  hasDomains={hasDomains}
+                  blockedBy={domainsBlockedBy(limits.domains, !model.canWrite)}
+                  hasDomains={model.hasDomains}
                   graceEndsAt={org?.graceEndsAt ?? null}
-                  register={register}
-                  onSubmit={handleSubmit(addDomain, (errors) =>
-                    toast(errors.hostname?.message ?? "Enter a valid hostname", "error"),
-                  )}
-                  pending={add.isPending}
+                  register={model.register}
+                  onSubmit={model.submit}
+                  pending={pending.adding}
                 />
               </div>
             )}
@@ -358,13 +389,19 @@ function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | 
       </div>
 
       <DeleteDomainDialog
-        deleting={deleting}
-        onClose={() => setDeleting(null)}
-        onConfirm={confirmDelete}
-        pending={remove.isPending}
+        deleting={model.deleting}
+        onClose={() => model.setDeleting(null)}
+        onConfirm={actions.confirmDelete}
+        pending={pending.removing}
       />
     </>
   );
+}
+
+function DomainsCard({ orgId, plan }: { orgId: string; plan: "free" | "hobby" | "pro" }) {
+  const model = useDomainsCardModel(orgId, plan);
+  if (model.limits.domains === 0 && !model.hasDomains) return <UpgradeDomainsCard />;
+  return <DomainsCardContent model={model} />;
 }
 
 /** Slide-in/out variants for the status badge swap: skip the motion (and

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -12,6 +12,7 @@ import {
   PLAN_LIMITS,
   type InviteDTO,
   type MemberDTO,
+  type CurrentUser,
   type OrgRole,
   type Sort,
   type UserOrg,
@@ -354,118 +355,207 @@ function canManageOrg(role: OrgRole): boolean {
   return role === "owner" || role === "admin";
 }
 
-export function MembersPage() {
-  const { org } = useCurrentOrg();
-  const orgId = org?.id ?? "";
-  const currentUser = useCurrentUser();
-  const myRole = resolveMyRole(currentUser.data?.user.isAdmin, org?.role);
-  // A locked org accepts no writes from anyone, its owner included (#160).
-  const canManage = canManageOrg(myRole) && !org?.locked;
+type MemberManagement = ReturnType<typeof useMemberManagement>;
+type SeatSummary = { limit: number; taken: number; left: number };
 
-  const {
-    members,
-    invites,
-    inviteOpen,
-    setInviteOpen,
-    inviteRole,
-    setInviteRole,
-    removing,
-    setRemoving,
-    sort,
-    setSort,
-    sorted,
-    setRole,
-    removeMember,
-    createInvite,
-    sendEmailInvite,
-    revokeInvite,
-    inviteUrl,
-    copyInvite,
-  } = useMemberManagement(orgId, canManage);
+function rowCount(rows: readonly object[] | undefined): number {
+  return rows ? rows.length : 0;
+}
 
-  const memberLimit = memberLimitFor(org);
+function seatSummary(org: UserOrg, management: MemberManagement): SeatSummary {
+  const limit = memberLimitFor(org);
   // An org at or over its cap cannot take another member: the server refuses
   // the invite with a 402, so offering the form is offering an error (#161).
   // Counted from the same figure the server uses, members plus open invites.
-  const seatsTaken = (members.data?.length ?? 0) + (invites.data?.length ?? 0);
-  const seatsLeft = Math.max(0, memberLimit - seatsTaken);
+  const taken = rowCount(management.members.data) + rowCount(management.invites.data);
+  return { limit, taken, left: Math.max(0, limit - taken) };
+}
+
+function MembersHeader({
+  org,
+  canManage,
+  seats,
+  onInvite,
+}: {
+  org: UserOrg;
+  canManage: boolean;
+  seats: SeatSummary;
+  onInvite: () => void;
+}) {
+  const action = canManage ? (
+    <div className="flex items-center gap-3">
+      <span className="tnum text-xs text-muted">
+        {seats.taken} / {seats.limit} members
+        {seats.taken > seats.limit && " (over the limit)"}
+      </span>
+      <Button
+        variant="primary"
+        onClick={onInvite}
+        disabled={seats.left === 0}
+        title={seats.left === 0 ? fullSeatsHint(org, seats.limit) : undefined}
+      >
+        <UserPlus size={15} /> Invite link
+      </Button>
+    </div>
+  ) : undefined;
+  return (
+    <PageHeader title="Members" sub="People with access to this organization" action={action} />
+  );
+}
+
+function MemberInviteSection({
+  org,
+  seats,
+  management,
+}: {
+  org: UserOrg;
+  seats: SeatSummary;
+  management: MemberManagement;
+}) {
+  if (seats.left === 0) {
+    return <SeatsFullNotice org={org} memberLimit={seats.limit} over={seats.taken > seats.limit} />;
+  }
+  return (
+    <InviteByEmailCard
+      org={org}
+      memberLimit={seats.limit}
+      sendEmailInvite={management.sendEmailInvite}
+    />
+  );
+}
+
+function ManagedInviteSection({
+  org,
+  canManage,
+  seats,
+  management,
+}: {
+  org: UserOrg;
+  canManage: boolean;
+  seats: SeatSummary;
+  management: MemberManagement;
+}) {
+  if (!canManage) return null;
+  return <MemberInviteSection org={org} seats={seats} management={management} />;
+}
+
+function PendingInvitesSection({
+  canManage,
+  management,
+}: {
+  canManage: boolean;
+  management: MemberManagement;
+}) {
+  const invites = management.invites.data;
+  if (!canManage || !hasPendingInvites(invites)) return null;
+  return (
+    <PendingInvitesCard
+      invites={invites ?? []}
+      inviteUrl={management.inviteUrl}
+      copyInvite={management.copyInvite}
+      revokeInvite={management.revokeInvite}
+    />
+  );
+}
+
+function MemberOverlays({ management }: { management: MemberManagement }) {
+  return (
+    <>
+      {management.removing && (
+        <RemoveMemberDialog
+          member={management.removing}
+          onClose={() => management.setRemoving(null)}
+          remove={management.removeMember}
+        />
+      )}
+      <InviteMemberDialog
+        open={management.inviteOpen}
+        onOpenChange={management.setInviteOpen}
+        role={management.inviteRole}
+        onRoleChange={management.setInviteRole}
+        onCreate={() => management.createInvite.mutate()}
+        isCreating={management.createInvite.isPending}
+      />
+    </>
+  );
+}
+
+function MembersView({
+  org,
+  userId,
+  canManage,
+  seats,
+  management,
+}: {
+  org: UserOrg;
+  userId: string | undefined;
+  canManage: boolean;
+  seats: SeatSummary;
+  management: MemberManagement;
+}) {
+  return (
+    <div>
+      <MembersHeader
+        org={org}
+        canManage={canManage}
+        seats={seats}
+        onInvite={() => management.setInviteOpen(true)}
+      />
+
+      <ManagedInviteSection org={org} canManage={canManage} seats={seats} management={management} />
+
+      <MemberTable
+        isLoading={management.members.isLoading}
+        sorted={management.sorted}
+        canManage={canManage}
+        sort={management.sort}
+        setSort={management.setSort}
+        meId={userId}
+        onSetRole={(memberId, role) => management.setRole.mutate({ userId: memberId, role })}
+        onRemove={(memberId, name) => management.setRemoving({ userId: memberId, name })}
+      />
+
+      <PendingInvitesSection canManage={canManage} management={management} />
+
+      <MemberOverlays management={management} />
+    </div>
+  );
+}
+
+function memberCanManage(
+  org: UserOrg | null,
+  currentUser: CurrentUser | null | undefined,
+): boolean {
+  if (!org) return false;
+  const myRole = resolveMyRole(currentUser?.user.isAdmin, org.role);
+  return canManageOrg(myRole) && !org.locked;
+}
+
+function memberOrgId(org: UserOrg | null): string {
+  return org ? org.id : "";
+}
+
+function currentMemberId(currentUser: CurrentUser | null | undefined): string | undefined {
+  return currentUser?.user.id;
+}
+
+export function MembersPage() {
+  const { org } = useCurrentOrg();
+  const currentUser = useCurrentUser();
+  // A locked org accepts no writes from anyone, its owner included (#160).
+  const canManage = memberCanManage(org, currentUser.data);
+  const management = useMemberManagement(memberOrgId(org), canManage);
 
   if (currentUser.isLoading) return <TableSkeleton rows={4} />;
   if (!org) return <NoOrgState />;
-
   return (
-    <div>
-      <PageHeader
-        title="Members"
-        sub="People with access to this organization"
-        action={
-          canManage && (
-            <div className="flex items-center gap-3">
-              <span className="tnum text-xs text-muted">
-                {seatsTaken} / {memberLimit} members
-                {seatsTaken > memberLimit && " (over the limit)"}
-              </span>
-              <Button
-                variant="primary"
-                onClick={() => setInviteOpen(true)}
-                disabled={seatsLeft === 0}
-                title={seatsLeft === 0 ? fullSeatsHint(org, memberLimit) : undefined}
-              >
-                <UserPlus size={15} /> Invite link
-              </Button>
-            </div>
-          )
-        }
-      />
-
-      {canManage &&
-        (seatsLeft === 0 ? (
-          <SeatsFullNotice org={org} memberLimit={memberLimit} over={seatsTaken > memberLimit} />
-        ) : (
-          <InviteByEmailCard
-            org={org}
-            memberLimit={memberLimit}
-            sendEmailInvite={sendEmailInvite}
-          />
-        ))}
-
-      <MemberTable
-        isLoading={members.isLoading}
-        sorted={sorted}
-        canManage={canManage}
-        sort={sort}
-        setSort={setSort}
-        meId={currentUser.data?.user.id}
-        onSetRole={(userId, role) => setRole.mutate({ userId, role })}
-        onRemove={(userId, name) => setRemoving({ userId, name })}
-      />
-
-      {canManage && hasPendingInvites(invites.data) && (
-        <PendingInvitesCard
-          invites={invites.data!}
-          inviteUrl={inviteUrl}
-          copyInvite={copyInvite}
-          revokeInvite={revokeInvite}
-        />
-      )}
-
-      {removing && (
-        <RemoveMemberDialog
-          member={removing}
-          onClose={() => setRemoving(null)}
-          remove={removeMember}
-        />
-      )}
-
-      <InviteMemberDialog
-        open={inviteOpen}
-        onOpenChange={setInviteOpen}
-        role={inviteRole}
-        onRoleChange={setInviteRole}
-        onCreate={() => createInvite.mutate()}
-        isCreating={createInvite.isPending}
-      />
-    </div>
+    <MembersView
+      org={org}
+      userId={currentMemberId(currentUser.data)}
+      canManage={canManage}
+      seats={seatSummary(org, management)}
+      management={management}
+    />
   );
 }
 


### PR DESCRIPTION
## What was wrong

The route entry points for Analytics and Members still mixed query state, derived state, and every render branch. The original issue also named `AdminUsersPage` and `DomainRow`, but both had already fallen off the current fallow report. The current domains hotspot was `DomainsCard`, so this layer follows the live report instead of editing stale targets.

## What changed

- Move the populated Analytics view into `AnalyticsReport`, split authenticated org gating from the org query state, and leave each component with one narrow decision.
- Group member management state and split the header, invite states, pending invites, table, and dialogs into narrow sections.
- Build one domains-card model and render it through a separate content component.
- Leave `AdminUsersPage` and `DomainRow` unchanged because neither is currently flagged.
- Preserve route behavior, copy, and layout.

## Evidence

- `bun run verify`: 308 unit tests and 398 Worker tests passed.
- `bun run fallow`: passed with no new route-health finding.
- The named `Analytics`, `MembersPage`, and `DomainRow` functions no longer appear in the fallow report; `DomainsCard` is absent too.
- Focused browser coverage: analytics export, invites, downgrade states, and default-domain flows, 7 passed.
- React Doctor: 100/100.

Closes #44
