### PR TITLE
List Google OAuth secrets in prod.secrets.env.example (#205)

### DIFF
--- a/prod.secrets.env.example
+++ b/prod.secrets.env.example
@@ -34,3 +34,12 @@ CF_API_TOKEN=
 # Leave unset and the check is skipped entirely, so this is the one thing
 # standing between the signup form and a bot.
 CAP_SECRET=
+
+# Google sign-in (#194). Create an OAuth 2.0 client at
+# console.cloud.google.com → APIs & Services → Credentials, with authorized
+# redirect URI https://rdyrct.com/api/auth/callback/google.
+# Leave both blank and the "Continue with Google" button never shows.
+# GOOGLE_EMULATOR_URL stays unset in prod (dev-only); the worker then uses
+# Google's discovery URL.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=


### PR DESCRIPTION
Google sign-in shipped in #198, but `prod.secrets.env.example` never named `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`, so the `wrangler secret bulk` run set nothing and the "Continue with Google" button stays dark on rdyrct.com.

Adds both, with a comment pointing at the Google Cloud console and the prod redirect URI. `GOOGLE_EMULATOR_URL` stays dev-only and unset in prod.

Docs only, no code.

Closes #205 once the prod secrets are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guidance for Google OAuth credentials in production.
  * Documented that leaving the credentials blank hides the “Continue with Google” option.
  * Clarified that production uses Google’s standard discovery service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->