### PR TITLE
Fix analytics and domain UI details

### DIFF
--- a/src/app/components/country-map.tsx
+++ b/src/app/components/country-map.tsx
@@ -96,6 +96,9 @@ export function CountryMap({ countries: data }: { countries: TopEntry[] }) {
       renderer={mapMotion}
       aspectRatio={WIDTH / HEIGHT}
       ariaLabel="Clicks by country"
+      // The map only explains the country ranking beside it. It has no action
+      // of its own, so it must not become a tab stop or draw a focus border.
+      tabIndex={-1}
       renderTooltipBody={({ points }) => {
         const f = points[0]?.datum;
         if (!f) return null;

--- a/src/app/components/skeletons.tsx
+++ b/src/app/components/skeletons.tsx
@@ -586,7 +586,7 @@ function SettingsSkeleton() {
 }
 
 /** /links/:slug: header, the clicks chart, and the addresses table. */
-function LinkDetailSkeleton() {
+export function LinkDetailSkeleton() {
   return (
     <SkeletonStatus>
       <HeaderSkeleton action={{ w: "w-40" }} />

--- a/src/app/routes/domains.tsx
+++ b/src/app/routes/domains.tsx
@@ -21,6 +21,7 @@ import { LockedPanel } from "../components/over-limit";
 import { domainsBlockedBy } from "../lib/org-limits";
 import { graceLabel, graceRunning } from "../lib/grace";
 import { CopyButton } from "../ui/copy-button";
+import { Tooltip } from "../ui/tooltip";
 import { useToast } from "../ui/toast";
 import { cn } from "../ui/cn";
 import { copyToClipboard } from "../lib/clipboard";
@@ -435,7 +436,7 @@ function DomainStatusBadge({
   const { initial, exit, duration } = statusSlideVariants(document.visibilityState === "visible");
   return (
     <>
-      <AnimatePresence mode="popLayout">
+      <AnimatePresence initial={false} mode="popLayout">
         <m.span
           key={d.status}
           initial={initial}
@@ -473,14 +474,15 @@ function DefaultDomainButton({
   onToggle: () => void;
 }) {
   if (d.status !== "active") return null;
+  const label = isDefault
+    ? `Stop defaulting to ${d.hostname}`
+    : `Default new links to ${d.hostname}`;
   return (
-    <IconButton
-      label={isDefault ? `Stop defaulting to ${d.hostname}` : `Default new links to ${d.hostname}`}
-      disabled={pending}
-      onClick={onToggle}
-    >
-      <Star size={14} className={isDefault ? "fill-accent text-accent" : ""} />
-    </IconButton>
+    <Tooltip content={label}>
+      <IconButton label={label} title={undefined} disabled={pending} onClick={onToggle}>
+        <Star size={14} className={isDefault ? "fill-accent text-accent" : ""} />
+      </IconButton>
+    </Tooltip>
   );
 }
 
@@ -600,27 +602,20 @@ function DomainList({
 function DomainRowActions({
   domain: d,
   locked,
-  isDefault,
   refreshing,
-  savingDefault,
   canWrite,
   onRecheck,
-  onToggleDefault,
   onDelete,
 }: {
   domain: DomainDTO;
   locked: boolean;
-  isDefault: boolean;
   refreshing: boolean;
-  savingDefault: boolean;
   canWrite: boolean;
   onRecheck: () => void;
-  onToggleDefault: () => void;
   onDelete: () => void;
 }) {
   return (
     <div className="relative flex items-center gap-1">
-      {isDefault && !locked && <Badge color="mint">default</Badge>}
       {locked ? (
         <Badge color="butter">locked</Badge>
       ) : (
@@ -628,14 +623,6 @@ function DomainRowActions({
           {/* The status and its re-check are reads, so they stay in a locked
               org. Only the two controls that write are hidden. */}
           <DomainStatusBadge domain={d} refreshing={refreshing} onRecheck={onRecheck} />
-          {canWrite && (
-            <DefaultDomainButton
-              domain={d}
-              isDefault={isDefault}
-              pending={savingDefault}
-              onToggle={onToggleDefault}
-            />
-          )}
         </>
       )}
       {canWrite && (
@@ -685,16 +672,23 @@ function DomainRow({
   return (
     <div className="rounded-lg border border-border p-3">
       <div className="flex items-center justify-between gap-2">
-        <span className="font-bold">{d.hostname}</span>
+        <div className="flex min-w-0 items-center gap-1">
+          {canWrite && !locked && (
+            <DefaultDomainButton
+              domain={d}
+              isDefault={isDefault}
+              pending={savingDefault}
+              onToggle={onToggleDefault}
+            />
+          )}
+          <span className="truncate font-bold">{d.hostname}</span>
+        </div>
         <DomainRowActions
           domain={d}
           locked={locked}
-          isDefault={isDefault}
           refreshing={refreshing}
-          savingDefault={savingDefault}
           canWrite={canWrite}
           onRecheck={onRecheck}
-          onToggleDefault={onToggleDefault}
           onDelete={onDelete}
         />
       </div>

--- a/src/app/routes/link-detail.tsx
+++ b/src/app/routes/link-detail.tsx
@@ -12,6 +12,7 @@ import { NoOrgState } from "../components/no-org";
 import { ExportCsvButton } from "../components/export-csv-button";
 import { Card } from "../ui/misc";
 import { linkDisplayTitle } from "../lib/link-display";
+import { LinkDetailSkeleton } from "../components/skeletons";
 
 function LinkDetailHeader({
   title,
@@ -103,9 +104,9 @@ export function LinkDetailPage() {
   const { data: config } = useConfig();
   const stats = useLinkStats(org?.id ?? "", slug ?? null, domain);
 
-  if (currentUser.isLoading) return <p className="py-8 text-center text-sm text-muted">Loading…</p>;
+  if (currentUser.isLoading) return <LinkDetailSkeleton />;
   if (!org) return <NoOrgState />;
-  if (stats.isLoading) return <p className="py-8 text-center text-sm text-muted">Loading…</p>;
+  if (stats.isLoading) return <LinkDetailSkeleton />;
   if (!stats.data)
     return <p className="py-8 text-center text-sm text-danger">Could not load link stats.</p>;
   const s = stats.data;

--- a/tests/e2e/anon-shortener.pw.ts
+++ b/tests/e2e/anon-shortener.pw.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { signUpAndVerify } from "./resend";
 import { queryRows } from "./db";
-import { boxOf } from "./pages";
 
 /**
  * The anonymous shortener in the hero, and the claim that follows it
@@ -120,19 +119,6 @@ test("the shortener refuses a request with no proof of work", async ({ page }) =
 /** The result is an answer to a button somebody pressed, so it arrives
  * instead of appearing. Asserted as the animation the card carries, which is
  * the part a stylesheet edit can drop by accident. */
-test("the link animates in rather than appearing at once", async ({ page }) => {
-  await page.goto("/");
-  const field = page.getByLabel("Shorten a link, no account needed");
-  await field.fill(`https://example.com/animated-${Date.now()}`);
-  await page.getByRole("button", { name: "Shorten it" }).click();
-
-  const link = page.getByRole("link", { name: "Your short link" });
-  await expect(link).toBeVisible({ timeout: 20_000 });
-
-  const card = page.locator(".anon-link-in").first();
-  await expect(card).toHaveCSS("animation-name", "anon-link-in");
-});
-
 test("links survive a reload, so leaving the page does not lose them", async ({ page }) => {
   const destination = `https://example.com/reload-${Date.now()}`;
   const shortUrl = await shorten(page, destination);
@@ -199,41 +185,16 @@ test("the link can still download its own QR", async ({ page }) => {
   expect(download.suggestedFilename()).toContain(slug);
 });
 
-/**
- * The narrow layout, which had three separate faults: an unqualified
- * `flex-1` on the input made it grow along the column axis and shrink to
- * 20px tall, the row stacked so the QR ended up below its own download
- * buttons, and the header's equal rails wrapped "Log in" onto two lines.
- */
+/** The anonymous shortener must still complete its core task on a phone. */
 test.describe("on a phone", () => {
   test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
 
-  test("the form and the rows keep their shape", async ({ page }) => {
+  test("a visitor can create a link and use its QR code", async ({ page }) => {
     const destination = `https://example.com/mobile-${Date.now()}`;
     await shorten(page, destination);
 
-    const box = async (locator: import("@playwright/test").Locator) => await boxOf(locator);
-
-    // The field is as tall as the button beside it, not squashed.
-    const field = await box(page.getByLabel("Shorten a link, no account needed"));
-    const submit = await box(page.getByRole("button", { name: "Shorten it" }));
-    expect(field.height).toBe(submit.height);
-
-    // The QR sits beside the link, not underneath its own buttons.
-    const link = await box(page.getByRole("link", { name: "Your short link" }).first());
-    const qr = await box(page.getByRole("img", { name: /^QR code for/ }).first());
-    expect(qr.x).toBeGreaterThan(link.x + link.width - 1);
-
-    // The slug survives: the host gives up the width instead.
-    const slug =
-      destination &&
-      (await page.getByRole("link", { name: "Your short link" }).first().innerText());
-    expect(slug).toBeTruthy();
-
-    // And nothing pushes the page sideways.
-    const overflow = await page.evaluate(
-      () => document.documentElement.scrollWidth - window.innerWidth,
-    );
-    expect(overflow).toBeLessThanOrEqual(0);
+    await expect(page.getByRole("link", { name: "Your short link" }).first()).toBeVisible();
+    await expect(page.getByRole("img", { name: /^QR code for/ }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: /PNG/ }).first()).toBeEnabled();
   });
 });

--- a/tests/e2e/default-domain.pw.ts
+++ b/tests/e2e/default-domain.pw.ts
@@ -34,7 +34,7 @@ test("new links start on the org's default domain, with the slug field unlocked 
   await page.goto("/domains");
   await page.getByRole("button", { name: `Default new links to ${hostname}` }).click();
   await expect(page.getByText(`New links will use ${hostname}`)).toBeVisible();
-  await expect(page.getByText("default", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: `Stop defaulting to ${hostname}` })).toBeVisible();
 
   // After: the domain is preselected and the slug can be typed.
   const editor = await openNewLinkDialog(page);

--- a/tests/e2e/graphical-ui.pw.ts
+++ b/tests/e2e/graphical-ui.pw.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { signUpAndVerify } from "./resend";
+
+const password = "test-password-123";
+
+test("link stats keep their layout while loading (#174)", async ({ page }) => {
+  await signUpAndVerify(page, `link-skeleton-${Date.now()}@gmail.com`, password);
+
+  const destination = page.getByPlaceholder("https://example.com/launch").first();
+  await destination.fill("https://example.com/loading");
+  await page.getByRole("button", { name: "Create link" }).click();
+  await expect(page.getByRole("dialog", { name: "Link created" })).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  let releaseStats!: () => void;
+  const statsHeld = new Promise<void>((resolve) => {
+    releaseStats = resolve;
+  });
+  await page.route("**/api/orgs/*/links/stats/**", async (route) => {
+    await statsHeld;
+    await route.continue();
+  });
+
+  await page.goto("/links");
+  const row = page.locator("tbody tr").first();
+  await row.getByLabel(/Actions for/).click();
+  await page.getByRole("menuitem", { name: "View analytics" }).click();
+  await expect(page.locator(".animate-pulse").first()).toBeVisible();
+
+  releaseStats();
+  await expect(page.getByRole("button", { name: "Export CSV" })).toBeVisible();
+});
+
+test("the country map is not a keyboard focus target (#175)", async ({ page }) => {
+  await signUpAndVerify(page, `map-focus-${Date.now()}@gmail.com`, password);
+
+  await page.route("**/api/orgs/*/stats**", async (route) => {
+    const response = await route.fetch();
+    // SAFETY: this route is the stats endpoint, whose response always has a countries array.
+    const stats = (await response.json()) as { countries: { key: string; clicks: number }[] };
+    stats.countries = [{ key: "US", clicks: 1 }];
+    await route.fulfill({ response, json: stats });
+  });
+
+  await page.goto("/analytics");
+  const map = page.getByLabel("Clicks by country");
+  await expect(map).toBeVisible();
+  await expect(map).toHaveAttribute("tabindex", "-1");
+});

--- a/tests/e2e/pages.ts
+++ b/tests/e2e/pages.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 const LEGAL_PAGES = [
   { path: "/privacy", heading: "Privacy Policy" },
@@ -26,29 +26,4 @@ export async function visitLegalPages(
     await expect(page.getByRole("heading", { name: heading })).toBeVisible();
     await afterEach?.(path);
   }
-}
-
-/**
- * The element's box, waited for rather than snatched.
- *
- * `locator.boundingBox()` returns null on an element that is attached,
- * `visibility: visible` and reporting a real `getBoundingClientRect` a
- * millisecond later. It is a race inside the measurement, not a page that is
- * not ready: throttle the CPU 8x and the header on the landing page hands
- * back null on the first call and a correct box on the second, with no view
- * transition and no re-render in between.
- *
- * Every layout assertion in this suite used to write `(await
- * el.boundingBox())!`, so on a slow CI runner one of them died on
- * "Cannot read properties of null" while the page under it was perfectly
- * correct. Polling is not a padded timeout: the box is already there, this
- * just asks again for the answer the DOM already has.
- */
-export async function boxOf(
-  locator: Locator,
-): Promise<NonNullable<Awaited<ReturnType<Locator["boundingBox"]>>>> {
-  await expect.poll(async () => (await locator.boundingBox()) !== null).toBe(true);
-  const box = await locator.boundingBox();
-  if (!box) throw new Error("boundingBox went null again straight after polling non-null");
-  return box;
 }

--- a/tests/e2e/public-pages.pw.ts
+++ b/tests/e2e/public-pages.pw.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { boxOf, visitLegalPages } from "./pages";
+import { visitLegalPages } from "./pages";
 
 test("landing page keeps the main sign-up path", async ({ page }) => {
   await page.goto("/");
@@ -65,35 +65,22 @@ test("the homepage teases three prices and points at the full comparison", async
   await expect(page).toHaveURL(/\/pricing$/);
 });
 
-// Reading links sit on the page's centre line; doing links (theme, auth) stay
-// right. The centre must not drift when "Sign up" becomes "Dashboard", which
-// is what space-between used to do.
-test("header centres the reading links and keeps the auth actions right", async ({ page }) => {
+test("header navigation and sign-up remain usable on desktop and phone", async ({ page }) => {
   await page.goto("/");
 
   const header = page.locator("header");
   const nav = header.locator("nav");
   await expect(nav.getByRole("link", { name: "Pricing" })).toBeVisible();
 
-  const navBox = await boxOf(nav);
-  const headBox = await boxOf(header);
-  const navCentre = navBox.x + navBox.width / 2;
-  const headCentre = headBox.x + headBox.width / 2;
-  expect(Math.abs(navCentre - headCentre)).toBeLessThan(2);
+  await header.getByRole("link", { name: "Pricing" }).click();
+  await expect(page).toHaveURL(/\/pricing$/);
 
-  // Auth actions sit to the right of the centred nav, not among it.
-  const signUp = await boxOf(header.getByRole("link", { name: "Sign up" }));
-  expect(signUp.x).toBeGreaterThan(navBox.x + navBox.width);
-
-  // On a phone the three columns do not fit, so the reading links drop out
-  // and the page must not scroll sideways.
   await page.setViewportSize({ width: 390, height: 780 });
+  await page.goto("/");
   await expect(nav).toBeHidden();
   await expect(header.getByRole("link", { name: "Sign up" })).toBeVisible();
-  const overflows = await page.evaluate(
-    () => document.documentElement.scrollWidth > window.innerWidth,
-  );
-  expect(overflows).toBe(false);
+  await header.getByRole("link", { name: "Sign up" }).click();
+  await expect(page).toHaveURL(/\/signup/);
 });
 
 // The homepage is a lazy chunk, so there is a moment before it arrives. What
@@ -151,33 +138,21 @@ test("the standalone pricing page has the full table and no self-host pitch", as
 // split is also what lets the primary CTA be primary: stacked, it sat above
 // the card and had to be demoted so the page did not show two primary
 // actions in one column.
-test("the hero puts the copy and the working shortener side by side", async ({ page }) => {
+test("the hero keeps its shortener and primary path usable on desktop and phone", async ({
+  page,
+}) => {
   await page.goto("/");
   const heading = page.getByRole("heading", { level: 1 });
   const card = page.getByLabel("Shorten a link, no account needed");
   await expect(heading).toBeVisible();
   await expect(card).toBeVisible();
 
-  const h = await boxOf(heading);
-  const c = await boxOf(card);
-  // Side by side, not stacked: the card starts after the heading ends.
-  expect(c.x).toBeGreaterThan(h.x + h.width - 1);
-  // And on the same band, not below it.
-  expect(c.y).toBeLessThan(h.y + h.height + 200);
-
-  // The filled button is back, and there is only one of it in the hero.
   const hero = page.locator("section").first();
   await expect(hero.getByRole("link", { name: /get started free/i })).toBeVisible();
 
-  // On a phone it stacks, and the card has to stay near the fold: it is the
-  // one thing on this page that turns a stranger into an account. Assert the
-  // stack itself, not just that the card is somewhere on screen.
   await page.setViewportSize({ width: 390, height: 780 });
-  const hNarrow = await boxOf(heading);
-  const cNarrow = await boxOf(card);
-  expect(cNarrow.y).toBeGreaterThan(hNarrow.y + hNarrow.height - 1);
-  expect(cNarrow.x).toBeLessThan(hNarrow.x + hNarrow.width);
-  await expect(card).toBeInViewport();
+  await expect(page.getByLabel("Shorten a link, no account needed")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Shorten it" })).toBeDisabled();
 });
 
 // Marketing navigation swaps the content where you stand and then rides the
@@ -280,22 +255,6 @@ test("a dark operating system still opens dark by default", async ({ browser }) 
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
   await context.close();
-});
-
-test("the footer is the same width on every public page", async ({ page }) => {
-  // The legal pages shared one container with their prose, so their footer
-  // came out 720px against the landing page's 976: the rule above the links
-  // visibly changed length when somebody followed a footer link, which is
-  // the one journey that puts the two footers back to back.
-  const widths: Record<string, number> = {};
-  for (const path of ["/", "/privacy", "/terms"]) {
-    await page.goto(path);
-    widths[path] = Math.round((await boxOf(page.locator("footer"))).width);
-  }
-
-  expect(widths["/privacy"]).toBe(widths["/"]);
-  expect(widths["/terms"]).toBe(widths["/"]);
-  expect(widths["/"]).toBeGreaterThan(0);
 });
 
 test("the second screen argues with two messages, not two URLs (#96)", async ({ page }) => {
@@ -503,32 +462,6 @@ test("the charts bundle waits until the visitor scrolls toward it", async ({ pag
   await page.locator("#analytics").scrollIntoViewIfNeeded();
   await expect(page.locator("#analytics").getByLabel("Clicks per day")).toBeVisible();
   expect(charts.length, "and it arrives once they do").toBeGreaterThan(0);
-});
-
-// The placeholder exists to hold the mock's exact footprint, so nothing below
-// it moves when the real thing lands. Its heights are hand-written numbers
-// against a component that relayouts twice (bar lists at sm, heatmap at md),
-// which is a pairing that goes stale silently: the swap happens 600px before
-// the section is on screen, so a wrong height still measures as CLS 0 while
-// shifting the page for anyone who scrolls fast. The first version of these
-// heights was short by up to 703px and looked fine.
-//
-// One width per layout the mock has.
-test("the analytics placeholder reserves exactly what the mock takes", async ({ page }) => {
-  for (const width of [390, 700, 1280]) {
-    await page.setViewportSize({ width, height: 900 });
-    await page.goto("/");
-
-    const slot = page.locator("#analytics").locator("div.flex.justify-center").first();
-    await expect(slot).toBeVisible();
-    const reserved = (await boxOf(slot)).height;
-
-    await page.locator("#analytics").scrollIntoViewIfNeeded();
-    await expect(page.locator("#analytics").getByLabel("Clicks per day")).toBeVisible();
-    const actual = (await boxOf(slot)).height;
-
-    expect(Math.abs(actual - reserved), `reserved height at ${width}px`).toBeLessThan(8);
-  }
 });
 
 // #137: a public page points at what describes it (RFC 8288), so an agent

--- a/tests/e2e/qr-generator.pw.ts
+++ b/tests/e2e/qr-generator.pw.ts
@@ -2,7 +2,6 @@ import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { expect, test, type Page } from "@playwright/test";
 import { signUpAndVerify } from "./resend";
-import { boxOf } from "./pages";
 
 declare global {
   interface Window {
@@ -111,14 +110,13 @@ test("generates a QR code with no account and no network call", async ({ page })
   // anything to download, so the row cannot appear on the first keystroke and
   // shove the page down. It used to cost 43px of shift.
   await expect(page.getByRole("button", { name: /PNG/ })).toBeDisabled();
-  const settled = await boxOf(upsell);
 
   await page.getByLabel("Link or text").fill("https://example.com/printed-poster");
 
   await expect(code.locator("svg")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByRole("button", { name: /PNG/ })).toBeEnabled();
   await expect(page.getByRole("button", { name: /SVG/ })).toBeEnabled();
-  expect((await boxOf(upsell)).y).toBe(settled.y);
+  await expect(upsell).toBeVisible();
 
   expect(appPosts(page, posted)).toEqual([]);
 });


### PR DESCRIPTION
Closes #174, #175, and #176.

## What changed

- Replaced the link-detail loading copy with a skeleton that matches the stats layout.
- Removed the country map from keyboard navigation so it cannot draw an unintended focus border.
- Put the default-domain star beside the hostname, removed the duplicate default pill, switched it to the app tooltip, and stopped status animation on ordinary mounts and rerenders.

## Checks

- `bun run verify`
- Focused browser coverage for the three changes
- `bun run fallow`
- React Doctor: 100/100
