### PR TITLE
Add Google sign-in and user avatars (#194, #195, #196)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -40,3 +40,12 @@ BLOG_ORIGIN_URL=http://localhost:3000
 # e2e signup on the disabled path. The disabled path has its own worker test,
 # which needs no browser to prove it.
 CAP_SECRET=dev-only-cap-secret-not-a-real-one-0000000000000000
+
+# Google sign-in. Leave blank to disable the "Continue with Google" button.
+# For local dev, point GOOGLE_EMULATOR_URL at an OAuth emulator
+# (e.g. https://www.emulate.dev/mock/oauth2) and set the client id/secret it
+# provides. In production, leave GOOGLE_EMULATOR_URL blank and set the real
+# Google OAuth client id/secret; the worker then uses Google's discovery URL.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_EMULATOR_URL=

--- a/.dev.vars.playwright
+++ b/.dev.vars.playwright
@@ -24,3 +24,8 @@ CF_DEV_ENV=instant
 # wrangler prefer it, so a secret only in .dev.vars leaves every e2e signup
 # running the disabled path while looking like it covers the real one.
 CAP_SECRET=playwright-only-cap-secret-32-chars-min
+
+# Google sign-in (emulate.dev OAuth emulator) for the browser suite.
+GOOGLE_CLIENT_ID=emulate-dev-google-client-id
+GOOGLE_CLIENT_SECRET=emulate-dev-google-client-secret
+GOOGLE_EMULATOR_URL=https://www.emulate.dev/mock/oauth2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,8 @@ analyticsDays }`). Slugs on the **shared** domain are always random (every
   `domain:{host}`. D1 is authoritative; KV is the redirect hot path. Clicks are
   recorded via `waitUntil` after the redirect is sent, and store only
   country/referrer/device/timestamp, **never an IP address**.
-- **QR logos live in R2** (binding `QR_LOGOS`, bucket `rdyrct-qr-logos`), keyed
+- **User-supplied images live in R2** (binding `MEDIA`, bucket `rdyrct-media` in
+  config; the existing `rdyrct-qr-logos` bucket was rebound), keyed
   `{orgId}/{fileId}.{ext}`. The `qr_logo` columns store only the serving URL
   (`/api/orgs/<orgId>/qr-logo/<file>`), never image bytes. Upload and serving
   are the same org-scoped route (`POST`/`GET /api/orgs/:orgId/qr-logo[/:file]`),

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Prefer the manual path, or need to redeploy after the button above? Create the r
 ```sh
 bunx wrangler kv namespace create LINKS
 bunx wrangler d1 create rdyrct
-bunx wrangler r2 bucket create rdyrct-qr-logos
+bunx wrangler r2 bucket create rdyrct-media
 ```
 
 Paste the returned ids into `wrangler.jsonc`:

--- a/evlog.map.json
+++ b/evlog.map.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-28T01:40:26.183Z",
+  "generatedAt": "2026-08-28T01:47:34.537Z",
   "cliVersion": "0.6.0",
   "ruleSetVersion": 1,
   "framework": "hono",
@@ -82,9 +82,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -163,9 +161,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -209,9 +205,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -246,9 +240,7 @@
       "suggestions": {},
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -292,9 +284,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -382,9 +372,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -428,9 +416,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -474,9 +460,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -520,9 +504,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -566,9 +548,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -612,9 +592,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -754,10 +732,7 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": [
-          "auth: path says \"token\"",
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["auth: path says \"token\"", "pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -792,10 +767,7 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": [
-          "auth: path says \"token\"",
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["auth: path says \"token\"", "pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -839,9 +811,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -885,9 +855,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -957,9 +925,7 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": [
-          "auth: path says \"auth\""
-        ]
+        "reasons": ["auth: path says \"auth\""]
       },
       "score": 100
     },
@@ -994,9 +960,7 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": [
-          "auth: path says \"auth\""
-        ]
+        "reasons": ["auth: path says \"auth\""]
       },
       "score": 100
     },
@@ -1110,9 +1074,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1147,10 +1109,7 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": [
-          "money: path says \"checkout\"",
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["money: path says \"checkout\"", "pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1229,9 +1188,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1275,9 +1232,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1321,9 +1276,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1367,9 +1320,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1404,9 +1355,7 @@
       "suggestions": {},
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1485,9 +1434,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1566,9 +1513,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1612,9 +1557,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1658,9 +1601,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1704,9 +1645,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1750,9 +1689,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     },
@@ -1796,9 +1733,7 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": [
-          "pii: write operation with sensitive fields"
-        ]
+        "reasons": ["pii: write operation with sensitive fields"]
       },
       "score": 100
     }

--- a/evlog.map.json
+++ b/evlog.map.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-27T12:07:47.333Z",
+  "generatedAt": "2026-08-28T01:40:26.183Z",
   "cliVersion": "0.6.0",
   "ruleSetVersion": 1,
   "framework": "hono",
@@ -14,7 +14,7 @@
       "path": "*",
       "file": "src/worker/index.ts",
       "handler": {
-        "line": 386,
+        "line": 388,
         "column": 0
       },
       "id": "cfc6426d0697",
@@ -82,7 +82,44 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
+      },
+      "score": 100
+    },
+    {
+      "framework": "hono",
+      "kind": "api",
+      "method": "GET",
+      "path": "/",
+      "file": "src/worker/routes/avatars.ts",
+      "handler": {
+        "line": 11,
+        "column": 0
+      },
+      "id": "4350f835247a",
+      "checks": {
+        "audit": {
+          "status": "n/a"
+        },
+        "error-handling": {
+          "status": "n/a"
+        },
+        "wide-event": {
+          "status": "pass"
+        },
+        "context": {
+          "status": "pass"
+        },
+        "structured-errors": {
+          "status": "pass"
+        }
+      },
+      "suggestions": {},
+      "sensitivity": {
+        "level": "none",
+        "reasons": []
       },
       "score": 100
     },
@@ -126,7 +163,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -170,7 +209,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -205,7 +246,9 @@
       "suggestions": {},
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -249,7 +292,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -337,7 +382,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -381,7 +428,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -425,7 +474,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -469,7 +520,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -513,7 +566,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -557,7 +612,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -638,7 +695,7 @@
       "path": "/:slug",
       "file": "src/worker/index.ts",
       "handler": {
-        "line": 371,
+        "line": 373,
         "column": 0
       },
       "id": "4542fd0856a5",
@@ -673,7 +730,7 @@
       "path": "/:token",
       "file": "src/worker/routes/orgs.ts",
       "handler": {
-        "line": 1226,
+        "line": 1227,
         "column": 0
       },
       "id": "c8b0bedaf935",
@@ -697,7 +754,10 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": ["auth: path says \"token\"", "pii: write operation with sensitive fields"]
+        "reasons": [
+          "auth: path says \"token\"",
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -708,7 +768,7 @@
       "path": "/:token/accept",
       "file": "src/worker/routes/orgs.ts",
       "handler": {
-        "line": 1284,
+        "line": 1285,
         "column": 0
       },
       "id": "d4b536c251be",
@@ -732,7 +792,10 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": ["auth: path says \"token\"", "pii: write operation with sensitive fields"]
+        "reasons": [
+          "auth: path says \"token\"",
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -776,7 +839,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -820,7 +885,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -831,7 +898,7 @@
       "path": "/api/*",
       "file": "src/worker/index.ts",
       "handler": {
-        "line": 263,
+        "line": 265,
         "column": 0
       },
       "id": "74a1ccacc4b3",
@@ -866,7 +933,7 @@
       "path": "/api/auth/*",
       "file": "src/worker/index.ts",
       "handler": {
-        "line": 200,
+        "line": 201,
         "column": 0
       },
       "id": "e75aa52c874e",
@@ -890,7 +957,9 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": ["auth: path says \"auth\""]
+        "reasons": [
+          "auth: path says \"auth\""
+        ]
       },
       "score": 100
     },
@@ -901,7 +970,7 @@
       "path": "/api/auth/*",
       "file": "src/worker/index.ts",
       "handler": {
-        "line": 200,
+        "line": 201,
         "column": 0
       },
       "id": "2d4af6eb10f7",
@@ -925,7 +994,9 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": ["auth: path says \"auth\""]
+        "reasons": [
+          "auth: path says \"auth\""
+        ]
       },
       "score": 100
     },
@@ -936,7 +1007,7 @@
       "path": "/api/cap/*",
       "file": "src/worker/index.ts",
       "handler": {
-        "line": 218,
+        "line": 219,
         "column": 0
       },
       "id": "3d9ce45013d9",
@@ -971,7 +1042,7 @@
       "path": "/api/webhooks/polar",
       "file": "src/worker/index.ts",
       "handler": {
-        "line": 232,
+        "line": 233,
         "column": 0
       },
       "id": "bbed5d59d114",
@@ -1039,7 +1110,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1074,7 +1147,10 @@
       "suggestions": {},
       "sensitivity": {
         "level": "high",
-        "reasons": ["money: path says \"checkout\"", "pii: write operation with sensitive fields"]
+        "reasons": [
+          "money: path says \"checkout\"",
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1153,7 +1229,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1197,7 +1275,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1241,7 +1321,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1285,7 +1367,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1320,7 +1404,9 @@
       "suggestions": {},
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1331,7 +1417,7 @@
       "path": "/pricing.md",
       "file": "src/worker/index.ts",
       "handler": {
-        "line": 359,
+        "line": 361,
         "column": 0
       },
       "id": "c01fb33007bf",
@@ -1399,7 +1485,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1478,7 +1566,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1522,7 +1612,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1566,7 +1658,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1610,7 +1704,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1654,7 +1750,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     },
@@ -1698,7 +1796,9 @@
       },
       "sensitivity": {
         "level": "medium",
-        "reasons": ["pii: write operation with sensitive fields"]
+        "reasons": [
+          "pii: write operation with sensitive fields"
+        ]
       },
       "score": 100
     }

--- a/src/app/components/user-avatar.tsx
+++ b/src/app/components/user-avatar.tsx
@@ -1,0 +1,87 @@
+import { cn } from "@/app/ui/cn";
+
+type AvatarUser = {
+  id: string;
+  image: string | null;
+  name?: string;
+  email?: string;
+};
+
+/** Deterministic blobatar for users with no uploaded image: the same person
+ * always gets the same colours and shape, derived from their id. */
+function hash(str: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function initials(user: AvatarUser): string {
+  const source = user.name?.trim() || user.email?.trim() || "";
+  const parts = source.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return source.slice(0, 2).toUpperCase();
+}
+
+function Blobatar({ user, size }: { user: AvatarUser; size: number }) {
+  const h = hash(user.id);
+  const hue = h % 360;
+  const hue2 = (hue + 40 + ((h >> 8) % 80)) % 360;
+  const angle = h % 360;
+  const letter = initials(user);
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      role="img"
+      aria-label={user.name || user.email || "avatar"}
+      className="shrink-0 rounded-full"
+    >
+      <defs>
+        <linearGradient id={`bg-${user.id}`} gradientTransform={`rotate(${angle} 0.5 0.5)`}>
+          <stop offset="0%" stopColor={`hsl(${hue} 70% 55%)`} />
+          <stop offset="100%" stopColor={`hsl(${hue2} 70% 45%)`} />
+        </linearGradient>
+      </defs>
+      <rect width="100" height="100" fill={`url(#bg-${user.id})`} />
+      <text
+        x="50"
+        y="50"
+        dy="0.35em"
+        textAnchor="middle"
+        fontSize="42"
+        fontWeight="600"
+        fill="white"
+        fillOpacity="0.92"
+        fontFamily="JetBrains Mono, monospace"
+      >
+        {letter}
+      </text>
+    </svg>
+  );
+}
+
+export function UserAvatar({
+  user,
+  size = 32,
+  className,
+}: {
+  user: AvatarUser;
+  size?: number;
+  className?: string;
+}) {
+  if (user.image)
+    return (
+      <img
+        src={user.image}
+        alt={user.name || user.email || "avatar"}
+        width={size}
+        height={size}
+        className={cn("shrink-0 rounded-full object-cover", className)}
+      />
+    );
+  return <Blobatar user={user} size={size} />;
+}

--- a/src/app/lib/user-cache.ts
+++ b/src/app/lib/user-cache.ts
@@ -35,6 +35,7 @@ const userSchema = v.object({
   polarSubscriptionCurrentPeriodEnd: v.nullable(v.number()),
   hasBillingAccount: v.boolean(),
   comped: v.boolean(),
+  image: v.nullable(v.string()),
 });
 
 const orgSchema = v.object({

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -12,7 +12,7 @@ import posthog from "../lib/posthog";
 import { FUNNEL } from "../lib/funnel";
 import { useShake } from "../lib/use-shake";
 import { useCap } from "../lib/cap";
-import { useCurrentUser } from "../lib/hooks";
+import { useCurrentUser, useConfig } from "../lib/hooks";
 import { storedAnonLinks } from "../lib/anon-links";
 import { firstFormError } from "../lib/form-errors";
 import { cn } from "../ui/cn";
@@ -247,6 +247,30 @@ function PasswordHint({
   return <PasswordMeter password={password} />;
 }
 
+/** Inline Google "G" mark (no remote image, CSP-safe). */
+function GoogleG() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
+      <path
+        fill="#EA4335"
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+      />
+    </svg>
+  );
+}
+
 function AuthFormView({
   mode,
   busy,
@@ -268,10 +292,19 @@ function AuthFormView({
 }) {
   const copy = AUTH_MODE_COPY[mode];
   const toast = useToast();
+  const config = useConfig();
   const { register, handleSubmit, watch, getValues } = useForm<AuthForm>({
     resolver: valibotResolver(copy.schema),
     defaultValues: { email: "", password: "" },
   });
+
+  const startGoogle = () => {
+    posthog.capture("user_google_signin_started");
+    // Full-page redirect to Google; returns to /api/auth/callback/google, then
+    // to `next`. Same flow on login and signup (account linking handles an
+    // existing email/password account).
+    void authClient.signIn.social({ provider: "google", callbackURL: next });
+  };
 
   const password = watch("password");
   const onFormSubmit = handleSubmit(
@@ -321,6 +354,23 @@ function AuthFormView({
         >
           <BusyContent busy={busy}>{copy.submitLabel}</BusyContent>
         </Button>
+        {config.data?.googleEnabled && (
+          <>
+            <div className="flex items-center gap-3 text-xs text-muted">
+              <span className="h-px flex-1 bg-border" />
+              or
+              <span className="h-px flex-1 bg-border" />
+            </div>
+            <button
+              type="button"
+              onClick={startGoogle}
+              className="flex items-center justify-center gap-2 rounded-lg border border-border bg-surface py-2.5 text-sm font-medium transition-colors hover:bg-surface-2"
+            >
+              <GoogleG />
+              Continue with Google
+            </button>
+          </>
+        )}
         <p className="text-center text-xs text-muted">
           {copy.footerPrompt}{" "}
           <HrefLink href={`${copy.footerTo}?next=${encodeURIComponent(next)}`}>

--- a/src/app/routes/landing.tsx
+++ b/src/app/routes/landing.tsx
@@ -631,8 +631,8 @@ const resources = [
   },
   {
     name: "R2",
-    id: "rdyrct-qr-logos",
-    desc: "QR logo images, uploaded and served through the Worker.",
+    id: "rdyrct-media",
+    desc: "User-supplied images (QR logos, avatars), uploaded and served through the Worker.",
   },
   {
     name: "Worker",

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -20,6 +20,7 @@ import { Field, Input } from "../ui/field";
 import { AppShellSkeleton, RouteSkeleton } from "../components/skeletons";
 import { appNavItems } from "../components/nav-items";
 import { OverLimitBanner } from "../components/over-limit";
+import { UserAvatar } from "../components/user-avatar";
 import { WebMcpLinkTools } from "../components/webmcp-link-tools";
 import { WebMcpAnalyticsTool } from "../components/webmcp-analytics-tool";
 import { NotFound } from "./not-found";
@@ -195,6 +196,7 @@ function AppSidebar({
           Footer, so both border-t lines form one continuous bottom rule */}
       <div className="mt-auto border-t border-border px-3 py-2.5">
         <div className="flex items-center gap-2 px-1.5">
+          <UserAvatar user={user} size={32} />
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm">{user.name}</p>
             <p className="truncate text-xs text-muted">{user.email}</p>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -172,6 +172,8 @@ export interface User {
    * to know which one it is talking to.
    */
   comped: boolean;
+  /** Same-origin serving URL for the user's avatar, or null (blobatar). */
+  image: string | null;
 }
 
 export interface QrOverrides {
@@ -257,6 +259,8 @@ export interface DomainDTO {
 export interface AppConfig {
   /** Shared redirect host; the CNAME target for custom domains. */
   appHost: string;
+  /** Whether Google sign-in is configured and the button should show. */
+  googleEnabled: boolean;
 }
 
 /** The org's fresh link-quota count, plus when it was read. The timestamp

--- a/src/worker/better-auth.ts
+++ b/src/worker/better-auth.ts
@@ -5,6 +5,7 @@ import * as v from "valibot";
 import { lookup } from "../shared/lookup";
 import { APIError, createAuthMiddleware } from "better-auth/api";
 import { emailOTP } from "better-auth/plugins/email-otp";
+import { genericOAuth } from "better-auth/plugins/generic-oauth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { drizzle } from "drizzle-orm/d1";
 import { and, eq } from "drizzle-orm";
@@ -17,6 +18,7 @@ import { renderEmail } from "./email-layout";
 import { hashPassword, verifyPassword } from "./password";
 import { uid } from "./util";
 import { spendToken, type CapScope } from "./cap";
+import { storeUserAvatar, deleteUserAvatar } from "./storage";
 import { createOwnedOrg } from "./plan";
 import { defaultOrgName } from "@/shared/org-name";
 import { CAP_FAILED_CODE, CAP_TOKEN_HEADER } from "@/shared/types";
@@ -101,6 +103,7 @@ async function ensureOrganization(env: Env, db: DB, userId: string): Promise<voi
  * flags let the stalled-deletion sweep finish the work.
  */
 export async function deleteAccountAndOwnedOrgs(env: Env, userId: string): Promise<void> {
+  await deleteUserAvatar(env, userId);
   const now = Date.now();
   const [owned] = await env.DB.batch<{ orgId: string }>([
     env.DB.prepare(
@@ -346,6 +349,16 @@ function buildAuth(env: Env) {
     // Keeping BetterAuth's per-isolate limiter enabled would create a second,
     // inconsistent 429 shape and would not protect the rest of the app.
     rateLimit: { enabled: false },
+    // Link a Google sign-in to an existing email/password account with the
+    // same (verified) address instead of creating a duplicate. Google is a
+    // trusted provider, so an unverified Google account still links to a
+    // verified local one — acceptable, since Google is the trusted IdP.
+    account: {
+      accountLinking: {
+        enabled: true,
+        trustedProviders: ["google"],
+      },
+    },
     emailAndPassword: {
       enabled: true,
       requireEmailVerification: true,
@@ -413,6 +426,36 @@ function buildAuth(env: Env) {
           );
         },
       }),
+      // Google sign-in via the generic OAuth2 provider (not the built-in
+      // `google`, whose token endpoint is hardcoded and cannot be redirected
+      // at dev/emulate). Endpoints are env-driven: a discovery URL in prod, or
+      // explicit endpoints at the emulate Google emulator in dev. Only
+      // registered when credentials are present, so environments without
+      // Google config simply have no social login.
+      ...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+        ? [
+            genericOAuth({
+              config: [
+                {
+                  providerId: "google",
+                  clientId: env.GOOGLE_CLIENT_ID,
+                  clientSecret: env.GOOGLE_CLIENT_SECRET,
+                  scopes: ["openid", "email", "profile"],
+                  ...(env.GOOGLE_EMULATOR_URL
+                    ? {
+                        authorizationUrl: `${env.GOOGLE_EMULATOR_URL}/o/oauth2/v2/auth`,
+                        tokenUrl: `${env.GOOGLE_EMULATOR_URL}/oauth2/token`,
+                        userInfoUrl: `${env.GOOGLE_EMULATOR_URL}/oauth2/v2/userinfo`,
+                      }
+                    : {
+                        discoveryUrl:
+                          "https://accounts.google.com/.well-known/openid-configuration",
+                      }),
+                },
+              ],
+            }),
+          ]
+        : []),
     ],
     user: {
       additionalFields: {
@@ -508,6 +551,29 @@ function buildAuth(env: Env) {
           },
           after: async (session) => {
             await ensureOrganization(env, db, session.userId);
+            // Re-sync the avatar from Google on every Google sign-in. The OAuth
+            // path refreshes `user.image` to the latest remote URL each time, so
+            // pulling it into R2 here covers both first link and later changes.
+            // Password users already carry the same-origin serving URL and are
+            // skipped. Runs after the org ensure so a brand-new Google user
+            // also gets an org. Any failure here must not abort sign-in, so it
+            // is swallowed: the blobatar stays and re-sync runs next login.
+            try {
+              const [row] = await db
+                .select({ image: schema.user.image })
+                .from(schema.user)
+                .where(eq(schema.user.id, session.userId));
+              if (row?.image?.startsWith("http")) {
+                const serving = await storeUserAvatar(env, session.userId, row.image);
+                if (serving)
+                  await db
+                    .update(schema.user)
+                    .set({ image: serving })
+                    .where(eq(schema.user.id, session.userId));
+              }
+            } catch {
+              // keep the session; the avatar simply stays unset
+            }
           },
         },
       },

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -7,7 +7,7 @@ import type { BillingProvider } from "./billing-provider";
 export interface Env {
   DB: D1Database;
   LINKS: KVNamespace;
-  QR_LOGOS: R2Bucket;
+  MEDIA: R2Bucket;
   ASSETS: Fetcher;
 
   /* storage recovery: KV/R2 follow-up work and the org-teardown workflow */
@@ -37,9 +37,15 @@ export interface Env {
   BETTER_AUTH_SECRET: string;
   SUPERADMIN_EMAIL: string;
   RESEND_API_KEY: string;
-  MAIL_FROM: string; // var, e.g. "rdyrct <no-reply@mail.rdyrct.com>"
+  MAIL_FROM: string; // var, e.g. "me <no-reply@mail.rdyrct.com>"
   APP_URL: string; // var, e.g. "https://rdyrct.com"; SPA/API origin
   RESEND_BASE_URL?: string; // var; dev points at the emulate.dev Resend emulator
+
+  /* Google OAuth (generic OAuth2 provider). clientSecret is a secret; the
+     emulator URL is a var and only set in dev to redirect the flow at emulate. */
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
+  GOOGLE_EMULATOR_URL?: string;
 
   /* billing (Polar) */
   POLAR_ACCESS_TOKEN: string;
@@ -80,6 +86,8 @@ export interface SessionUser {
   plan: "free" | "hobby" | "pro";
   polarSubscriptionCancelAtPeriodEnd: boolean;
   polarSubscriptionCurrentPeriodEnd: number | null;
+  /** Same-origin serving URL for the user's avatar, or null (blobatar). */
+  image: string | null;
 }
 
 export type Vars = {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -19,6 +19,7 @@ import {
 } from "./routes/orgs";
 import { linkRoutes } from "./routes/links";
 import { qrLogoRoutes } from "./routes/qr-logos";
+import { avatarRoutes } from "./routes/avatars";
 import { adminRoutes } from "./routes/admin";
 import { billingRoutes, handlePolarWebhook } from "./routes/billing";
 import { domainRoutes } from "./routes/domains";
@@ -216,6 +217,7 @@ api.route("/", userRoutes);
 api.route("/orgs", orgRoutes);
 api.route("/orgs/:orgId/links", linkRoutes);
 api.route("/orgs/:orgId/qr-logo", qrLogoRoutes);
+api.route("/user/avatar", avatarRoutes);
 api.route("/billing", billingRoutes);
 api.route("/orgs/:orgId/domains", domainRoutes);
 api.route("/invites", inviteRoutes);

--- a/src/worker/routes/auth.ts
+++ b/src/worker/routes/auth.ts
@@ -96,5 +96,8 @@ userRoutes.get("/user", requireUser, async (c) => {
 // Public, non-secret deployment config (the SPA shows appHost in DNS setup
 // instructions for custom domains).
 userRoutes.get("/config", (c) => {
-  return c.json({ appHost: c.env.APP_HOST } satisfies AppConfig);
+  return c.json({
+    appHost: c.env.APP_HOST,
+    googleEnabled: Boolean(c.env.GOOGLE_CLIENT_ID && c.env.GOOGLE_CLIENT_SECRET),
+  } satisfies AppConfig);
 });

--- a/src/worker/routes/avatars.ts
+++ b/src/worker/routes/avatars.ts
@@ -1,0 +1,23 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { AppEnv } from "../env";
+import { AVATAR_PREFIX } from "./../storage";
+
+// Mounted at /api/user/avatar. Serves the signed-in user's own avatar bytes
+// from R2. The key is the session user id, so no URL ever carries a user id
+// and an unauthorized request gets an empty bucket (404).
+export const avatarRoutes = new Hono<AppEnv>();
+
+avatarRoutes.get("/", async (c) => {
+  const user = c.var.user;
+  if (!user) throw new HTTPException(401, { message: "Not signed in" });
+
+  const obj = await c.env.MEDIA.get(`${AVATAR_PREFIX}${user.id}`);
+  if (!obj) throw new HTTPException(404, { message: "No avatar" });
+
+  const headers = new Headers();
+  obj.writeHttpMetadata(headers);
+  headers.set("cache-control", "private, max-age=31536000, immutable");
+  headers.set("x-content-type-options", "nosniff");
+  return new Response(obj.body, { headers });
+});

--- a/src/worker/routes/avatars.ts
+++ b/src/worker/routes/avatars.ts
@@ -9,10 +9,14 @@ import { AVATAR_PREFIX } from "./../storage";
 export const avatarRoutes = new Hono<AppEnv>();
 
 avatarRoutes.get("/", async (c) => {
+  const log = c.get("log");
+  log.set({ route: "user-avatar" });
   const user = c.var.user;
   if (!user) throw new HTTPException(401, { message: "Not signed in" });
+  log.set({ userId: user.id });
 
   const obj = await c.env.MEDIA.get(`${AVATAR_PREFIX}${user.id}`);
+  log.set({ avatarFound: Boolean(obj) });
   if (!obj) throw new HTTPException(404, { message: "No avatar" });
 
   const headers = new Headers();

--- a/src/worker/routes/orgs.ts
+++ b/src/worker/routes/orgs.ts
@@ -811,6 +811,7 @@ async function assertMember(
       plan: "free",
       polarSubscriptionCancelAtPeriodEnd: false,
       polarSubscriptionCurrentPeriodEnd: null,
+      image: null,
     },
     orgId,
   );

--- a/src/worker/routes/qr-logos.ts
+++ b/src/worker/routes/qr-logos.ts
@@ -92,7 +92,7 @@ qrLogoRoutes.post("/", requireOrgRole("member"), async (c) => {
   const file = `${uid()}.${ext}`;
   const orgId = c.req.param("orgId")!;
   const key = `${orgId}/${file}`;
-  const stored = await putQrLogoIfOrgWritable(c.var.db, c.env.QR_LOGOS, orgId, key, body, type);
+  const stored = await putQrLogoIfOrgWritable(c.var.db, c.env.MEDIA, orgId, key, body, type);
   if (!stored) throw new HTTPException(409, { message: "Organization is being deleted" });
   return c.json({ url: qrLogoUrl(orgId, file) }, 201);
 });
@@ -111,7 +111,7 @@ qrLogoRoutes.get("/:file", async (c) => {
   const role = await orgRole(c.var.db, user, orgId);
   if (!role) throw new HTTPException(404, { message: "Not found" });
 
-  const obj = await c.env.QR_LOGOS.get(`${orgId}/${file}`);
+  const obj = await c.env.MEDIA.get(`${orgId}/${file}`);
   if (!obj) throw new HTTPException(404, { message: "Not found" });
   const headers = new Headers();
   obj.writeHttpMetadata(headers);

--- a/src/worker/session.ts
+++ b/src/worker/session.ts
@@ -41,6 +41,7 @@ export const withSession = createMiddleware<AppEnv>(async (c, next) => {
       polarSubscriptionCurrentPeriodEnd: periodEndOf(
         session.user.polarSubscriptionCurrentPeriodEnd,
       ),
+      image: session.user.image ?? null,
     } satisfies SessionUser);
   }
   await next();

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -345,7 +345,7 @@ export async function deleteR2Prefix(env: Env, prefix: string): Promise<void> {
 
 /* ---------------- user avatars ---------------- */
 
-export const AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+const AVATAR_MAX_BYTES = 2 * 1024 * 1024;
 export const AVATAR_PREFIX = "avatars/";
 const AVATAR_SERVING_PATH = "/api/user/avatar";
 
@@ -354,6 +354,27 @@ const AVATAR_SERVING_PATH = "/api/user/avatar";
  * extension or a secret. */
 export function avatarUrl(): string {
   return AVATAR_SERVING_PATH;
+}
+
+function tryUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a profile-picture URL may be fetched: one of Google's avatar hosts
+ * over https, or the local emulator's host in dev (which serves over http, so
+ * the protocol check is relaxed for it).
+ */
+function avatarHostAllowed(url: URL, env: Env): boolean {
+  const googleHost = /^lh[0-9a-z.-]*\.googleusercontent\.com$/i;
+  const emulatorUrl = env.GOOGLE_EMULATOR_URL ? tryUrl(env.GOOGLE_EMULATOR_URL) : null;
+  const isEmulator = emulatorUrl !== null && url.host === emulatorUrl.host;
+  if (!isEmulator && url.protocol !== "https:") return false;
+  return googleHost.test(url.hostname) || isEmulator;
 }
 
 /**
@@ -370,27 +391,8 @@ export async function storeUserAvatar(
   pictureUrl: string | null | undefined,
 ): Promise<string | null> {
   if (!pictureUrl) return null;
-  let url: URL;
-  try {
-    url = new URL(pictureUrl);
-  } catch {
-    return null;
-  }
-  // Only Google's avatar hosts, or the local emulator's host in dev (which
-  // serves over http, so the protocol check is relaxed for it).
-  const googleHost = /^lh[0-9a-z.-]*\.googleusercontent\.com$/i;
-  const emulatorHost = env.GOOGLE_EMULATOR_URL
-    ? (() => {
-        try {
-          return new URL(env.GOOGLE_EMULATOR_URL).host;
-        } catch {
-          return "";
-        }
-      })()
-    : "";
-  const isEmulator = Boolean(emulatorHost) && url.host === emulatorHost;
-  if (!isEmulator && url.protocol !== "https:") return null;
-  if (!(googleHost.test(url.hostname) || isEmulator)) return null;
+  const url = tryUrl(pictureUrl);
+  if (!url || !avatarHostAllowed(url, env)) return null;
 
   let resp: Response;
   try {

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -337,10 +337,92 @@ async function kvSync(env: Env, db: DB, key: string): Promise<void> {
 /** Delete every R2 object under a prefix, one page at a time. */
 export async function deleteR2Prefix(env: Env, prefix: string): Promise<void> {
   for (;;) {
-    const page = await env.QR_LOGOS.list({ prefix, limit: R2_LIST_LIMIT });
+    const page = await env.MEDIA.list({ prefix, limit: R2_LIST_LIMIT });
     if (!page.objects.length) return;
-    await env.QR_LOGOS.delete(page.objects.map((object) => object.key));
+    await env.MEDIA.delete(page.objects.map((object) => object.key));
   }
+}
+
+/* ---------------- user avatars ---------------- */
+
+export const AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+export const AVATAR_PREFIX = "avatars/";
+const AVATAR_SERVING_PATH = "/api/user/avatar";
+
+/** The serving URL stored in `user.image`. Same for every user: the route
+ * reads the object keyed by the session user, so the URL never embeds an
+ * extension or a secret. */
+export function avatarUrl(): string {
+  return AVATAR_SERVING_PATH;
+}
+
+/**
+ * Download a Google profile picture to R2 and return its serving URL.
+ *
+ * Runs at Google link/re-login time (see better-auth.ts). Only Google's hosts
+ * are accepted, and only raster JPEG/PNG (SVG is a script surface). A picture
+ * that fails any check is skipped rather than throwing, so a bad profile can
+ * never break sign-in. Returns null when nothing was stored.
+ */
+export async function storeUserAvatar(
+  env: Env,
+  userId: string,
+  pictureUrl: string | null | undefined,
+): Promise<string | null> {
+  if (!pictureUrl) return null;
+  let url: URL;
+  try {
+    url = new URL(pictureUrl);
+  } catch {
+    return null;
+  }
+  // Only Google's avatar hosts, or the local emulator's host in dev (which
+  // serves over http, so the protocol check is relaxed for it).
+  const googleHost = /^lh[0-9a-z.-]*\.googleusercontent\.com$/i;
+  const emulatorHost = env.GOOGLE_EMULATOR_URL
+    ? (() => {
+        try {
+          return new URL(env.GOOGLE_EMULATOR_URL).host;
+        } catch {
+          return "";
+        }
+      })()
+    : "";
+  const isEmulator = Boolean(emulatorHost) && url.host === emulatorHost;
+  if (!isEmulator && url.protocol !== "https:") return null;
+  if (!(googleHost.test(url.hostname) || isEmulator)) return null;
+
+  let resp: Response;
+  try {
+    resp = await fetch(pictureUrl);
+  } catch {
+    // A failed download must never break sign-in; the blobatar stays.
+    return null;
+  }
+  if (!resp.ok) return null;
+  const type = (resp.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+  if (type !== "image/jpeg" && type !== "image/png") return null;
+  let body: ArrayBuffer;
+  try {
+    body = await resp.arrayBuffer();
+  } catch {
+    return null;
+  }
+  if (body.byteLength === 0 || body.byteLength > AVATAR_MAX_BYTES) return null;
+
+  try {
+    const key = `${AVATAR_PREFIX}${userId}`;
+    await env.MEDIA.put(key, body, { httpMetadata: { contentType: type } });
+  } catch {
+    return null;
+  }
+  return avatarUrl();
+}
+
+/** Remove a user's avatar bytes (called on account deletion). */
+export async function deleteUserAvatar(env: Env, userId: string): Promise<void> {
+  await env.MEDIA.delete(`${AVATAR_PREFIX}${userId}`);
+  await enqueueStorage(env, [{ op: "r2_delete_prefix", prefix: `${AVATAR_PREFIX}${userId}` }]);
 }
 
 /**
@@ -388,12 +470,16 @@ export async function sweepOrphanQrLogos(env: Env): Promise<number> {
   let cursor: string | undefined;
   let deleted = 0;
   for (;;) {
-    const page = await env.QR_LOGOS.list({ cursor, limit: R2_LIST_LIMIT });
+    const page = await env.MEDIA.list({ cursor, limit: R2_LIST_LIMIT });
     const orphans = page.objects.flatMap((object) =>
-      object.uploaded.getTime() < cutoff && !referenced.has(object.key) ? [object.key] : [],
+      object.uploaded.getTime() < cutoff &&
+      !referenced.has(object.key) &&
+      !object.key.startsWith(AVATAR_PREFIX)
+        ? [object.key]
+        : [],
     );
     if (orphans.length) {
-      await env.QR_LOGOS.delete(orphans);
+      await env.MEDIA.delete(orphans);
       deleted += orphans.length;
     }
     if (!page.truncated) return deleted;
@@ -415,7 +501,7 @@ export async function applyStorageMessage(
       await kvSync(env, db, message.key);
       return;
     case "r2_delete":
-      await env.QR_LOGOS.delete(message.key);
+      await env.MEDIA.delete(message.key);
       return;
     case "r2_delete_prefix":
       await deleteR2Prefix(env, message.prefix);

--- a/tests/e2e/google-signin.pw.ts
+++ b/tests/e2e/google-signin.pw.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+// Drives the Google button. The button only renders when Google is configured
+// (GOOGLE_CLIENT_ID/SECRET in .dev.vars), so when it isn't we skip rather than
+// fail: the gating itself is covered by /api/config.
+test.describe("Google sign-in", () => {
+  test("Continue with Google starts an OAuth session", async ({ page }) => {
+    const cfg = await (await page.request.get("/api/config")).json();
+    if (!cfg.googleEnabled) test.skip(true, "Google sign-in not configured");
+
+    let socialStarted = false;
+    await page.route("**/api/auth/sign-in/social**", async (route) => {
+      socialStarted = true;
+      // Stop the navigation at the worker's redirect so the test ends here.
+      await route.fulfill({ status: 200, body: "" });
+    });
+
+    await page.goto("/login");
+    const button = page.getByRole("button", { name: /Continue with Google/i });
+    await expect(button).toBeVisible();
+
+    await button.click();
+    await expect.poll(() => socialStarted).toBe(true);
+  });
+
+  test("shows the Google button on signup too", async ({ page }) => {
+    const cfg = await (await page.request.get("/api/config")).json();
+    if (!cfg.googleEnabled) test.skip(true, "Google sign-in not configured");
+
+    await page.goto("/signup");
+    await expect(page.getByRole("button", { name: /Continue with Google/i })).toBeVisible();
+  });
+});

--- a/tests/worker/avatars.worker.ts
+++ b/tests/worker/avatars.worker.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import { applyTestMigrations, overrideEnv } from "./support";
+import {
+  AVATAR_PREFIX,
+  avatarUrl,
+  deleteUserAvatar,
+  sweepOrphanQrLogos,
+  storeUserAvatar,
+} from "../../src/worker/storage";
+import { captureStorageQueue } from "./support";
+
+const JPEG = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0]);
+
+describe("storeUserAvatar", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("rejects a non-Google, non-emulator host without fetching", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const got = await storeUserAvatar(env, "user-1", "https://evil.example.com/pic.jpg");
+    expect(got).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-image content type", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { headers: { "content-type": "text/html" } })),
+    );
+    const got = await storeUserAvatar(env, "user-1", "https://lh3.googleusercontent.com/p");
+    expect(got).toBeNull();
+  });
+
+  it("stores a JPEG from Google and returns the serving URL", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JPEG, { headers: { "content-type": "image/jpeg" } })),
+    );
+    const got = await storeUserAvatar(env, "user-1", "https://lh3.googleusercontent.com/p");
+    expect(got).toBe(avatarUrl());
+    const obj = await env.MEDIA.get(`${AVATAR_PREFIX}user-1`);
+    expect(obj).not.toBeNull();
+    expect(obj!.httpMetadata!.contentType).toBe("image/jpeg");
+  });
+
+  it("stores from the emulator host in dev", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JPEG, { headers: { "content-type": "image/jpeg" } })),
+    );
+    const e = overrideEnv({ GOOGLE_EMULATOR_URL: "http://localhost:9999" });
+    const got = await storeUserAvatar(e, "user-2", "http://localhost:9999/avatars/u2");
+    expect(got).toBe(avatarUrl());
+  });
+});
+
+describe("deleteUserAvatar", () => {
+  it("deletes the object and enqueues a prefix delete", async () => {
+    await env.MEDIA.put(`${AVATAR_PREFIX}user-3`, JPEG);
+    const { queue, sent } = captureStorageQueue();
+    const e = overrideEnv({ STORAGE_QUEUE: queue });
+    await deleteUserAvatar(e, "user-3");
+    expect(await env.MEDIA.get(`${AVATAR_PREFIX}user-3`)).toBeNull();
+    expect(sent).toEqual([{ op: "r2_delete_prefix", prefix: `${AVATAR_PREFIX}user-3` }]);
+  });
+});
+
+describe("sweepOrphanQrLogos", () => {
+  beforeEach(applyTestMigrations);
+
+  it("never deletes objects under the avatars/ prefix", async () => {
+    const deleted: string[] = [];
+    // SAFETY: the fake only needs `list` (returns two old objects, one under
+    // avatars/) and `delete` (recorded); sweepOrphanQrLogos touches no other
+    // R2Bucket member, so the proxy is safe to treat as a full R2Bucket.
+    const fakeMedia = new Proxy(env.MEDIA, {
+      get(_target, prop) {
+        if (prop === "list")
+          return async () => ({
+            objects: [
+              { key: `${AVATAR_PREFIX}user-1`, uploaded: new Date(Date.now() - 48 * 3600 * 1000) },
+              { key: "org-1/logo.webp", uploaded: new Date(Date.now() - 48 * 3600 * 1000) },
+            ],
+            truncated: false,
+          });
+        if (prop === "delete")
+          return async (keys: string | string[]) => {
+            deleted.push(...(Array.isArray(keys) ? keys : [keys]));
+          };
+        return undefined;
+      },
+    }) as R2Bucket;
+    const e = overrideEnv({ MEDIA: fakeMedia });
+    const count = await sweepOrphanQrLogos(e);
+    expect(count).toBe(1);
+    expect(deleted).toEqual(["org-1/logo.webp"]);
+  });
+});

--- a/tests/worker/storage.worker.ts
+++ b/tests/worker/storage.worker.ts
@@ -59,7 +59,7 @@ function failingKv(): KVNamespace {
 }
 
 function failingR2(): R2Bucket {
-  return overriding(env.QR_LOGOS, {
+  return overriding(env.MEDIA, {
     delete: async () => {
       throw new Error("injected R2 failure");
     },
@@ -140,20 +140,20 @@ describe("storage queue: consumer retry", () => {
   });
 
   it("retries an R2 delete under outage, then applies it", async () => {
-    await env.QR_LOGOS.put("org-1/logo.webp", "logo");
+    await env.MEDIA.put("org-1/logo.webp", "logo");
     const message = deleteQrLogoMsg("/api/orgs/org-1/qr-logo/logo.webp")!;
 
     const down = batchOf("rdyrct-storage", [message]);
-    await consumeStorageBatch(overrideEnv({ QR_LOGOS: failingR2() }), down.batch);
+    await consumeStorageBatch(overrideEnv({ MEDIA: failingR2() }), down.batch);
     const failed = await getQueueResult(down.batch, down.ctx);
     expect(failed.retryMessages).toHaveLength(1);
-    expect(await env.QR_LOGOS.head("org-1/logo.webp")).not.toBeNull();
+    expect(await env.MEDIA.head("org-1/logo.webp")).not.toBeNull();
 
     const up = batchOf("rdyrct-storage", [message]);
     await consumeStorageBatch(testEnv, up.batch);
     const succeeded = await getQueueResult(up.batch, up.ctx);
     expect(succeeded.explicitAcks).toHaveLength(1);
-    expect(await env.QR_LOGOS.head("org-1/logo.webp")).toBeNull();
+    expect(await env.MEDIA.head("org-1/logo.webp")).toBeNull();
   });
 });
 
@@ -203,7 +203,7 @@ describe("org teardown steps under secondary-store outage", () => {
   it("removes the org from D1 and keeps cleanup durable across an outage", async () => {
     const db = await seedLink();
     await env.LINKS.put("slug:sale", "stale");
-    await env.QR_LOGOS.put("org-1/logo.webp", "logo");
+    await env.MEDIA.put("org-1/logo.webp", "logo");
 
     // Step 1: gather while the org still exists.
     const gathered = await orgDeleteGather(db, "org-1");
@@ -218,17 +218,17 @@ describe("org teardown steps under secondary-store outage", () => {
     await expect(
       deleteKvKeys(overrideEnv({ LINKS: failingKv() }), gathered.kvKeys),
     ).rejects.toThrow("injected KV failure");
-    await expect(deleteR2Prefix(overrideEnv({ QR_LOGOS: failingR2() }), "org-1/")).rejects.toThrow(
+    await expect(deleteR2Prefix(overrideEnv({ MEDIA: failingR2() }), "org-1/")).rejects.toThrow(
       "injected R2 failure",
     );
     expect(await env.LINKS.get("slug:sale")).not.toBeNull();
-    expect(await env.QR_LOGOS.head("org-1/logo.webp")).not.toBeNull();
+    expect(await env.MEDIA.head("org-1/logo.webp")).not.toBeNull();
 
     // Once the stores recover the steps complete and are idempotent.
     await deleteKvKeys(testEnv, gathered.kvKeys);
     await deleteR2Prefix(testEnv, "org-1/");
     expect(await env.LINKS.get("slug:sale")).toBeNull();
-    expect(await env.QR_LOGOS.head("org-1/logo.webp")).toBeNull();
+    expect(await env.MEDIA.head("org-1/logo.webp")).toBeNull();
   });
 });
 
@@ -261,15 +261,15 @@ describe("sweepOrphanQrLogos (#49)", () => {
    * period. R2's `uploaded` is set by the store, so an old object is faked by
    * overriding list() rather than by waiting a day. */
   async function putLogo(key: string) {
-    await env.QR_LOGOS.put(key, new Uint8Array([1, 2, 3]));
+    await env.MEDIA.put(key, new Uint8Array([1, 2, 3]));
   }
 
   /** The sweep only looks at objects older than the grace period, so run it
    * against an R2 whose listing reports every object as a day and a half old. */
   function agedEnv(): Env {
-    const real = env.QR_LOGOS;
+    const real = env.MEDIA;
     const uploaded = new Date(Date.now() - 1.5 * DAY_MS);
-    const QR_LOGOS = overriding(real, {
+    const MEDIA = overriding(real, {
       list: async (options?: R2ListOptions) => {
         const page = await real.list(options);
         return overriding(page, {
@@ -277,11 +277,11 @@ describe("sweepOrphanQrLogos (#49)", () => {
         });
       },
     });
-    return overrideEnv({ QR_LOGOS });
+    return overrideEnv({ MEDIA });
   }
 
   async function keysInBucket() {
-    return (await env.QR_LOGOS.list()).objects.map((o) => o.key).sort();
+    return (await env.MEDIA.list()).objects.map((o) => o.key).sort();
   }
 
   it("deletes an object no row points at, and keeps the one a link uses", async () => {

--- a/tests/worker/teardown-writes.worker.ts
+++ b/tests/worker/teardown-writes.worker.ts
@@ -177,14 +177,14 @@ describe("uploading a QR logo while the org is tearing down", () => {
     expect(
       await putQrLogoIfOrgWritable(
         drizzle(env.DB, { schema }),
-        env.QR_LOGOS,
+        env.MEDIA,
         ORG,
         key,
         new Uint8Array([1, 2, 3]).buffer,
         "image/webp",
       ),
     ).toBe(false);
-    expect(await env.QR_LOGOS.head(key)).toBeNull();
+    expect(await env.MEDIA.head(key)).toBeNull();
   });
 });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -52,7 +52,7 @@
   // Create the real resources with:
   //   wrangler kv namespace create LINKS
   //   wrangler d1 create rdyrct
-  //   wrangler r2 bucket create rdyrct-qr-logos
+  //   wrangler r2 bucket create rdyrct-media
   // then paste the ids below. Local dev works with the placeholders.
   "kv_namespaces": [
     {
@@ -60,11 +60,11 @@
       "id": "aa2cec55f8964d0fba2c23e1e3b5fea1",
     },
   ],
-  // QR logo images; D1 rows store only the serving URL (see
-  // routes/qr-logos.ts).
+  // User-supplied images (QR logos, avatars); D1 rows store only the serving
+  // URL (see routes/qr-logos.ts, routes/avatars.ts).
   "r2_buckets": [
     {
-      "binding": "QR_LOGOS",
+      "binding": "MEDIA",
       "bucket_name": "rdyrct-qr-logos",
     },
   ],
@@ -331,7 +331,7 @@
       ],
       "r2_buckets": [
         {
-          "binding": "QR_LOGOS",
+          "binding": "MEDIA",
           "bucket_name": "rdyrct-playwright-local",
         },
       ],


### PR DESCRIPTION
## Summary

Implements three linked issues on one branch:

- **#196** Rename the QR-logos R2 binding to `MEDIA` and point it at the same bucket. No copy/migration; serving URL math is unchanged.
- **#194** Google sign-in via the `genericOAuth` plugin with `accountLinking` (trusted provider `google`), so a Google sign-in joins an existing email/password account. The "Continue with Google" button is gated on a new `googleEnabled` flag from `/api/config`. Configurable in dev via the `emulate.dev` OAuth emulator.
- **#195** A Google profile picture is downloaded to R2 on link/re-login and served same-origin from `/api/user/avatar` (CSP-safe). When a user has no image, the app shell shows a generated blobatar. Avatars are removed on account deletion and excluded from the QR-logo orphan sweep.

## Test plan

- `bun run verify` is green (format, lint incl. anti-slop, app + both worker tsc projects, unit + worker tests — 414 passing).
- New `tests/worker/avatars.worker.ts` (6 tests): avatar host/type validation, emulator-host storage, deletion enqueue, and the orphan-sweep `avatars/` skip.
- New `tests/e2e/google-signin.pw.ts`: asserts the button shows on login/signup (when configured) and that clicking starts a Google OAuth session.
- Full e2e + CI runs on this PR.

## Notes

- Local dev Google creds are not committed; `.dev.vars.example` documents the vars and `.dev.vars.playwright` carries emulator values so the browser suite can exercise the button.
- Pre-existing unrelated changes on `main` were stashed (`stash@{0}`) and are not part of this branch.