### PR TITLE
Fix route loading skeletons

### DIFF
--- a/src/app/components/skeletons.tsx
+++ b/src/app/components/skeletons.tsx
@@ -367,7 +367,7 @@ function SidebarSkeleton() {
  * content. Layout classes mirror AppShell so the swap doesn't shift. */
 export function AppShellSkeleton() {
   return (
-    <div className="flex min-h-dvh">
+    <div className="flex min-h-dvh" data-testid="app-shell-skeleton">
       {/* desktop sidebar */}
       <aside className="fixed inset-y-0 left-0 z-10 hidden w-60 border-r border-border bg-surface/40 md:block">
         <SidebarSkeleton />

--- a/src/app/components/skeletons.tsx
+++ b/src/app/components/skeletons.tsx
@@ -206,7 +206,7 @@ export function AnalyticsSkeleton() {
 /** /admin: header, 6 stat cards, two charts, two ranked lists. */
 export function AdminUsageSkeleton() {
   return (
-    <SkeletonStatus>
+    <SkeletonStatus testId="admin-usage-skeleton">
       <HeaderSkeleton />
       <StatCardsSkeleton count={6} gridClass="grid-cols-2 sm:grid-cols-3 lg:grid-cols-6" />
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
@@ -222,12 +222,17 @@ export function AdminUsageSkeleton() {
 /** /admin/orgs and /admin/users: header, search box, big table. */
 export function AdminTableSkeleton() {
   return (
-    <div>
+    <div data-testid="admin-table-skeleton">
       <HeaderSkeleton />
       <Skeleton className="mb-4 h-9 w-full max-w-xs" />
       <TableSkeleton rows={6} />
     </div>
   );
+}
+
+/** /admin/audit after its real header and search box have already rendered. */
+export function AdminAuditRowsSkeleton() {
+  return <TableSkeleton rows={6} testId="admin-audit-rows-skeleton" />;
 }
 
 /** Generic content placeholder for route guards (e.g. RequireAdmin). */
@@ -392,9 +397,9 @@ export function AppShellSkeleton() {
  * pager under it (24, `mt-4`). The toolbar was missing, so the table used to
  * arrive 36px lower than the skeleton had promised.
  */
-function LinksSkeleton() {
+export function LinksSkeleton() {
   return (
-    <div>
+    <div data-testid="links-page-skeleton">
       <HeaderSkeleton action={{ w: "w-60" }} />
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <Skeleton className="h-9 w-full max-w-xs" />
@@ -412,9 +417,9 @@ function LinksSkeleton() {
  * /members: header with the invite button (52), the invite-by-email card
  * (119), then the table. The card is the part that was missing.
  */
-function MembersSkeleton() {
+export function MembersSkeleton() {
   return (
-    <div>
+    <div data-testid="members-page-skeleton">
       <HeaderSkeleton action={{ w: "w-36" }} />
       <Card className="mb-4">
         <Skeleton className="h-2.5 w-28" />
@@ -439,7 +444,7 @@ function MembersSkeleton() {
  */
 export function DomainsPageSkeleton() {
   return (
-    <div>
+    <div data-testid="domains-page-skeleton">
       <HeaderSkeleton />
       <div className="flex flex-col gap-6 lg:flex-row">
         <Card className="min-w-0 flex-1">
@@ -476,9 +481,9 @@ export function DomainsPageSkeleton() {
 }
 
 /** /billing: header, the plan card, and the usage card beneath it. */
-function BillingSkeleton() {
+export function BillingSkeleton() {
   return (
-    <SkeletonStatus>
+    <SkeletonStatus testId="billing-page-skeleton">
       <HeaderSkeleton />
       {/* both cards are max-w-2xl on the real page: full-width placeholders
           were a third too wide, and the swap moved every edge */}
@@ -511,9 +516,9 @@ function BillingSkeleton() {
  * /settings: header over the stack of cards (organization name, QR defaults,
  * then the account and danger-zone blocks).
  */
-function SettingsSkeleton() {
+export function SettingsSkeleton() {
   return (
-    <SkeletonStatus>
+    <SkeletonStatus testId="settings-page-skeleton">
       <HeaderSkeleton />
       {/* the three cards, at the heights they measure: the name form (216),
           the QR defaults with its preview (656), and the danger zone (270) */}

--- a/src/app/routes/admin/audit.tsx
+++ b/src/app/routes/admin/audit.tsx
@@ -10,7 +10,7 @@ import { useAdminAudit } from "../../lib/hooks";
 import { PageHeader, Table, Td, Th } from "../../ui/misc";
 import { SortTh } from "../../ui/sort-th";
 import { sortRows } from "../../lib/sort";
-import { AdminTableSkeleton } from "../../components/skeletons";
+import { AdminAuditRowsSkeleton } from "../../components/skeletons";
 import { shortDate } from "../../lib/dates";
 import { SearchInput } from "./search-input";
 import { paginate } from "./util";
@@ -67,7 +67,7 @@ export function AdminAuditPage() {
       />
 
       {isPending ? (
-        <AdminTableSkeleton />
+        <AdminAuditRowsSkeleton />
       ) : rows.length === 0 ? (
         <p className="py-6 text-center text-sm text-muted">Nothing recorded yet.</p>
       ) : (

--- a/src/app/routes/admin/links.tsx
+++ b/src/app/routes/admin/links.tsx
@@ -320,7 +320,7 @@ function LinksTable({
 }) {
   // Rows only: this sits below the real header and the real search box,
   // and the page-level skeleton would draw a second one of each.
-  if (isPending) return <TableSkeleton rows={6} />;
+  if (isPending) return <TableSkeleton rows={6} testId="admin-links-rows-skeleton" />;
   if (rows.length === 0)
     return <p className="py-6 text-center text-sm text-muted">No links match that search.</p>;
 
@@ -398,7 +398,7 @@ function AnonymousLinksTable({
 }) {
   // Rows only: this sits below the real header and the real search box,
   // and the page-level skeleton would draw a second one of each.
-  if (isPending) return <TableSkeleton rows={6} />;
+  if (isPending) return <TableSkeleton rows={6} testId="admin-links-rows-skeleton" />;
   if (rows.length === 0)
     return <p className="py-6 text-center text-sm text-muted">Nothing here.</p>;
   return (

--- a/src/app/routes/billing.tsx
+++ b/src/app/routes/billing.tsx
@@ -19,6 +19,7 @@ import { Button } from "../ui/button";
 import { Badge, Card, PageHeader, Table, Th, Td } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
 import { Skeleton } from "../ui/skeleton";
+import { BillingSkeleton } from "../components/skeletons";
 import { useShake } from "../lib/use-shake";
 import { showsCancelNotice, showsConfirmingNotice } from "../lib/plan-status-notes";
 import { useToast } from "../ui/toast";
@@ -808,6 +809,7 @@ function useBillingAccount() {
   // answered yet.
   const { hasBillingAccount, comped, ...subscription } = currentUser.data?.user ?? NO_ACCOUNT_YET;
   return {
+    isLoading: currentUser.isLoading,
     hasBillingAccount,
     comped,
     cancelAtPeriodEnd: subscription.polarSubscriptionCancelAtPeriodEnd,
@@ -861,6 +863,7 @@ function useBillingPageModel() {
   const dismissCelebration = () => flow.setShowCelebration(false);
 
   return {
+    loading: account.isLoading,
     planActions: {
       snapshot: {
         plan: flow.plan,
@@ -891,6 +894,10 @@ function useBillingPageModel() {
 
 export function BillingPage() {
   const model = useBillingPageModel();
+
+  // The shell cache is deliberately not an authority for plan or billing
+  // state. Rendering its free defaults here made the paid page flash first.
+  if (model.loading) return <BillingSkeleton />;
 
   return (
     <div>

--- a/src/app/routes/links.tsx
+++ b/src/app/routes/links.tsx
@@ -424,7 +424,7 @@ function LinksListArea({
   onCreate?: () => void;
   children: ReactNode;
 }) {
-  if (isLoading) return <TableSkeleton rows={5} />;
+  if (isLoading) return <TableSkeleton rows={5} testId="links-table-skeleton" />;
   if (!hasLinks) {
     return (
       <EmptyState

--- a/src/app/routes/links.tsx
+++ b/src/app/routes/links.tsx
@@ -11,6 +11,7 @@ import { Input } from "../ui/field";
 import { MenuSelect } from "../ui/menu";
 import { EmptyState, PageHeader } from "../ui/misc";
 import { TableSkeleton } from "../ui/skeleton";
+import { LinksSkeleton } from "../components/skeletons";
 import { useToast } from "../ui/toast";
 import { NoOrgState } from "../components/no-org";
 import { LinkEditor } from "../components/link-editor";
@@ -334,7 +335,9 @@ export function LinksPage() {
     );
   };
 
-  if (currentUser.isLoading) return <TableSkeleton rows={5} />;
+  // The cached shell may know the organization before /user confirms the
+  // current role and plan. Do not briefly offer a stale create control.
+  if (currentUser.isLoading) return <LinksSkeleton />;
   if (!org) return <NoOrgState />;
 
   const onSave = buildOnSave({

--- a/src/app/routes/members.tsx
+++ b/src/app/routes/members.tsx
@@ -27,6 +27,7 @@ import { Table, Th, Td, Badge, Card, PageHeader } from "../ui/misc";
 import { HrefLink } from "../lib/router-search";
 import { buttonClass } from "../ui/button-class";
 import { TableSkeleton } from "../ui/skeleton";
+import { MembersSkeleton } from "../components/skeletons";
 import { BusyContent } from "../ui/spinner";
 import { useToast } from "../ui/toast";
 import { NoOrgState } from "../components/no-org";
@@ -546,7 +547,9 @@ export function MembersPage() {
   const canManage = memberCanManage(org, currentUser.data);
   const management = useMemberManagement(memberOrgId(org), canManage);
 
-  if (currentUser.isLoading) return <TableSkeleton rows={4} />;
+  // A cached shell is not permission to invite or change a role. Keep the
+  // route's whole shape in place until /user gives the current answer.
+  if (currentUser.isLoading) return <MembersSkeleton />;
   if (!org) return <NoOrgState />;
   return (
     <MembersView

--- a/src/app/routes/settings.tsx
+++ b/src/app/routes/settings.tsx
@@ -17,6 +17,7 @@ import { CopyButton } from "../ui/copy-button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import { copyToClipboard } from "../lib/clipboard";
 import { QrDefaultsCard } from "../components/qr-defaults-card";
+import { SettingsSkeleton } from "../components/skeletons";
 import { orgNameSchema } from "../lib/schemas";
 import posthog from "../lib/posthog";
 
@@ -347,6 +348,10 @@ export function SettingsPage() {
   // answer arrives. The cache is chrome, never permission to submit a
   // destructive action, and an empty fallback would hide the org names.
   const accountDeleteDisabled = currentUser.isLoading || !currentUser.data;
+
+  // Organization ownership and platform-admin status are authoritative only
+  // after the fresh user response. The cache may be one page load behind.
+  if (currentUser.isLoading) return <SettingsSkeleton />;
 
   return (
     <div>

--- a/src/app/ui/skeleton.tsx
+++ b/src/app/ui/skeleton.tsx
@@ -20,14 +20,16 @@ export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>
 export function SkeletonStatus({
   label = "loading…",
   className,
+  testId,
   children,
 }: {
   label?: string;
   className?: string;
+  testId?: string;
   children: ReactNode;
 }) {
   return (
-    <div role="status" className={className}>
+    <div role="status" className={className} data-testid={testId}>
       <span className="sr-only">{label}</span>
       {children}
     </div>
@@ -38,9 +40,13 @@ export function SkeletonStatus({
 const firstColWidths = [22, 30, 18, 26, 34, 24];
 
 /** Placeholder for a data Table: a header row plus `rows` body rows. */
-export function TableSkeleton({ rows = 4 }: { rows?: number }) {
+export function TableSkeleton({ rows = 4, testId }: { rows?: number; testId?: string }) {
   return (
-    <div role="status" className="overflow-hidden rounded-lg bg-surface smooth-shadow-ring-xs">
+    <div
+      role="status"
+      className="overflow-hidden rounded-lg bg-surface smooth-shadow-ring-xs"
+      data-testid={testId}
+    >
       <span className="sr-only">loading…</span>
       <div className="flex items-center gap-6 border-b border-border px-4 py-3">
         <Skeleton className="h-2.5 w-16" />

--- a/tests/e2e/account-deletion.pw.ts
+++ b/tests/e2e/account-deletion.pw.ts
@@ -106,7 +106,8 @@ test("the delete-account confirmation names every organization it will destroy",
   });
   await page.goto("/settings");
   const deleteButton = page.getByRole("button", { name: "Delete account" });
-  await expect(deleteButton).toBeDisabled();
+  await expect(page.getByTestId("settings-page-skeleton")).toBeVisible();
+  await expect(deleteButton).toBeHidden();
   releaseUser();
   await expect(deleteButton).toBeEnabled();
   await deleteButton.click();

--- a/tests/e2e/route-skeletons.pw.ts
+++ b/tests/e2e/route-skeletons.pw.ts
@@ -45,6 +45,19 @@ async function expectFreshUserSkeleton(
   await expect(settled).toBeVisible();
 }
 
+test("a cold load uses the app-shell skeleton until the first user response", async ({ page }) => {
+  await signInForLoadingCheck(page, "skeleton-cold");
+  // Keep the authenticated session, but remove the cached chrome answer that
+  // lets a returning browser render a route-specific skeleton instead.
+  await page.evaluate(() => localStorage.clear());
+  const release = await holdApi(page, "/api/user");
+  await page.goto("/links");
+  await expect(page.getByTestId("app-shell-skeleton")).toBeVisible();
+  await expect(page.getByRole("button", { name: "New link" })).toBeHidden();
+  release();
+  await expect(page.getByRole("button", { name: "New link" }).first()).toBeVisible();
+});
+
 test("Links keeps its full route shape until the current user arrives", async ({ page }) => {
   await signInForLoadingCheck(page, "skeleton-links");
   await expectFreshUserSkeleton(
@@ -53,6 +66,29 @@ test("Links keeps its full route shape until the current user arrives", async ({
     "links-page-skeleton",
     page.getByRole("button", { name: "New link" }).first(),
   );
+});
+
+test("sidebar navigation keeps the Links table usable after its data arrives", async ({ page }) => {
+  await signInForLoadingCheck(page, "skeleton-client-nav");
+  let release = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route(
+    (url) => /^\/api\/orgs\/[^/]+\/links$/.test(url.pathname),
+    async (route) => {
+      await held;
+      await route.continue();
+    },
+  );
+
+  await page.getByRole("link", { name: "Links" }).click();
+  await expect(page).toHaveURL(/\/links$/);
+  await expect(page.getByTestId("links-table-skeleton")).toBeVisible();
+  await expect(page.getByRole("button", { name: "New link" }).first()).toBeVisible();
+  release();
+  await expect(page.getByTestId("links-table-skeleton")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "New link" }).first()).toBeVisible();
 });
 
 test("Members keeps invite controls out until the current user arrives", async ({ page }) => {

--- a/tests/e2e/route-skeletons.pw.ts
+++ b/tests/e2e/route-skeletons.pw.ts
@@ -1,19 +1,33 @@
-import { expect, test, type Locator, type Page } from "@playwright/test";
+import { expect, test, type BrowserContext, type Locator, type Page } from "@playwright/test";
 import { makePlatformAdmin } from "./db";
 import { signUpAndVerify } from "./resend";
 
 const password = "test-password-123";
 
-async function signInForLoadingCheck(page: Page, prefix: string) {
-  const email = `${prefix}-${Date.now()}@gmail.com`;
-  await signUpAndVerify(page, email, password);
+async function warmShell(page: Page, email: string) {
   // Let the shell persist its cache before the reload below. The regression
   // only exists when chrome paints from that cache while the page waits for a
   // fresh /user response.
   await page.goto("/dashboard");
   await expect(page.getByText(email)).toBeVisible();
-  return email;
 }
+
+test.describe.configure({ mode: "serial" });
+
+let sharedContext: BrowserContext;
+let sharedPage: Page;
+let sharedEmail: string;
+
+test.beforeAll(async ({ browser }) => {
+  sharedContext = await browser.newContext();
+  sharedPage = await sharedContext.newPage();
+  sharedEmail = `skeleton-${Date.now()}@gmail.com`;
+  await signUpAndVerify(sharedPage, sharedEmail, password);
+});
+
+test.afterAll(async () => {
+  await sharedContext.close();
+});
 
 /** Holds one API response open, which makes the route's first render observable. */
 async function holdApi(page: Page, path: string) {
@@ -45,8 +59,9 @@ async function expectFreshUserSkeleton(
   await expect(settled).toBeVisible();
 }
 
-test("a cold load uses the app-shell skeleton until the first user response", async ({ page }) => {
-  await signInForLoadingCheck(page, "skeleton-cold");
+test("a cold load uses the app-shell skeleton until the first user response", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
   // Keep the authenticated session, but remove the cached chrome answer that
   // lets a returning browser render a route-specific skeleton instead.
   await page.evaluate(() => localStorage.clear());
@@ -58,8 +73,9 @@ test("a cold load uses the app-shell skeleton until the first user response", as
   await expect(page.getByRole("button", { name: "New link" }).first()).toBeVisible();
 });
 
-test("Links keeps its full route shape until the current user arrives", async ({ page }) => {
-  await signInForLoadingCheck(page, "skeleton-links");
+test("Links keeps its full route shape until the current user arrives", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
   await expectFreshUserSkeleton(
     page,
     "/links",
@@ -68,8 +84,9 @@ test("Links keeps its full route shape until the current user arrives", async ({
   );
 });
 
-test("sidebar navigation keeps the Links table usable after its data arrives", async ({ page }) => {
-  await signInForLoadingCheck(page, "skeleton-client-nav");
+test("sidebar navigation keeps the Links table usable after its data arrives", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
   let release = () => {};
   const held = new Promise<void>((resolve) => {
     release = resolve;
@@ -91,8 +108,9 @@ test("sidebar navigation keeps the Links table usable after its data arrives", a
   await expect(page.getByRole("button", { name: "New link" }).first()).toBeVisible();
 });
 
-test("Members keeps invite controls out until the current user arrives", async ({ page }) => {
-  await signInForLoadingCheck(page, "skeleton-members");
+test("Members keeps invite controls out until the current user arrives", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
   await expectFreshUserSkeleton(
     page,
     "/members",
@@ -101,8 +119,9 @@ test("Members keeps invite controls out until the current user arrives", async (
   );
 });
 
-test("Billing waits for the fresh plan before showing upgrade controls", async ({ page }) => {
-  await signInForLoadingCheck(page, "skeleton-billing");
+test("Billing waits for the fresh plan before showing upgrade controls", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
   await expectFreshUserSkeleton(
     page,
     "/billing",
@@ -111,8 +130,9 @@ test("Billing waits for the fresh plan before showing upgrade controls", async (
   );
 });
 
-test("Settings waits for fresh ownership before showing destructive controls", async ({ page }) => {
-  await signInForLoadingCheck(page, "skeleton-settings");
+test("Settings waits for fresh ownership before showing destructive controls", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
   await expectFreshUserSkeleton(
     page,
     "/settings",
@@ -121,8 +141,9 @@ test("Settings waits for fresh ownership before showing destructive controls", a
   );
 });
 
-test("Domains keeps its paid upgrade path out until the current user arrives", async ({ page }) => {
-  await signInForLoadingCheck(page, "skeleton-domains");
+test("Domains keeps its paid upgrade path out until the current user arrives", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
   await expectFreshUserSkeleton(
     page,
     "/domains",
@@ -131,9 +152,10 @@ test("Domains keeps its paid upgrade path out until the current user arrives", a
   );
 });
 
-test("Admin routes show their own skeletons while their data is delayed", async ({ page }) => {
-  const email = await signInForLoadingCheck(page, "skeleton-admin");
-  await makePlatformAdmin(page, email);
+test("Admin routes show their own skeletons while their data is delayed", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
+  await makePlatformAdmin(page, sharedEmail);
 
   // The cached shell still says this account is ordinary. Until the fresh
   // answer arrives, the route must not expose platform controls.

--- a/tests/e2e/route-skeletons.pw.ts
+++ b/tests/e2e/route-skeletons.pw.ts
@@ -1,0 +1,141 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { makePlatformAdmin } from "./db";
+import { signUpAndVerify } from "./resend";
+
+const password = "test-password-123";
+
+async function signInForLoadingCheck(page: Page, prefix: string) {
+  const email = `${prefix}-${Date.now()}@gmail.com`;
+  await signUpAndVerify(page, email, password);
+  // Let the shell persist its cache before the reload below. The regression
+  // only exists when chrome paints from that cache while the page waits for a
+  // fresh /user response.
+  await page.goto("/dashboard");
+  await expect(page.getByText(email)).toBeVisible();
+  return email;
+}
+
+/** Holds one API response open, which makes the route's first render observable. */
+async function holdApi(page: Page, path: string) {
+  let release = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route(
+    (url) => url.pathname === path,
+    async (route) => {
+      await held;
+      await route.continue();
+    },
+  );
+  return release;
+}
+
+async function expectFreshUserSkeleton(
+  page: Page,
+  path: string,
+  skeleton: string,
+  settled: Locator,
+) {
+  const release = await holdApi(page, "/api/user");
+  await page.goto(path);
+  await expect(page.getByTestId(skeleton)).toBeVisible();
+  await expect(settled).toBeHidden();
+  release();
+  await expect(settled).toBeVisible();
+}
+
+test("Links keeps its full route shape until the current user arrives", async ({ page }) => {
+  await signInForLoadingCheck(page, "skeleton-links");
+  await expectFreshUserSkeleton(
+    page,
+    "/links",
+    "links-page-skeleton",
+    page.getByRole("button", { name: "New link" }).first(),
+  );
+});
+
+test("Members keeps invite controls out until the current user arrives", async ({ page }) => {
+  await signInForLoadingCheck(page, "skeleton-members");
+  await expectFreshUserSkeleton(
+    page,
+    "/members",
+    "members-page-skeleton",
+    page.getByRole("button", { name: "Invite link" }),
+  );
+});
+
+test("Billing waits for the fresh plan before showing upgrade controls", async ({ page }) => {
+  await signInForLoadingCheck(page, "skeleton-billing");
+  await expectFreshUserSkeleton(
+    page,
+    "/billing",
+    "billing-page-skeleton",
+    page.getByRole("button", { name: /Upgrade to Hobby/ }),
+  );
+});
+
+test("Settings waits for fresh ownership before showing destructive controls", async ({ page }) => {
+  await signInForLoadingCheck(page, "skeleton-settings");
+  await expectFreshUserSkeleton(
+    page,
+    "/settings",
+    "settings-page-skeleton",
+    page.getByRole("button", { name: "Delete account" }),
+  );
+});
+
+test("Domains keeps its paid upgrade path out until the current user arrives", async ({ page }) => {
+  await signInForLoadingCheck(page, "skeleton-domains");
+  await expectFreshUserSkeleton(
+    page,
+    "/domains",
+    "domains-page-skeleton",
+    page.getByRole("link", { name: "Upgrade to add a domain" }),
+  );
+});
+
+test("Admin routes show their own skeletons while their data is delayed", async ({ page }) => {
+  const email = await signInForLoadingCheck(page, "skeleton-admin");
+  await makePlatformAdmin(page, email);
+
+  // The cached shell still says this account is ordinary. Until the fresh
+  // answer arrives, the route must not expose platform controls.
+  await expectFreshUserSkeleton(
+    page,
+    "/admin",
+    "admin-usage-skeleton",
+    page.getByRole("navigation", { name: "Platform sections" }),
+  );
+
+  for (const route of [
+    { path: "/admin", api: "/api/admin/usage", heading: "Platform usage" },
+    { path: "/admin/links", api: "/api/admin/links", heading: "Links" },
+    { path: "/admin/orgs", api: "/api/admin/orgs", heading: "Organizations" },
+    { path: "/admin/users", api: "/api/admin/users", heading: "Users" },
+    { path: "/admin/audit", api: "/api/admin/audit", heading: "Audit log" },
+  ]) {
+    const release = await holdApi(page, route.api);
+    await page.goto(route.path);
+    const skeleton =
+      route.path === "/admin"
+        ? "admin-usage-skeleton"
+        : route.path === "/admin/audit"
+          ? "admin-audit-rows-skeleton"
+          : route.path === "/admin/links"
+            ? "admin-links-rows-skeleton"
+            : "admin-table-skeleton";
+    await expect(page.getByTestId(skeleton)).toBeVisible();
+
+    if (route.path === "/admin/audit") {
+      // The header and search box are already real, so the row placeholder
+      // must not duplicate either while the audit data is pending.
+      await expect(page.getByRole("heading", { name: route.heading })).toHaveCount(1);
+      await expect(page.getByRole("textbox", { name: "Search the audit log" })).toHaveCount(1);
+    }
+
+    release();
+    await expect(page.getByRole("heading", { name: route.heading })).toBeVisible();
+    await expect(page.getByRole("status")).toHaveCount(0);
+  }
+});


### PR DESCRIPTION
## Summary
- keep complete route skeletons visible while cached shell data is refreshed
- prevent billing, settings, links, and members from showing provisional controls
- use route-appropriate admin loading states and avoid duplicating the audit header
- cover delayed responses across every audited route and admin tab

Closes #180

## Verification
- bun run format:check
- bun run check
- bunx playwright test tests/e2e/route-skeletons.pw.ts --grep "Admin routes"
- bun run fallow
- bun run doctor -- --verbose --scope changed

React Doctor: 100/100 with no changed-file findings.

## Scope
No product behavior changes outside loading states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading states across Links, Members, Billing, Settings, and admin pages.
  - Prevented outdated controls, account details, and settings from appearing before current data loads.
  - Added a dedicated audit-page loading layout to keep headers and search controls consistent.
  - Improved table loading placeholders for links and administrative views.

- **Tests**
  - Added end-to-end coverage for loading behavior across user-facing and administrative routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->