### PR TITLE
Raise the CI email rate limit

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -425,9 +425,10 @@
           "namespace_id": "24002",
           "simple": {
             // Higher than production's (10): the e2e suite's real sign-ups
-            // and password-reset sends across files share this one budget,
-            // and production's abuse-control number is too tight for that.
-            "limit": 30,
+            // and password-reset sends across files share this one budget.
+            // Three concurrent browser workers can exceed 30 before a minute
+            // elapses, turning an unrelated scenario into a rate-limit test.
+            "limit": 100,
             "period": 60,
           },
         },


### PR DESCRIPTION
Raises only the Playwright environment's shared email-send quota from 30 to 100 requests per minute. Production remains at 10. This prevents concurrent E2E account-creation flows from exhausting a shared CI budget before they reach the scenario under test.

Validated: the two invite browser scenarios pass locally.