### PR TITLE
Show 'new version available' banner on stale-tab chunk failures

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/andreabruno/Code/Products/rdyrct/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/andreabruno/Code/Products/rdyrct/node_modules

--- a/src/app/components/error-boundary.tsx
+++ b/src/app/components/error-boundary.tsx
@@ -17,14 +17,11 @@ type State = { crashed: boolean; chunkError: boolean };
  * It is recoverable by reloading onto the current build, so we prompt a reload
  * rather than render the crash page.
  */
-function isChunkLoadError(error: unknown): boolean {
-  if (!(error instanceof Error) || !error.message) return false;
-  return (
-    /failed to fetch dynamically imported module/i.test(error.message) ||
-    /importing a module script failed/i.test(error.message) ||
-    /error loading dynamically imported module/i.test(error.message) ||
-    /failed to load a dynamic application chunk/i.test(error.message)
-  );
+const CHUNK_LOAD_ERROR =
+  /failed to fetch dynamically imported module|importing a module script failed|error loading dynamically imported module|failed to load a dynamic application chunk/i;
+
+function isChunkLoadError(error: Error): boolean {
+  return CHUNK_LOAD_ERROR.test(error.message);
 }
 
 /**

--- a/src/app/components/error-boundary.tsx
+++ b/src/app/components/error-boundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import posthog from "../lib/posthog";
 import { captureClientException } from "../lib/sentry";
+import { signalNewVersionAvailable } from "../lib/new-version";
 
 type Props = {
   children: ReactNode;
@@ -8,7 +9,23 @@ type Props = {
   fallback?: ReactNode;
 };
 
-type State = { crashed: boolean };
+type State = { crashed: boolean; chunkError: boolean };
+
+/**
+ * A failed code-split chunk load almost always means a stale build: a visitor
+ * has a tab open whose hashed asset filenames no longer exist after a deploy.
+ * It is recoverable by reloading onto the current build, so we prompt a reload
+ * rather than render the crash page.
+ */
+function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error) || !error.message) return false;
+  return (
+    /failed to fetch dynamically imported module/i.test(error.message) ||
+    /importing a module script failed/i.test(error.message) ||
+    /error loading dynamically imported module/i.test(error.message) ||
+    /failed to load a dynamic application chunk/i.test(error.message)
+  );
+}
 
 /**
  * Catches render/commit-phase exceptions so one broken subtree degrades to a
@@ -19,13 +36,21 @@ type State = { crashed: boolean };
  * unmount the whole app and a visitor would see nothing.
  */
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { crashed: false };
+  state: State = { crashed: false, chunkError: false };
 
-  static getDerivedStateFromError(): State {
-    return { crashed: true };
+  static getDerivedStateFromError(error: Error): State {
+    return { crashed: true, chunkError: isChunkLoadError(error) };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    if (isChunkLoadError(error)) {
+      // A stale tab after a deploy: surface the "new version available"
+      // banner and let the visitor reload. The app can't render the failed
+      // chunk, so we stay blank behind the banner rather than flash the
+      // crash notice.
+      signalNewVersionAvailable();
+      return;
+    }
     posthog.captureException(error, { componentStack: info.componentStack });
     captureClientException(error, info.componentStack);
   }
@@ -33,6 +58,9 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (!this.state.crashed) return this.props.children;
     if (this.props.fallback !== undefined) return this.props.fallback;
+    // A chunk-load failure renders blank behind the banner; everything else
+    // gets the crash notice.
+    if (this.state.chunkError) return null;
     return <FullPageError />;
   }
 }

--- a/src/app/components/new-version-banner.tsx
+++ b/src/app/components/new-version-banner.tsx
@@ -1,0 +1,40 @@
+import { X } from "@/app/ui/icons";
+import { useSyncExternalStore } from "react";
+import { Button } from "../ui/button";
+import {
+  dismissNewVersion,
+  getNewVersion,
+  reloadNow,
+  subscribeNewVersion,
+} from "../lib/new-version";
+
+/**
+ * Shown when a code-split chunk fails to load: almost always a stale tab after
+ * a deploy, whose old asset names no longer exist. We point the visitor at a
+ * reload instead of crashing or auto-reloading under them. Mounted outside the
+ * error boundary so it survives the boundary catching the chunk failure.
+ */
+export function NewVersionBanner() {
+  const available = useSyncExternalStore(subscribeNewVersion, getNewVersion);
+  if (!available) return null;
+
+  return (
+    <div
+      role="alert"
+      className="fixed inset-x-0 top-0 z-[100] flex items-center justify-center gap-3 border-b border-border bg-surface px-4 py-2.5 text-sm"
+    >
+      <span className="text-text">A new version of the app is available.</span>
+      <Button variant="primary" size="sm" onClick={reloadNow}>
+        Reload
+      </Button>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={dismissNewVersion}
+        className="ml-1 rounded p-1 text-muted transition-colors duration-150 hover:text-text"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/app/lib/new-version.ts
+++ b/src/app/lib/new-version.ts
@@ -1,0 +1,38 @@
+// A code-split chunk failing to load almost always means a stale tab: a
+// visitor has a tab open whose hashed asset filenames no longer exist after a
+// deploy. Rather than reload (which flashes and can loop on a broken deploy)
+// or crash, we surface an in-app "new version available" banner and let the
+// visitor reload when they choose. This store is the bridge between the
+// non-React `vite:preloadError` handler and the React banner.
+
+let available = false;
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach((l) => l());
+}
+
+export function signalNewVersionAvailable() {
+  if (available) return;
+  available = true;
+  emit();
+}
+
+export function dismissNewVersion() {
+  if (!available) return;
+  available = false;
+  emit();
+}
+
+export function subscribeNewVersion(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getNewVersion(): boolean {
+  return available;
+}
+
+export function reloadNow() {
+  window.location.reload();
+}

--- a/src/app/lib/sentry.ts
+++ b/src/app/lib/sentry.ts
@@ -1,9 +1,8 @@
 import * as Sentry from "@sentry/react";
+import { signalNewVersionAvailable } from "./new-version";
 
 // SAFETY: Vite exposes configured VITE_ variables as strings and leaves absent values undefined.
 const dsn = import.meta.env.VITE_PUBLIC_SENTRY_DSN as string | undefined;
-const CHUNK_RELOAD_KEY = "rdyrct:chunk-reload-at";
-const CHUNK_RELOAD_WINDOW_MS = 30_000;
 
 // Error reports are operational telemetry, not product analytics: do not add
 // replays, tracing, cookies, or personal data. The DSN is deliberately public
@@ -34,14 +33,14 @@ if (dsn) {
   });
 }
 
+// A failed code-split chunk is almost always a stale build: a visitor has a
+// tab open whose hashed asset filenames no longer exist after a deploy. We
+// surface the in-app "new version available" banner and let them reload when
+// they choose, rather than crashing or reloading under them. Not reported to
+// Sentry: it is either not a bug (stale tab) or a broken deploy that will
+// already surface real errors elsewhere.
 window.addEventListener("vite:preloadError", () => {
-  const previous = Number(sessionStorage.getItem(CHUNK_RELOAD_KEY));
-  const recent = Number.isFinite(previous) && Date.now() - previous < CHUNK_RELOAD_WINDOW_MS;
-  if (recent) return;
-
-  sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
-  captureClientException(new Error("Failed to load a dynamic application chunk"));
-  void flushClientEvents().finally(() => window.location.reload());
+  signalNewVersionAvailable();
 });
 
 export function captureClientException(error: Error, componentStack?: string | null) {
@@ -51,9 +50,4 @@ export function captureClientException(error: Error, componentStack?: string | n
     scope.setContext("react", { componentStack: componentStack ?? "" });
     Sentry.captureException(error);
   });
-}
-
-async function flushClientEvents(): Promise<void> {
-  if (!dsn) return;
-  await Sentry.flush(2_000);
 }

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -26,6 +26,7 @@ import "@fontsource/jetbrains-mono/latin-700.css";
 import "./styles.css";
 import { ToastProvider } from "./ui/toast";
 import { ErrorBoundary } from "./components/error-boundary";
+import { NewVersionBanner } from "./components/new-version-banner";
 import { ConsentBanner } from "./ui/consent-banner";
 import { AppShellSkeleton } from "./components/skeletons";
 import { LandingHeader } from "./components/landing-header";
@@ -383,6 +384,9 @@ createRoot(document.getElementById("root")!).render(
         <ErrorBoundary>
           <RouterProvider router={router} />
         </ErrorBoundary>
+        {/* Outside the boundary: it stays mounted when a chunk failure crashes
+            the app underneath, so the "new version available" prompt survives. */}
+        <NewVersionBanner />
       </ToastProvider>
     </QueryClientProvider>
   </StrictMode>,


### PR DESCRIPTION
## What
When a code-split chunk fails to load — almost always a stale tab after a deploy, whose old hashed asset names no longer exist on the server — we previously waited up to 2s for a Sentry flush and then hard-reloaded, flashing the crash page in the meantime. This replaces that with an in-app banner prompting the visitor to reload, and stops reporting the failure to Sentry.

## Why
- The 2s wait before reload is what made the "Something broke" page flash on screen; ugly and scary for a non-bug.
- The chunk failure is either not a bug (stale tab) or a genuinely broken deploy that will already surface real errors elsewhere, so the Sentry event was pure noise.

## How
- `src/app/lib/new-version.ts`: tiny store bridging the non-React `vite:preloadError` handler and the React banner.
- `src/app/components/new-version-banner.tsx`: fixed top banner with a Reload button and a dismiss (X). Mounted in `main.tsx` **outside** the `ErrorBoundary` so it survives the boundary catching the chunk failure.
- `sentry.ts`: the `vite:preloadError` listener now signals the banner instead of reloading/reporting.
- `error-boundary.tsx`: a chunk-load failure no longer paints `FullPageError`; it signals the banner and renders blank behind it.

## Notes
- Auto-reload was removed entirely, so there is no reload-loop risk on a broken deploy; the visitor drives the reload via the banner.
- `bun run check` passes.

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app “New version available” banner when an update is detected.
  * Users can reload immediately or dismiss the notification.
  * The update notification remains visible even when stale content causes an app loading error.

* **Bug Fixes**
  * Improved handling of deployment-related loading errors without displaying a crash notice or forcing an unexpected reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->