### PR TITLE
Automate dependency update pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      bun-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What changed

- add weekly Dependabot updates for the Bun dependency graph
- add weekly Dependabot updates for GitHub Actions
- group minor and patch updates so maintenance stays reviewable

## Issue

Relates to #32

## Why this shape

The issue already has Bun pinned in `package.json` and CI. This PR fills the missing dependency-update automation called out in the issue comment without changing runtime code or the release path. It covers the dependency-automation slice of #32; the remaining release, migration, staging, and recovery work stays tracked there.

## Verification

- `bun run verify`
- `bun run fallow`

The Worker suite completed with 399 passing tests. Wrangler still emits its existing uncaught-workerd diagnostics during the run, but the test process completed successfully.
