### PR TITLE
Display name, account menu, blobatar, last-used sign-in badge

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -41,11 +41,12 @@ BLOG_ORIGIN_URL=http://localhost:3000
 # which needs no browser to prove it.
 CAP_SECRET=dev-only-cap-secret-not-a-real-one-0000000000000000
 
-# Google sign-in. Leave blank to disable the "Continue with Google" button.
-# For local dev, point GOOGLE_EMULATOR_URL at an OAuth emulator
-# (e.g. https://www.emulate.dev/mock/oauth2) and set the client id/secret it
-# provides. In production, leave GOOGLE_EMULATOR_URL blank and set the real
-# Google OAuth client id/secret; the worker then uses Google's discovery URL.
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-GOOGLE_EMULATOR_URL=
+# Google sign-in. Leave all three blank to hide the "Continue with Google"
+# button. For local dev, `bun run dev` starts the emulate google service
+# behind portless at https://google.emulate.localhost, so the values below
+# work as-is (the client id/secret are arbitrary, the emulator accepts any).
+# In production, leave GOOGLE_EMULATOR_URL blank and set the real Google
+# OAuth client id/secret; the worker then uses Google's discovery URL.
+GOOGLE_CLIENT_ID=test-client
+GOOGLE_CLIENT_SECRET=test-secret
+GOOGLE_EMULATOR_URL=https://google.emulate.localhost

--- a/.dev.vars.playwright
+++ b/.dev.vars.playwright
@@ -25,7 +25,8 @@ CF_DEV_ENV=instant
 # running the disabled path while looking like it covers the real one.
 CAP_SECRET=playwright-only-cap-secret-32-chars-min
 
-# Google sign-in (emulate.dev OAuth emulator) for the browser suite.
-GOOGLE_CLIENT_ID=emulate-dev-google-client-id
-GOOGLE_CLIENT_SECRET=emulate-dev-google-client-secret
-GOOGLE_EMULATOR_URL=https://www.emulate.dev/mock/oauth2
+# Google sign-in. The local emulate google service, started by the resend
+# webServer in playwright.config.ts (resend on 4000, google on 4001).
+GOOGLE_CLIENT_ID=test-client
+GOOGLE_CLIENT_SECRET=test-secret
+GOOGLE_EMULATOR_URL=http://localhost:4001

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Always use **bun**, never npm/npx.
 
 ```sh
 bun install
-bun run dev                 # vite dev (Worker + SPA) via portless: https://rdyrct.localhost
+bun run dev                 # vite dev (Worker + SPA) via portless: https://rdyrct.localhost, plus the Google OAuth emulator at https://google.emulate.localhost
 bun run mail                # local Resend inbox via portless: https://mail.rdyrct.localhost (read: curl https://mail.rdyrct.localhost/emails -H 'authorization: Bearer test_token_admin')
 bun run db:migrate:local    # apply migrations to local D1
 bun run db:reset:local      # wipe local D1 + KV, re-apply migrations (start from scratch; restart dev after)

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@tanstack/react-query": "^5.102.0",
         "@tanstack/react-router": "^1.170.31",
         "better-auth": "^1.7.1",
+        "blobatar": "^2.5.0",
         "browser-image-compression": "^2.0.2",
         "canvas-confetti": "^1.9.4",
         "capjs-core": "0.1.2",
@@ -838,6 +839,8 @@
     "better-call": ["better-call@1.4.0", "", { "dependencies": { "@better-auth/utils": "^0.5.0", "@better-fetch/fetch": "^1.3.1", "rou3": "^0.9.1", "set-cookie-parser": "^3.1.2" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "blobatar": ["blobatar@2.5.0", "", { "peerDependencies": { "react": ">=18", "vue": ">=3" }, "optionalPeers": ["react", "vue"] }, "sha512-fVFzNgElUbqiLt8NLWYPRg7ljbOPP2/L+8hW6wdVntULNaTnQjlsy1FPr2JTux/Sckpfmc1misXWt+6CL3xXqg=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -135,7 +135,7 @@
     },
     "src/app/routes/settings.tsx": {
       "crap_moderate": {
-        "count": 1
+        "count": 2
       }
     },
     "src/app/ui/dialog.tsx": {
@@ -170,6 +170,11 @@
     },
     "src/worker/storage.ts": {
       "crap_moderate": {
+        "count": 1
+      }
+    },
+    "src/app/routes/organization.tsx": {
+      "crap_high": {
         "count": 1
       }
     }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@tanstack/react-query": "^5.102.0",
     "@tanstack/react-router": "^1.170.31",
     "better-auth": "^1.7.1",
+    "blobatar": "^2.5.0",
     "browser-image-compression": "^2.0.2",
     "canvas-confetti": "^1.9.4",
     "capjs-core": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "dev": "portless rdyrct vite dev",
+    "dev": "trap 'kill 0' INT TERM; portless rdyrct vite dev & bun run mail & bunx emulate start --service google --portless --port 4001 & wait",
     "mail": "portless mail.rdyrct bunx emulate --service resend",
     "polar:listen": "NODE_EXTRA_CA_CERTS=\"$HOME/.portless/ca.pem\" polar listen https://rdyrct.localhost/api/webhooks/polar",
     "build": "vite build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,7 +55,9 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: "bunx emulate --service resend",
+      // resend on 4000, google OAuth on 4001 (see GOOGLE_EMULATOR_URL in
+      // .dev.vars.playwright). One process, so one webServer entry.
+      command: "bunx emulate --service resend,google",
       url: "http://127.0.0.1:4000/emails",
       reuseExistingServer: !process.env.CI,
       gracefulShutdown: { signal: "SIGTERM", timeout: 500 },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -20,6 +20,7 @@ Disallow: /dashboard
 Disallow: /analytics
 Disallow: /links
 Disallow: /members
+Disallow: /organization
 Disallow: /billing
 Disallow: /domains
 Disallow: /settings

--- a/scripts/seed-local.ts
+++ b/scripts/seed-local.ts
@@ -492,7 +492,7 @@ async function seed() {
   });
   const accountRows = users.map(
     (u) =>
-      `(${q(`seed-acc-${u.id.slice(5)}`)}, ${q(u.id)}, 'credential', ${q(u.id)}, ${q(passwordHash)}, ${u.createdAt}, ${u.createdAt})`,
+      `(${q(`seed-acc-${u.id.slice(5)}`)}, ${q(u.id)}, 'local:credential', 'credential', ${q(u.id)}, ${q(passwordHash)}, ${u.createdAt}, ${u.createdAt})`,
   );
   await sqlBatch([
     `INSERT INTO user (id, name, email, email_verified, plan, subscription_plan,
@@ -500,7 +500,7 @@ async function seed() {
        polar_subscription_cancel_at_period_end,
        comp_plan, comp_reason, comp_granted_at, created_at, updated_at)
      VALUES ${userRows.join(",")}`,
-    `INSERT INTO account (id, account_id, provider_id, user_id, password, created_at, updated_at) VALUES ${accountRows.join(",")}`,
+    `INSERT INTO account (id, account_id, issuer, provider_id, user_id, password, created_at, updated_at) VALUES ${accountRows.join(",")}`,
   ]);
 
   /* orgs + members */

--- a/src/app/components/nav-items.ts
+++ b/src/app/components/nav-items.ts
@@ -1,4 +1,5 @@
 import {
+  Building2,
   ChartColumn,
   CreditCard,
   LayoutDashboard,
@@ -16,6 +17,7 @@ export const appNavItems = [
   { to: "/links", icon: Link2, label: "Links" },
   { to: "/domains", icon: WorldWww, label: "Domains" },
   { to: "/members", icon: Users, label: "Members" },
+  { to: "/organization", icon: Building2, label: "Organization" },
   { to: "/billing", icon: CreditCard, label: "Billing" },
   { to: "/settings", icon: Settings, label: "Settings" },
 ] as const;

--- a/src/app/components/skeletons.tsx
+++ b/src/app/components/skeletons.tsx
@@ -510,31 +510,68 @@ export function BillingSkeleton() {
   );
 }
 
-/**
- * /settings: header over the stack of cards (organization name, QR defaults,
- * then the account and danger-zone blocks).
- */
+/** One danger-zone card: the label, a two-line blurb, and a button. */
+function DangerCardSkeleton() {
+  return (
+    <Card className="max-w-2xl">
+      <Skeleton className="h-2.5 w-24" />
+      <div className="mt-4">
+        <Skeleton className="h-3 w-full max-w-md" />
+        <Skeleton className="mt-2 h-3 w-3/5" />
+        <Skeleton className="mt-4 h-9 w-40" />
+      </div>
+    </Card>
+  );
+}
+
+/** /settings: the account card (name, email, save, dark-mode row) and the
+ * delete-account danger card. */
 export function SettingsSkeleton() {
   return (
     <SkeletonStatus testId="settings-page-skeleton">
       <HeaderSkeleton />
-      {/* the three cards, at the heights they measure: the name form (216),
-          the QR defaults with its preview (656), and the danger zone (270) */}
       <div className="flex flex-col gap-4">
         <Card className="max-w-2xl">
-          <Skeleton className="h-2.5 w-32" />
-          <div className="mt-5">
-            <Skeleton className="h-2.5 w-24" />
-            <Skeleton className="mt-2 h-9 w-full max-w-sm" />
+          {[0, 1].map((i) => (
+            <div key={i} className={i === 0 ? "" : "mt-4"}>
+              <Skeleton className="h-2.5 w-24" />
+              <Skeleton className="mt-2 h-9 w-full" />
+            </div>
+          ))}
+          <Skeleton className="mt-4 h-9 w-24" />
+          <div className="mt-4 border-t border-border pt-4">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-5 w-9 rounded-full" />
+            </div>
           </div>
-          <Skeleton className="mt-5 h-9 w-32" />
-          <Skeleton className="mt-5 h-3 w-56" />
+        </Card>
+        <DangerCardSkeleton />
+      </div>
+    </SkeletonStatus>
+  );
+}
+
+/** /organization: the name/id card, the QR defaults card, and the
+ * delete-organization danger card. */
+export function OrganizationSkeleton() {
+  return (
+    <SkeletonStatus testId="organization-page-skeleton">
+      <HeaderSkeleton />
+      <div className="flex flex-col gap-4">
+        <Card className="max-w-2xl">
+          {[0, 1].map((i) => (
+            <div key={i} className={i === 0 ? "" : "mt-4"}>
+              <Skeleton className="h-2.5 w-32" />
+              <Skeleton className="mt-2 h-9 w-full" />
+            </div>
+          ))}
+          <Skeleton className="mt-4 h-9 w-24" />
         </Card>
         {/* QR defaults, 656: the label pair beside the 160x185 preview, then
             the colour, background and logo fields full width under them, then
             the save button. */}
         <Card className="max-w-2xl">
-          {/* the card's own label (17) and its note (16) */}
           <span className="flex h-[17px] items-center">
             <Skeleton className="h-2.5 w-32" />
           </span>
@@ -573,16 +610,7 @@ export function SettingsSkeleton() {
           </div>
           <Skeleton className="mt-5 h-9 w-full" />
         </Card>
-        <Card className="max-w-2xl">
-          <Skeleton className="h-2.5 w-24" />
-          {[0, 1].map((i) => (
-            <div key={i} className="mt-6">
-              <Skeleton className="h-3 w-full max-w-md" />
-              <Skeleton className="mt-2 h-3 w-3/5" />
-              <Skeleton className="mt-4 h-9 w-40" />
-            </div>
-          ))}
-        </Card>
+        <DangerCardSkeleton />
       </div>
     </SkeletonStatus>
   );
@@ -618,6 +646,7 @@ const PAGE_SKELETONS = {
   "/domains": DomainsPageSkeleton,
   "/billing": BillingSkeleton,
   "/settings": SettingsSkeleton,
+  "/organization": OrganizationSkeleton,
   "/admin": AdminUsageSkeleton,
 } satisfies Record<string, () => ReactElement>;
 

--- a/src/app/components/user-avatar.tsx
+++ b/src/app/components/user-avatar.tsx
@@ -1,3 +1,4 @@
+import { blobatar } from "blobatar";
 import { cn } from "@/app/ui/cn";
 
 type AvatarUser = {
@@ -7,61 +8,12 @@ type AvatarUser = {
   email?: string;
 };
 
-/** Deterministic blobatar for users with no uploaded image: the same person
- * always gets the same colours and shape, derived from their id. */
-function hash(str: string): number {
-  let h = 2166136261;
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i);
-    h = Math.imul(h, 16777619);
-  }
-  return h >>> 0;
-}
-
-function initials(user: AvatarUser): string {
-  const source = user.name?.trim() || user.email?.trim() || "";
-  const parts = source.split(/\s+/).filter(Boolean);
-  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
-  return source.slice(0, 2).toUpperCase();
-}
-
-function Blobatar({ user, size }: { user: AvatarUser; size: number }) {
-  const h = hash(user.id);
-  const hue = h % 360;
-  const hue2 = (hue + 40 + ((h >> 8) % 80)) % 360;
-  const angle = h % 360;
-  const letter = initials(user);
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 100 100"
-      role="img"
-      aria-label={user.name || user.email || "avatar"}
-      className="shrink-0 rounded-full"
-    >
-      <defs>
-        <linearGradient id={`bg-${user.id}`} gradientTransform={`rotate(${angle} 0.5 0.5)`}>
-          <stop offset="0%" stopColor={`hsl(${hue} 70% 55%)`} />
-          <stop offset="100%" stopColor={`hsl(${hue2} 70% 45%)`} />
-        </linearGradient>
-      </defs>
-      <rect width="100" height="100" fill={`url(#bg-${user.id})`} />
-      <text
-        x="50"
-        y="50"
-        dy="0.35em"
-        textAnchor="middle"
-        fontSize="42"
-        fontWeight="600"
-        fill="white"
-        fillOpacity="0.92"
-        fontFamily="JetBrains Mono, monospace"
-      >
-        {letter}
-      </text>
-    </svg>
-  );
+/** Deterministic blobatar (blobatar.dev) for users with no uploaded image:
+ * the same id always renders the same creature. Seeded on the id, not the
+ * name, so a rename keeps the same face. */
+function blobatarDataUri(user: AvatarUser): string {
+  const svg = blobatar(user.id, { title: user.name || user.email || "avatar" });
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
 export function UserAvatar({
@@ -73,15 +25,14 @@ export function UserAvatar({
   size?: number;
   className?: string;
 }) {
-  if (user.image)
-    return (
-      <img
-        src={user.image}
-        alt={user.name || user.email || "avatar"}
-        width={size}
-        height={size}
-        className={cn("shrink-0 rounded-full object-cover", className)}
-      />
-    );
-  return <Blobatar user={user} size={size} />;
+  const src = user.image ?? blobatarDataUri(user);
+  return (
+    <img
+      src={src}
+      alt={user.name || user.email || "avatar"}
+      width={size}
+      height={size}
+      className={cn("shrink-0 rounded-full object-cover", className)}
+    />
+  );
 }

--- a/src/app/lib/hooks.ts
+++ b/src/app/lib/hooks.ts
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tansta
 import { api, ApiError } from "./api";
 import { authClient } from "./auth-client";
 import { readCachedUser, writeCachedUser } from "./user-cache";
+import { lastAuth, setLastAuth } from "./last-auth";
 import posthog from "./posthog";
 import { FUNNEL } from "./funnel";
 import type {
@@ -51,6 +52,11 @@ export function useCurrentUser(enabled = true) {
           plan: user.user.plan,
           is_admin: user.user.isAdmin,
         });
+        // Backfill the Google address once the OAuth round trip lands, so a
+        // later visit to /login can offer "continue as <email>".
+        if (lastAuth()?.method === "google" && lastAuth()?.email !== user.user.email) {
+          setLastAuth("google", user.user.email);
+        }
         return user;
       } catch (e) {
         if (e instanceof ApiError && e.status === 401) {

--- a/src/app/lib/last-auth.ts
+++ b/src/app/lib/last-auth.ts
@@ -1,0 +1,25 @@
+/**
+ * Which sign-in method this browser used last, so the login and signup pages
+ * can point a returning visitor at the same one. A convenience hint, kept in
+ * localStorage: a wrong or missing value only costs one extra glance.
+ */
+export type AuthMethod = "google" | "password";
+
+const KEY = "lastAuthMethod";
+
+export function setLastAuthMethod(method: AuthMethod): void {
+  try {
+    localStorage.setItem(KEY, method);
+  } catch {
+    // private mode or storage disabled: the hint is optional.
+  }
+}
+
+export function lastAuthMethod(): AuthMethod | null {
+  try {
+    const v = localStorage.getItem(KEY);
+    return v === "google" || v === "password" ? v : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/app/lib/last-auth.ts
+++ b/src/app/lib/last-auth.ts
@@ -1,24 +1,43 @@
 /**
- * Which sign-in method this browser used last, so the login and signup pages
- * can point a returning visitor at the same one. A convenience hint, kept in
- * localStorage: a wrong or missing value only costs one extra glance.
+ * Which sign-in method this browser used last, and (for Google) which
+ * account, so the login and signup pages can offer a one-click "continue as
+ * you". A convenience hint kept in localStorage: a wrong or missing value
+ * only costs one extra click.
  */
+import * as v from "valibot";
+
 export type AuthMethod = "google" | "password";
 
-const KEY = "lastAuthMethod";
+const KEY = "rdyrct:last-auth:v1";
 
-export function setLastAuthMethod(method: AuthMethod): void {
+const schema = v.object({
+  method: v.picklist(["google", "password"]),
+  email: v.optional(v.string()),
+});
+
+export type LastAuth = v.InferOutput<typeof schema>;
+
+/**
+ * Record the method, and the email when we have it. Called with just the
+ * method (e.g. before the Google redirect, when the address isn't known
+ * yet) it keeps whatever email was stored for that method.
+ */
+export function setLastAuth(method: AuthMethod, email?: string): void {
   try {
-    localStorage.setItem(KEY, method);
+    const prev = lastAuth();
+    const kept = email ?? (prev?.method === method ? prev.email : undefined);
+    localStorage.setItem(KEY, JSON.stringify(kept ? { method, email: kept } : { method }));
   } catch {
     // private mode or storage disabled: the hint is optional.
   }
 }
 
-export function lastAuthMethod(): AuthMethod | null {
+export function lastAuth(): LastAuth | null {
   try {
-    const v = localStorage.getItem(KEY);
-    return v === "google" || v === "password" ? v : null;
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = v.safeParse(schema, JSON.parse(raw));
+    return parsed.success ? parsed.output : null;
   } catch {
     return null;
   }

--- a/src/app/lib/schemas.ts
+++ b/src/app/lib/schemas.ts
@@ -14,6 +14,17 @@ export const orgNameSchema = v.object({
   ),
 });
 
+/** Your own display name. Shown in the sidebar and used for the blobatar
+ * initials. Same shape as an org name: something typed, 100 chars or fewer. */
+export const accountNameSchema = v.object({
+  name: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, "Enter your name"),
+    v.maxLength(100, "Name must be 100 characters or fewer"),
+  ),
+});
+
 const tryUrl = (val: string) => v.is(v.pipe(v.string(), v.url()), val);
 
 const destinationField = v.pipe(

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -77,6 +77,9 @@ const DomainsPage = lazy(() =>
 const SettingsPage = lazy(() =>
   import("./routes/settings").then((m) => ({ default: m.SettingsPage })),
 );
+const OrganizationPage = lazy(() =>
+  import("./routes/organization").then((m) => ({ default: m.OrganizationPage })),
+);
 const AdminUsagePage = lazy(() =>
   import("./routes/admin/usage").then((m) => ({
     default: m.AdminUsagePage,
@@ -293,6 +296,11 @@ const settingsRoute = createRoute({
   path: "/settings",
   component: SettingsPage,
 });
+const organizationRoute = createRoute({
+  getParentRoute: () => appShellRoute,
+  path: "/organization",
+  component: OrganizationPage,
+});
 
 // One guard for the whole section, and one place for its sub-navigation.
 // Four separate RequireAdmin routes was four chances to forget one, and one
@@ -355,6 +363,7 @@ const routeTree = rootRoute.addChildren([
     billingRoute,
     domainsRoute,
     settingsRoute,
+    organizationRoute,
     adminRoute.addChildren([
       adminUsageRoute,
       adminLinksRoute,

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -510,7 +510,10 @@ interface VerifyDeps {
  * hand. Returns false when it already handled navigation itself. */
 async function establishSessionAfterVerify(deps: VerifyDeps): Promise<boolean> {
   const sess = await authClient.getSession();
-  if (sess?.data) return true;
+  if (sess?.data) {
+    setLastAuth("password", deps.authEmail);
+    return true;
+  }
   if (!deps.authPassword) {
     clearPending();
     deps.toast("Email verified. Sign in to continue.");
@@ -525,6 +528,7 @@ async function establishSessionAfterVerify(deps: VerifyDeps): Promise<boolean> {
     deps.toast(friendlyAuthError(signInError), "error");
     return false;
   }
+  setLastAuth("password", deps.authEmail);
   return true;
 }
 

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -4,7 +4,7 @@ import { valibotResolver } from "@hookform/resolvers/valibot";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useSearchParams, HrefLink } from "../lib/router-search";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
-import { Check } from "@/app/ui/icons";
+import { ArrowRight, Check } from "@/app/ui/icons";
 import { AuthCard, PasswordMeter } from "../components/auth-form";
 import { authClient } from "../lib/auth-client";
 import { friendlyAuthError } from "../lib/auth-errors";
@@ -14,11 +14,10 @@ import { useShake } from "../lib/use-shake";
 import { useCap } from "../lib/cap";
 import { useCurrentUser, useConfig } from "../lib/hooks";
 import { storedAnonLinks } from "../lib/anon-links";
-import { lastAuthMethod, setLastAuthMethod } from "../lib/last-auth";
+import { lastAuth, setLastAuth } from "../lib/last-auth";
 import { firstFormError } from "../lib/form-errors";
 import { cn } from "../ui/cn";
 import { Button } from "../ui/button";
-import { Badge } from "../ui/misc";
 import { Field, Input } from "../ui/field";
 import { OtpInput } from "../ui/otp";
 import { BusyContent } from "../ui/spinner";
@@ -245,6 +244,41 @@ function PasswordHint({
   return <PasswordMeter password={password} />;
 }
 
+/**
+ * The Google sign-in control. A plain button by default; when this browser
+ * last signed in with Google and we kept the address, it becomes a
+ * one-click "continue as you@…" row instead.
+ */
+function GoogleEntry({ email, onClick }: { email?: string; onClick: () => void }) {
+  if (!email) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex items-center justify-center gap-2 rounded-lg border border-border bg-surface py-2.5 text-sm font-medium transition-colors hover:bg-surface-2"
+      >
+        <GoogleG />
+        Continue with Google
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Continue as ${email}`}
+      className="flex items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2.5 text-sm transition-colors hover:bg-surface-2"
+    >
+      <GoogleG />
+      <span className="min-w-0 flex-1 truncate text-left font-medium">{email}</span>
+      <span className="shrink-0 rounded-full bg-accent/10 px-2 py-0.5 text-2xs font-medium text-accent">
+        Last used
+      </span>
+      <ArrowRight size={16} className="shrink-0 text-muted" />
+    </button>
+  );
+}
+
 /** Inline Google "G" mark (no remote image, CSP-safe). */
 function GoogleG() {
   return (
@@ -292,15 +326,15 @@ function AuthFormView({
   const toast = useToast();
   const config = useConfig();
   // Read once on mount: a returning visitor who last signed in with Google
-  // gets that button flagged.
-  const [googleLastUsed] = useState(() => lastAuthMethod() === "google");
+  // gets a one-click "continue as you" row.
+  const [lastUsed] = useState(lastAuth);
   const { register, handleSubmit, watch, getValues } = useForm<AuthForm>({
     resolver: valibotResolver(copy.schema),
     defaultValues: { email: "", password: "" },
   });
 
   const startGoogle = () => {
-    setLastAuthMethod("google");
+    setLastAuth("google");
     posthog.capture("user_google_signin_started");
     // Full-page redirect to Google; returns to /api/auth/callback/google, then
     // to `next`. Same flow on login and signup (account linking handles an
@@ -329,19 +363,10 @@ function AuthFormView({
         {mode === "signup" && <SignupSubtitle next={next} />}
         {config.data?.googleEnabled && (
           <>
-            <button
-              type="button"
+            <GoogleEntry
+              email={lastUsed?.method === "google" ? lastUsed.email : undefined}
               onClick={startGoogle}
-              className="flex items-center justify-center gap-2 rounded-lg border border-border bg-surface py-2.5 text-sm font-medium transition-colors hover:bg-surface-2"
-            >
-              <GoogleG />
-              Continue with Google
-              {googleLastUsed && (
-                <Badge color="accent" className="ml-1">
-                  Last used
-                </Badge>
-              )}
-            </button>
+            />
             <div className="flex items-center gap-3 text-xs text-muted">
               <span className="h-px flex-1 bg-border" />
               or
@@ -434,7 +459,7 @@ interface SubmitDeps {
 async function trySignIn(email: string, password: string, deps: SubmitDeps) {
   const { error: signInError } = await authClient.signIn.email({ email, password });
   if (!signInError) {
-    setLastAuthMethod("password");
+    setLastAuth("password", email);
     await deps.qc.refetchQueries({ queryKey: ["user"] });
     const isAdmin = deps.qc.getQueryData<CurrentUser | null>(["user"])?.user.isAdmin ?? false;
     posthog.capture("user_signed_in");

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -211,22 +211,18 @@ const AUTH_MODE_COPY = {
 };
 
 /**
- * One line under "Create an account", saying what happens next.
- *
- * The card used to render identically whether somebody arrived cold, clicked
- * "Start Pro", or clicked "Keep this link" with a link waiting to be claimed:
- * every reassurance the landing page built was dropped at the door. It also
- * never mentioned the emailed code, which is the step people abandon.
- *
- * Nothing under "Sign in". Somebody who already has an account does not need
- * to be sold the plan.
+ * One line under "Create an account", only when the visitor arrived with
+ * context to carry through: a link waiting to be claimed, or a checkout
+ * they were mid-way into. A cold visitor gets nothing, and neither does
+ * "Sign in": somebody who already has an account does not need a pitch.
  */
 function SignupSubtitle({ next }: { next: string }) {
   const body = storedAnonLinks().length
     ? "Your link is waiting. Sign up and it becomes permanent, with the clicks it earns."
     : next.startsWith("/billing")
       ? "Create your account, then check out. No card needed to create the account."
-      : "Free plan, no credit card. We'll email you a 6-digit code to confirm your address.";
+      : null;
+  if (!body) return null;
   return <p className="-mt-2 text-xs text-muted">{body}</p>;
 }
 
@@ -331,6 +327,28 @@ function AuthFormView({
       >
         <h1 className="font-bold">{copy.title}</h1>
         {mode === "signup" && <SignupSubtitle next={next} />}
+        {config.data?.googleEnabled && (
+          <>
+            <button
+              type="button"
+              onClick={startGoogle}
+              className="flex items-center justify-center gap-2 rounded-lg border border-border bg-surface py-2.5 text-sm font-medium transition-colors hover:bg-surface-2"
+            >
+              <GoogleG />
+              Continue with Google
+              {googleLastUsed && (
+                <Badge color="accent" className="ml-1">
+                  Last used
+                </Badge>
+              )}
+            </button>
+            <div className="flex items-center gap-3 text-xs text-muted">
+              <span className="h-px flex-1 bg-border" />
+              or
+              <span className="h-px flex-1 bg-border" />
+            </div>
+          </>
+        )}
         <Field label="Email">
           <Input type="email" {...register("email")} required autoComplete="email" />
         </Field>
@@ -360,28 +378,6 @@ function AuthFormView({
         >
           <BusyContent busy={busy}>{copy.submitLabel}</BusyContent>
         </Button>
-        {config.data?.googleEnabled && (
-          <>
-            <div className="flex items-center gap-3 text-xs text-muted">
-              <span className="h-px flex-1 bg-border" />
-              or
-              <span className="h-px flex-1 bg-border" />
-            </div>
-            <button
-              type="button"
-              onClick={startGoogle}
-              className="flex items-center justify-center gap-2 rounded-lg border border-border bg-surface py-2.5 text-sm font-medium transition-colors hover:bg-surface-2"
-            >
-              <GoogleG />
-              Continue with Google
-              {googleLastUsed && (
-                <Badge color="accent" className="ml-1">
-                  Last used
-                </Badge>
-              )}
-            </button>
-          </>
-        )}
         <p className="text-center text-xs text-muted">
           {copy.footerPrompt}{" "}
           <HrefLink href={`${copy.footerTo}?next=${encodeURIComponent(next)}`}>

--- a/src/app/routes/auth.tsx
+++ b/src/app/routes/auth.tsx
@@ -14,9 +14,11 @@ import { useShake } from "../lib/use-shake";
 import { useCap } from "../lib/cap";
 import { useCurrentUser, useConfig } from "../lib/hooks";
 import { storedAnonLinks } from "../lib/anon-links";
+import { lastAuthMethod, setLastAuthMethod } from "../lib/last-auth";
 import { firstFormError } from "../lib/form-errors";
 import { cn } from "../ui/cn";
 import { Button } from "../ui/button";
+import { Badge } from "../ui/misc";
 import { Field, Input } from "../ui/field";
 import { OtpInput } from "../ui/otp";
 import { BusyContent } from "../ui/spinner";
@@ -293,12 +295,16 @@ function AuthFormView({
   const copy = AUTH_MODE_COPY[mode];
   const toast = useToast();
   const config = useConfig();
+  // Read once on mount: a returning visitor who last signed in with Google
+  // gets that button flagged.
+  const [googleLastUsed] = useState(() => lastAuthMethod() === "google");
   const { register, handleSubmit, watch, getValues } = useForm<AuthForm>({
     resolver: valibotResolver(copy.schema),
     defaultValues: { email: "", password: "" },
   });
 
   const startGoogle = () => {
+    setLastAuthMethod("google");
     posthog.capture("user_google_signin_started");
     // Full-page redirect to Google; returns to /api/auth/callback/google, then
     // to `next`. Same flow on login and signup (account linking handles an
@@ -368,6 +374,11 @@ function AuthFormView({
             >
               <GoogleG />
               Continue with Google
+              {googleLastUsed && (
+                <Badge color="accent" className="ml-1">
+                  Last used
+                </Badge>
+              )}
             </button>
           </>
         )}
@@ -427,6 +438,7 @@ interface SubmitDeps {
 async function trySignIn(email: string, password: string, deps: SubmitDeps) {
   const { error: signInError } = await authClient.signIn.email({ email, password });
   if (!signInError) {
+    setLastAuthMethod("password");
     await deps.qc.refetchQueries({ queryKey: ["user"] });
     const isAdmin = deps.qc.getQueryData<CurrentUser | null>(["user"])?.user.isAdmin ?? false;
     posthog.capture("user_signed_in");

--- a/src/app/routes/organization.tsx
+++ b/src/app/routes/organization.tsx
@@ -1,0 +1,253 @@
+import { useState, useEffect, useRef } from "react";
+import { errorMessage } from "@/app/lib/error-message";
+import { useForm } from "react-hook-form";
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCurrentUser } from "../lib/hooks";
+import { useCurrentOrg } from "../lib/current-org";
+import { api } from "../lib/api";
+import type { OrgRole, UserOrg } from "@/shared/types";
+import { Button } from "../ui/button";
+import { Field, Input } from "../ui/field";
+import { Card, PageHeader } from "../ui/misc";
+import { BusyContent } from "../ui/spinner";
+import { useToast } from "../ui/toast";
+import { CopyButton } from "../ui/copy-button";
+import { ConfirmDialog } from "../ui/confirm-dialog";
+import { copyToClipboard } from "../lib/clipboard";
+import { QrDefaultsCard } from "../components/qr-defaults-card";
+import { NoOrgState } from "../components/no-org";
+import { OrganizationSkeleton } from "../components/skeletons";
+import { orgNameSchema } from "../lib/schemas";
+import posthog from "../lib/posthog";
+
+type OrgNameForm = { name: string };
+
+function isOrgOwner(isPlatformAdmin: boolean, role: OrgRole | undefined): boolean {
+  return isPlatformAdmin || role === "owner";
+}
+
+/** The org-name field: syncs its default value when the current org
+ * changes, and saves via PATCH. */
+function useOrgRenameForm(org: UserOrg | null) {
+  const qc = useQueryClient();
+  const toast = useToast();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { isSubmitting },
+  } = useForm<OrgNameForm>({
+    resolver: valibotResolver(orgNameSchema),
+    defaultValues: { name: "" },
+  });
+  const resetOrgId = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!org) {
+      resetOrgId.current = undefined;
+      return;
+    }
+    if (resetOrgId.current === org.id) return;
+    resetOrgId.current = org.id;
+    reset({ name: org.name });
+  }, [org, reset]);
+
+  const currentName = watch("name");
+
+  const rename = handleSubmit(
+    async (data) => {
+      try {
+        await api(`/orgs/${org?.id ?? ""}`, { method: "PATCH", body: { name: data.name } });
+        await qc.invalidateQueries({ queryKey: ["user"] });
+        posthog.capture("organization_renamed");
+        toast("Organization renamed");
+      } catch (e) {
+        toast(errorMessage(e), "error");
+      }
+    },
+    (errors) => toast(errors.name?.message ?? "Enter an organization name", "error"),
+  );
+
+  return { register, rename, currentName, isSubmitting, clearName: () => reset({ name: "" }) };
+}
+
+/** The delete-organization confirm dialog and its request. */
+function useDeleteOrgFlow(orgId: string, clearNameField: () => void) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [confirmName, setConfirmName] = useState("");
+  const [pending, setPending] = useState(false);
+
+  const close = () => {
+    setOpen(false);
+    setConfirmName("");
+  };
+
+  const deleteOrg = async () => {
+    setPending(true);
+    try {
+      await api(`/orgs/${orgId}`, { method: "DELETE" });
+      posthog.capture("organization_deleted");
+      close();
+      clearNameField();
+      toast("Organization deleted");
+      // useCurrentOrg falls back to the next org (or NoOrgState everywhere).
+      await qc.refetchQueries({ queryKey: ["user"] });
+    } catch (e) {
+      toast(errorMessage(e), "error");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return { open, setOpen, close, confirmName, setConfirmName, pending, deleteOrg };
+}
+
+function OrgNameCard({
+  orgId,
+  isOwner,
+  register,
+  rename,
+  currentName,
+  isSubmitting,
+}: {
+  orgId: string;
+  isOwner: boolean;
+  register: ReturnType<typeof useOrgRenameForm>["register"];
+  rename: () => void;
+  currentName: string | undefined;
+  isSubmitting: boolean;
+}) {
+  return (
+    <Card className="max-w-2xl">
+      <div className="flex flex-col gap-4">
+        <Field label="Organization name">
+          <Input {...register("name")} disabled={!isOwner} />
+        </Field>
+        <Field label="Organization id">
+          <Input value={orgId} disabled readOnly />
+        </Field>
+        {isOwner ? (
+          <div>
+            <Button
+              variant="primary"
+              onClick={rename}
+              disabled={!currentName?.trim() || isSubmitting}
+            >
+              <BusyContent busy={isSubmitting}>Save</BusyContent>
+            </Button>
+          </div>
+        ) : (
+          <p className="text-xs text-muted">Only the owner can change these settings.</p>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function DeleteOrgCard({ orgName, onDelete }: { orgName: string; onDelete: () => void }) {
+  return (
+    <Card className="max-w-2xl">
+      <div className="flex flex-col gap-3">
+        <p className="text-xs font-medium text-danger">Danger zone</p>
+        <p className="text-sm text-muted">
+          Permanently delete <span className="text-text">{orgName}</span> with every link, custom
+          domain, and all click history. Short links stop working immediately.
+        </p>
+        <div>
+          <Button variant="danger" onClick={onDelete}>
+            Delete organization
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function DeleteOrgDialog({
+  org,
+  flow,
+}: {
+  org: UserOrg;
+  flow: ReturnType<typeof useDeleteOrgFlow>;
+}) {
+  const toast = useToast();
+  return (
+    <ConfirmDialog
+      title="Delete organization"
+      open={flow.open}
+      onClose={flow.close}
+      onConfirm={flow.deleteOrg}
+      confirmLabel="Delete organization"
+      danger
+      pending={flow.pending}
+      confirmDisabled={flow.confirmName.trim() !== org.name}
+    >
+      <div>
+        <p className="mb-4 text-sm">
+          This permanently deletes <span className="font-bold text-accent">{org.name}</span>: every
+          link, custom domain, and all click history. Short links stop working immediately. This
+          cannot be undone.
+        </p>
+        <div>
+          <div className="mb-1.5 flex flex-wrap items-center gap-1.5 text-sm text-muted">
+            <span>To confirm, type</span>
+            <code className="rounded bg-bg px-1.5 py-0.5 text-text">{org.name}</code>
+            <CopyButton
+              text={org.name}
+              label="Copy organization name"
+              onCopy={(text) => copyToClipboard(text, toast)}
+            />
+          </div>
+          <Input
+            value={flow.confirmName}
+            onChange={(e) => flow.setConfirmName(e.target.value)}
+            placeholder={org.name}
+            aria-label={`Type ${org.name} to confirm deletion`}
+            autoFocus
+          />
+        </div>
+      </div>
+    </ConfirmDialog>
+  );
+}
+
+export function OrganizationPage() {
+  const { org } = useCurrentOrg();
+  const orgId = org?.id ?? "";
+  const currentUser = useCurrentUser();
+  const isOwner = isOrgOwner(!!currentUser.data?.user.isAdmin, org?.role);
+
+  const { register, rename, currentName, isSubmitting, clearName } = useOrgRenameForm(org);
+  const deleteOrgFlow = useDeleteOrgFlow(orgId, clearName);
+
+  // Ownership is authoritative only after the fresh user response.
+  if (currentUser.isLoading) return <OrganizationSkeleton />;
+  if (!org) return <NoOrgState />;
+
+  return (
+    <div>
+      <PageHeader title="Organization" sub="Settings for the current organization" />
+      <div className="flex flex-col gap-4">
+        <OrgNameCard
+          orgId={orgId}
+          isOwner={isOwner}
+          register={register}
+          rename={rename}
+          currentName={currentName}
+          isSubmitting={isSubmitting}
+        />
+        <QrDefaultsCard key={org.id} />
+        {isOwner && (
+          <DeleteOrgCard orgName={org.name} onDelete={() => deleteOrgFlow.setOpen(true)} />
+        )}
+      </div>
+
+      <DeleteOrgDialog org={org} flow={deleteOrgFlow} />
+    </div>
+  );
+}

--- a/src/app/routes/settings.tsx
+++ b/src/app/routes/settings.tsx
@@ -1,12 +1,10 @@
-import { type ReactNode, useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { errorMessage } from "@/app/lib/error-message";
 import { useForm } from "react-hook-form";
 import { valibotResolver } from "@hookform/resolvers/valibot";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCurrentUser } from "../lib/hooks";
-import { useCurrentOrg } from "../lib/current-org";
-import { api } from "../lib/api";
-import type { OrgRole, UserOrg } from "@/shared/types";
+import type { UserOrg } from "@/shared/types";
 import { authClient } from "../lib/auth-client";
 import { Button } from "../ui/button";
 import { Field, Input } from "../ui/field";
@@ -14,16 +12,12 @@ import { Switch } from "../ui/switch";
 import { Card, PageHeader } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
 import { useToast } from "../ui/toast";
-import { CopyButton } from "../ui/copy-button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
-import { copyToClipboard } from "../lib/clipboard";
-import { QrDefaultsCard } from "../components/qr-defaults-card";
 import { SettingsSkeleton } from "../components/skeletons";
-import { accountNameSchema, orgNameSchema } from "../lib/schemas";
+import { accountNameSchema } from "../lib/schemas";
 import { useTheme } from "../lib/theme";
 import posthog from "../lib/posthog";
 
-type OrgNameForm = { name: string };
 type AccountNameForm = { name: string };
 
 /** The account-name field: same PATCH-on-save shape as the org rename, but
@@ -112,86 +106,6 @@ function AccountCard({
   );
 }
 
-/** The org-name field: syncs its default value when the current org
- * changes, and saves via PATCH. */
-function useOrgRenameForm(org: UserOrg | null) {
-  const qc = useQueryClient();
-  const toast = useToast();
-
-  const {
-    register,
-    handleSubmit,
-    reset,
-    watch,
-    formState: { isSubmitting },
-  } = useForm<OrgNameForm>({
-    resolver: valibotResolver(orgNameSchema),
-    defaultValues: { name: "" },
-  });
-  const resetOrgId = useRef<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!org) {
-      resetOrgId.current = undefined;
-      return;
-    }
-    if (resetOrgId.current === org.id) return;
-    resetOrgId.current = org.id;
-    reset({ name: org.name });
-  }, [org, reset]);
-
-  const currentName = watch("name");
-
-  const rename = handleSubmit(
-    async (data) => {
-      try {
-        await api(`/orgs/${org?.id ?? ""}`, { method: "PATCH", body: { name: data.name } });
-        await qc.invalidateQueries({ queryKey: ["user"] });
-        posthog.capture("organization_renamed");
-        toast("Organization renamed");
-      } catch (e) {
-        toast(errorMessage(e), "error");
-      }
-    },
-    (errors) => toast(errors.name?.message ?? "Enter an organization name", "error"),
-  );
-
-  return { register, rename, currentName, isSubmitting, clearName: () => reset({ name: "" }) };
-}
-
-/** The delete-organization confirm dialog and its request. */
-function useDeleteOrgFlow(orgId: string, clearNameField: () => void) {
-  const qc = useQueryClient();
-  const toast = useToast();
-  const [open, setOpen] = useState(false);
-  const [confirmName, setConfirmName] = useState("");
-  const [pending, setPending] = useState(false);
-
-  const close = () => {
-    setOpen(false);
-    setConfirmName("");
-  };
-
-  const deleteOrg = async () => {
-    setPending(true);
-    try {
-      await api(`/orgs/${orgId}`, { method: "DELETE" });
-      posthog.capture("organization_deleted");
-      close();
-      clearNameField();
-      toast("Organization deleted");
-      // useCurrentOrg falls back to the next org (or NoOrgState everywhere).
-      await qc.refetchQueries({ queryKey: ["user"] });
-    } catch (e) {
-      toast(errorMessage(e), "error");
-    } finally {
-      setPending(false);
-    }
-  };
-
-  return { open, setOpen, close, confirmName, setConfirmName, pending, deleteOrg };
-}
-
 /** The delete-account confirm dialog and its request. */
 function useDeleteAccountFlow() {
   const toast = useToast();
@@ -218,48 +132,6 @@ function useDeleteAccountFlow() {
   return { open, setOpen, pending, deleteAccount };
 }
 
-function OrgNameCard({
-  orgId,
-  isOwner,
-  register,
-  rename,
-  currentName,
-  isSubmitting,
-}: {
-  orgId: string;
-  isOwner: boolean;
-  register: ReturnType<typeof useOrgRenameForm>["register"];
-  rename: () => void;
-  currentName: string | undefined;
-  isSubmitting: boolean;
-}) {
-  return (
-    <Card className="max-w-2xl">
-      <div className="flex flex-col gap-4">
-        <Field label="Organization name">
-          <Input {...register("name")} disabled={!isOwner} />
-        </Field>
-        <Field label="Organization id">
-          <Input value={orgId} disabled readOnly />
-        </Field>
-        {isOwner ? (
-          <div>
-            <Button
-              variant="primary"
-              onClick={rename}
-              disabled={!currentName?.trim() || isSubmitting}
-            >
-              <BusyContent busy={isSubmitting}>Save</BusyContent>
-            </Button>
-          </div>
-        ) : (
-          <p className="text-xs text-muted">Only the owner can change these settings.</p>
-        )}
-      </div>
-    </Card>
-  );
-}
-
 function DeleteAccountCard({ disabled, onDelete }: { disabled: boolean; onDelete: () => void }) {
   return (
     <Card className="max-w-2xl">
@@ -276,87 +148,6 @@ function DeleteAccountCard({ disabled, onDelete }: { disabled: boolean; onDelete
         </div>
       </div>
     </Card>
-  );
-}
-
-function DeleteOrgCard({ orgName, onDelete }: { orgName: string; onDelete: () => void }) {
-  return (
-    <Card className="max-w-2xl">
-      <div className="flex flex-col gap-3">
-        <p className="text-xs font-medium text-danger">Danger zone</p>
-        <p className="text-sm text-muted">
-          Permanently delete <span className="text-text">{orgName}</span> with every link, custom
-          domain, and all click history. Short links stop working immediately.
-        </p>
-        <div>
-          <Button variant="danger" onClick={onDelete}>
-            Delete organization
-          </Button>
-        </div>
-      </div>
-    </Card>
-  );
-}
-
-function DeleteOrgDialog({
-  org,
-  flow,
-}: {
-  org: UserOrg;
-  flow: ReturnType<typeof useDeleteOrgFlow>;
-}) {
-  const toast = useToast();
-  return (
-    <ConfirmDialog
-      title="Delete organization"
-      open={flow.open}
-      onClose={flow.close}
-      onConfirm={flow.deleteOrg}
-      confirmLabel="Delete organization"
-      danger
-      pending={flow.pending}
-      confirmDisabled={flow.confirmName.trim() !== org.name}
-    >
-      <div>
-        <p className="mb-4 text-sm">
-          This permanently deletes <span className="font-bold text-accent">{org.name}</span>: every
-          link, custom domain, and all click history. Short links stop working immediately. This
-          cannot be undone.
-        </p>
-        <div>
-          <div className="mb-1.5 flex flex-wrap items-center gap-1.5 text-sm text-muted">
-            <span>To confirm, type</span>
-            <code className="rounded bg-bg px-1.5 py-0.5 text-text">{org.name}</code>
-            <CopyButton
-              text={org.name}
-              label="Copy organization name"
-              onCopy={(text) => copyToClipboard(text, toast)}
-            />
-          </div>
-          <Input
-            value={flow.confirmName}
-            onChange={(e) => flow.setConfirmName(e.target.value)}
-            placeholder={org.name}
-            aria-label={`Type ${org.name} to confirm deletion`}
-            autoFocus
-          />
-        </div>
-      </div>
-    </ConfirmDialog>
-  );
-}
-
-function isOrgOwner(isPlatformAdmin: boolean, role: OrgRole | undefined): boolean {
-  return isPlatformAdmin || role === "owner";
-}
-
-/** A titled group of settings cards. */
-function Section({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <section className="flex flex-col gap-4">
-      <h2 className="text-sm font-semibold text-muted">{title}</h2>
-      {children}
-    </section>
   );
 }
 
@@ -394,13 +185,7 @@ function DeleteAccountWarning({ orgs }: { orgs: UserOrg[] }) {
 }
 
 export function SettingsPage() {
-  const { org } = useCurrentOrg();
-  const orgId = org?.id ?? "";
   const currentUser = useCurrentUser();
-  const isOwner = isOrgOwner(!!currentUser.data?.user.isAdmin, org?.role);
-
-  const { register, rename, currentName, isSubmitting, clearName } = useOrgRenameForm(org);
-  const deleteOrgFlow = useDeleteOrgFlow(orgId, clearName);
   const deleteAccountFlow = useDeleteAccountFlow();
   const ownedOrgs = (currentUser.data?.orgs ?? []).filter((o) => o.role === "owner");
   // The shell may paint Settings from its cache before this fresh /user
@@ -408,44 +193,21 @@ export function SettingsPage() {
   // destructive action, and an empty fallback would hide the org names.
   const accountDeleteDisabled = currentUser.isLoading || !currentUser.data;
 
-  // Organization ownership and platform-admin status are authoritative only
-  // after the fresh user response. The cache may be one page load behind.
   if (currentUser.isLoading) return <SettingsSkeleton />;
 
   return (
     <div>
-      <PageHeader title="Settings" sub="Account and organization settings" />
-      <div className="flex flex-col gap-8">
-        <Section title="Your account">
-          <AccountCard
-            userName={currentUser.data?.user.name}
-            userEmail={currentUser.data?.user.email}
-          />
-          <DeleteAccountCard
-            disabled={accountDeleteDisabled}
-            onDelete={() => deleteAccountFlow.setOpen(true)}
-          />
-        </Section>
-
-        {org && (
-          <Section title="Organization">
-            <OrgNameCard
-              orgId={orgId}
-              isOwner={isOwner}
-              register={register}
-              rename={rename}
-              currentName={currentName}
-              isSubmitting={isSubmitting}
-            />
-            <QrDefaultsCard key={org.id} />
-            {isOwner && (
-              <DeleteOrgCard orgName={org.name} onDelete={() => deleteOrgFlow.setOpen(true)} />
-            )}
-          </Section>
-        )}
+      <PageHeader title="Settings" sub="Your account" />
+      <div className="flex flex-col gap-4">
+        <AccountCard
+          userName={currentUser.data?.user.name}
+          userEmail={currentUser.data?.user.email}
+        />
+        <DeleteAccountCard
+          disabled={accountDeleteDisabled}
+          onDelete={() => deleteAccountFlow.setOpen(true)}
+        />
       </div>
-
-      {org && <DeleteOrgDialog org={org} flow={deleteOrgFlow} />}
 
       <ConfirmDialog
         title="Delete account"

--- a/src/app/routes/settings.tsx
+++ b/src/app/routes/settings.tsx
@@ -18,10 +18,90 @@ import { ConfirmDialog } from "../ui/confirm-dialog";
 import { copyToClipboard } from "../lib/clipboard";
 import { QrDefaultsCard } from "../components/qr-defaults-card";
 import { SettingsSkeleton } from "../components/skeletons";
-import { orgNameSchema } from "../lib/schemas";
+import { accountNameSchema, orgNameSchema } from "../lib/schemas";
+import { useTheme } from "../lib/theme";
 import posthog from "../lib/posthog";
 
 type OrgNameForm = { name: string };
+type AccountNameForm = { name: string };
+
+/** The account-name field: same PATCH-on-save shape as the org rename, but
+ * it goes through BetterAuth's own updateUser endpoint. */
+function useAccountNameForm(currentUserName: string | undefined) {
+  const qc = useQueryClient();
+  const toast = useToast();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { isSubmitting },
+  } = useForm<AccountNameForm>({
+    resolver: valibotResolver(accountNameSchema),
+    defaultValues: { name: "" },
+  });
+  const synced = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (currentUserName === undefined || synced.current === currentUserName) return;
+    synced.current = currentUserName;
+    reset({ name: currentUserName });
+  }, [currentUserName, reset]);
+
+  const currentName = watch("name");
+
+  const save = handleSubmit(
+    async (data) => {
+      const { error } = await authClient.updateUser({ name: data.name.trim() });
+      if (error) {
+        toast(error.message ?? "Could not save your name", "error");
+        return;
+      }
+      await qc.invalidateQueries({ queryKey: ["user"] });
+      posthog.capture("account_name_changed");
+      toast("Name saved");
+    },
+    (errors) => toast(errors.name?.message ?? "Enter your name", "error"),
+  );
+
+  return { register, save, currentName, isSubmitting };
+}
+
+function AccountCard({ userName }: { userName: string | undefined }) {
+  const { register, save, currentName, isSubmitting } = useAccountNameForm(userName);
+  const [theme, toggleTheme] = useTheme();
+  return (
+    <Card className="max-w-2xl">
+      <div className="flex flex-col gap-4">
+        <Field label="Your name">
+          <Input {...register("name")} />
+        </Field>
+        <div>
+          <Button
+            variant="primary"
+            onClick={save}
+            disabled={
+              !currentName?.trim() || currentName.trim() === (userName ?? "") || isSubmitting
+            }
+          >
+            <BusyContent busy={isSubmitting}>Save</BusyContent>
+          </Button>
+        </div>
+        <div className="border-t border-border" />
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm">Theme</p>
+            <p className="text-xs text-muted">Currently {theme === "dark" ? "dark" : "light"}.</p>
+          </div>
+          <Button variant="outline" onClick={toggleTheme}>
+            Switch to {theme === "dark" ? "light" : "dark"}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
 
 /** The org-name field: syncs its default value when the current org
  * changes, and saves via PATCH. */
@@ -357,6 +437,8 @@ export function SettingsPage() {
     <div>
       <PageHeader title="Settings" sub="Account and organization settings" />
       <div className="flex flex-col gap-4">
+        <AccountCard userName={currentUser.data?.user.name} />
+
         {/* org cards only when an org exists; account deletion always */}
         <OrgSettingsCards
           org={org}

--- a/src/app/routes/settings.tsx
+++ b/src/app/routes/settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { type ReactNode, useState, useEffect, useRef } from "react";
 import { errorMessage } from "@/app/lib/error-message";
 import { useForm } from "react-hook-form";
 import { valibotResolver } from "@hookform/resolvers/valibot";
@@ -69,7 +69,13 @@ function useAccountNameForm(currentUserName: string | undefined) {
   return { register, save, currentName, isSubmitting };
 }
 
-function AccountCard({ userName }: { userName: string | undefined }) {
+function AccountCard({
+  userName,
+  userEmail,
+}: {
+  userName: string | undefined;
+  userEmail: string | undefined;
+}) {
   const { register, save, currentName, isSubmitting } = useAccountNameForm(userName);
   const [theme, toggleTheme] = useTheme();
   return (
@@ -77,6 +83,9 @@ function AccountCard({ userName }: { userName: string | undefined }) {
       <div className="flex flex-col gap-4">
         <Field label="Your name">
           <Input {...register("name")} />
+        </Field>
+        <Field label="Email">
+          <Input value={userEmail ?? ""} disabled readOnly />
         </Field>
         <div>
           <Button
@@ -251,44 +260,37 @@ function OrgNameCard({
   );
 }
 
-function DangerZoneCard({
-  org,
-  isOwner,
-  accountDeleteDisabled,
-  onDeleteOrg,
-  onDeleteAccount,
-}: {
-  org: UserOrg | null;
-  isOwner: boolean;
-  accountDeleteDisabled: boolean;
-  onDeleteOrg: () => void;
-  onDeleteAccount: () => void;
-}) {
+function DeleteAccountCard({ disabled, onDelete }: { disabled: boolean; onDelete: () => void }) {
   return (
     <Card className="max-w-2xl">
       <div className="flex flex-col gap-3">
         <p className="text-xs font-medium text-danger">Danger zone</p>
-        {org && isOwner && (
-          <>
-            <p className="text-sm text-muted">
-              Permanently delete <span className="text-text">{org.name}</span> with every link,
-              custom domain, and all click history. Short links stop working immediately.
-            </p>
-            <div>
-              <Button variant="danger" onClick={onDeleteOrg}>
-                Delete organization
-              </Button>
-            </div>
-            <div className="my-1 border-t border-border" />
-          </>
-        )}
         <p className="text-sm text-muted">
           Permanently delete your account, and every organization you own with it. Organizations you
           only belong to are left alone.
         </p>
         <div>
-          <Button variant="danger" onClick={onDeleteAccount} disabled={accountDeleteDisabled}>
+          <Button variant="danger" onClick={onDelete} disabled={disabled}>
             Delete account
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function DeleteOrgCard({ orgName, onDelete }: { orgName: string; onDelete: () => void }) {
+  return (
+    <Card className="max-w-2xl">
+      <div className="flex flex-col gap-3">
+        <p className="text-xs font-medium text-danger">Danger zone</p>
+        <p className="text-sm text-muted">
+          Permanently delete <span className="text-text">{orgName}</span> with every link, custom
+          domain, and all click history. Short links stop working immediately.
+        </p>
+        <div>
+          <Button variant="danger" onClick={onDelete}>
+            Delete organization
           </Button>
         </div>
       </div>
@@ -348,36 +350,13 @@ function isOrgOwner(isPlatformAdmin: boolean, role: OrgRole | undefined): boolea
   return isPlatformAdmin || role === "owner";
 }
 
-function OrgSettingsCards({
-  org,
-  orgId,
-  isOwner,
-  register,
-  rename,
-  currentName,
-  isSubmitting,
-}: {
-  org: UserOrg | null;
-  orgId: string;
-  isOwner: boolean;
-  register: ReturnType<typeof useOrgRenameForm>["register"];
-  rename: () => void;
-  currentName: string | undefined;
-  isSubmitting: boolean;
-}) {
-  if (!org) return null;
+/** A titled group of settings cards. */
+function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <>
-      <OrgNameCard
-        orgId={orgId}
-        isOwner={isOwner}
-        register={register}
-        rename={rename}
-        currentName={currentName}
-        isSubmitting={isSubmitting}
-      />
-      <QrDefaultsCard key={org.id} />
-    </>
+    <section className="flex flex-col gap-4">
+      <h2 className="text-sm font-semibold text-muted">{title}</h2>
+      {children}
+    </section>
   );
 }
 
@@ -436,27 +415,34 @@ export function SettingsPage() {
   return (
     <div>
       <PageHeader title="Settings" sub="Account and organization settings" />
-      <div className="flex flex-col gap-4">
-        <AccountCard userName={currentUser.data?.user.name} />
+      <div className="flex flex-col gap-8">
+        <Section title="Your account">
+          <AccountCard
+            userName={currentUser.data?.user.name}
+            userEmail={currentUser.data?.user.email}
+          />
+          <DeleteAccountCard
+            disabled={accountDeleteDisabled}
+            onDelete={() => deleteAccountFlow.setOpen(true)}
+          />
+        </Section>
 
-        {/* org cards only when an org exists; account deletion always */}
-        <OrgSettingsCards
-          org={org}
-          orgId={orgId}
-          isOwner={isOwner}
-          register={register}
-          rename={rename}
-          currentName={currentName}
-          isSubmitting={isSubmitting}
-        />
-
-        <DangerZoneCard
-          org={org}
-          isOwner={isOwner}
-          accountDeleteDisabled={accountDeleteDisabled}
-          onDeleteOrg={() => deleteOrgFlow.setOpen(true)}
-          onDeleteAccount={() => deleteAccountFlow.setOpen(true)}
-        />
+        {org && (
+          <Section title="Organization">
+            <OrgNameCard
+              orgId={orgId}
+              isOwner={isOwner}
+              register={register}
+              rename={rename}
+              currentName={currentName}
+              isSubmitting={isSubmitting}
+            />
+            <QrDefaultsCard key={org.id} />
+            {isOwner && (
+              <DeleteOrgCard orgName={org.name} onDelete={() => deleteOrgFlow.setOpen(true)} />
+            )}
+          </Section>
+        )}
       </div>
 
       {org && <DeleteOrgDialog org={org} flow={deleteOrgFlow} />}

--- a/src/app/routes/settings.tsx
+++ b/src/app/routes/settings.tsx
@@ -10,6 +10,7 @@ import type { OrgRole, UserOrg } from "@/shared/types";
 import { authClient } from "../lib/auth-client";
 import { Button } from "../ui/button";
 import { Field, Input } from "../ui/field";
+import { Switch } from "../ui/switch";
 import { Card, PageHeader } from "../ui/misc";
 import { BusyContent } from "../ui/spinner";
 import { useToast } from "../ui/toast";
@@ -90,13 +91,12 @@ function AccountCard({ userName }: { userName: string | undefined }) {
         </div>
         <div className="border-t border-border" />
         <div className="flex items-center justify-between gap-4">
-          <div>
-            <p className="text-sm">Theme</p>
-            <p className="text-xs text-muted">Currently {theme === "dark" ? "dark" : "light"}.</p>
-          </div>
-          <Button variant="outline" onClick={toggleTheme}>
-            Switch to {theme === "dark" ? "light" : "dark"}
-          </Button>
+          <p className="text-sm">Dark mode</p>
+          <Switch
+            label="Dark mode"
+            checked={theme === "dark"}
+            onCheckedChange={(on) => on !== (theme === "dark") && toggleTheme()}
+          />
         </div>
       </div>
     </Card>

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -14,7 +14,7 @@ import { useTheme } from "../lib/theme";
 import { useToast } from "../ui/toast";
 import { Menu, MenuItem, MenuSeparator } from "../ui/menu";
 import { Dialog } from "../ui/dialog";
-import { Button, IconButton } from "../ui/button";
+import { Button } from "../ui/button";
 import { Field, Input } from "../ui/field";
 
 import { AppShellSkeleton, RouteSkeleton } from "../components/skeletons";
@@ -162,6 +162,7 @@ function AppSidebar({
   onSignOut: () => void;
   signOutPending: boolean;
 }) {
+  const navigate = useNavigate();
   return (
     <div className="flex h-full flex-col">
       {/* brand — desktop only; on mobile the top bar already shows it */}
@@ -195,25 +196,28 @@ function AppSidebar({
       {/* user footer — py-2.5 makes this block exactly as tall as the main
           Footer, so both border-t lines form one continuous bottom rule */}
       <div className="mt-auto border-t border-border px-3 py-2.5">
-        <div className="flex items-center gap-2 px-1.5">
-          <UserAvatar user={user} size={32} />
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm">{user.name}</p>
-            <p className="truncate text-xs text-muted">{user.email}</p>
-          </div>
-          <IconButton label="Toggle theme" className="p-2" onClick={onToggleTheme}>
+        <Menu
+          label="Account menu"
+          trigger={
+            <div className="flex items-center gap-2 rounded-md px-1.5 py-1 hover:bg-surface-2">
+              <UserAvatar user={user} size={32} />
+              <p className="min-w-0 flex-1 truncate text-sm">{user.name}</p>
+              <ChevronsUpDown size={14} className="shrink-0 text-muted" />
+            </div>
+          }
+        >
+          <p className="truncate px-2.5 py-1.5 text-xs text-muted">{user.email}</p>
+          <MenuSeparator />
+          <MenuItem onClick={() => void navigate({ to: "/settings" })}>Settings</MenuItem>
+          <MenuItem onClick={onToggleTheme}>
             <MorphIcon icon={theme === "dark" ? sun : moon} size={15} spring="snappy" />
-          </IconButton>
-          <IconButton
-            label="Sign out"
-            danger
-            className="p-2"
-            disabled={signOutPending}
-            onClick={onSignOut}
-          >
-            <LogOut size={15} />
-          </IconButton>
-        </div>
+            {theme === "dark" ? "Light theme" : "Dark theme"}
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem className="text-danger" disabled={signOutPending} onClick={onSignOut}>
+            <LogOut size={15} /> Sign out
+          </MenuItem>
+        </Menu>
       </div>
     </div>
   );

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -206,8 +206,6 @@ function AppSidebar({
             </div>
           }
         >
-          <p className="truncate px-2.5 py-1.5 text-xs text-muted">{user.email}</p>
-          <MenuSeparator />
           <MenuItem onClick={() => void navigate({ to: "/settings" })}>
             <Settings size={15} /> Settings
           </MenuItem>

--- a/src/app/routes/shell.tsx
+++ b/src/app/routes/shell.tsx
@@ -3,7 +3,7 @@ import { errorMessage } from "@/app/lib/error-message";
 import { Link, Outlet, useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, LazyMotion, domAnimation, m } from "motion/react";
-import { Layers, ChevronsUpDown, Plus, Check, LogOut } from "@/app/ui/icons";
+import { Layers, ChevronsUpDown, Plus, Check, LogOut, Settings } from "@/app/ui/icons";
 import { MorphIcon } from "morphicons/react";
 import { menu2, moon, sun, x } from "@/app/ui/icon-nodes";
 import { useCurrentUser, useLogout, useShellUser } from "../lib/hooks";
@@ -208,8 +208,10 @@ function AppSidebar({
         >
           <p className="truncate px-2.5 py-1.5 text-xs text-muted">{user.email}</p>
           <MenuSeparator />
-          <MenuItem onClick={() => void navigate({ to: "/settings" })}>Settings</MenuItem>
-          <MenuItem onClick={onToggleTheme}>
+          <MenuItem onClick={() => void navigate({ to: "/settings" })}>
+            <Settings size={15} /> Settings
+          </MenuItem>
+          <MenuItem closeOnClick={false} onClick={onToggleTheme}>
             <MorphIcon icon={theme === "dark" ? sun : moon} size={15} spring="snappy" />
             {theme === "dark" ? "Light theme" : "Dark theme"}
           </MenuItem>

--- a/src/app/ui/menu.tsx
+++ b/src/app/ui/menu.tsx
@@ -42,16 +42,20 @@ export function MenuItem({
   children,
   className,
   disabled,
+  closeOnClick,
 }: {
   onClick?: () => void;
   children: ReactNode;
   className?: string;
   disabled?: boolean;
+  /** Defaults to true; pass false for an item that stays open (e.g. a toggle). */
+  closeOnClick?: boolean;
 }) {
   return (
     <BaseMenu.Item
       onClick={onClick}
       disabled={disabled}
+      closeOnClick={closeOnClick}
       className={cn(
         "flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 text-sm text-text outline-none select-none data-[highlighted]:bg-surface-2 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,

--- a/src/app/ui/switch.tsx
+++ b/src/app/ui/switch.tsx
@@ -1,0 +1,32 @@
+import { Switch as BaseSwitch } from "@base-ui/react/switch";
+import { cn } from "./cn";
+
+/**
+ * A binary toggle. It has no visible text of its own, so pass `label` for
+ * the accessible name.
+ */
+export function Switch({
+  checked,
+  onCheckedChange,
+  label,
+  className,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <BaseSwitch.Root
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      aria-label={label}
+      className={cn(
+        "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border bg-surface-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent data-[checked]:border-accent data-[checked]:bg-accent",
+        className,
+      )}
+    >
+      <BaseSwitch.Thumb className="pointer-events-none block size-3.5 translate-x-0.5 rounded-full bg-text transition-transform data-[checked]:translate-x-[18px] data-[checked]:bg-bg" />
+    </BaseSwitch.Root>
+  );
+}

--- a/src/worker/util.ts
+++ b/src/worker/util.ts
@@ -44,6 +44,7 @@ export const RESERVED_SLUGS = new Set([
   "analytics",
   "links",
   "members",
+  "organization",
   "billing",
   "domains",
   "settings",

--- a/tests/e2e/auth.pw.ts
+++ b/tests/e2e/auth.pw.ts
@@ -1,6 +1,7 @@
 import { expect, type Page, test } from "@playwright/test";
 import { signUpAndVerify } from "./resend";
 import { rawSql } from "./db";
+import { signOut } from "./pages";
 
 async function blockAuthRequests(page: Page) {
   const counter = { count: 0 };
@@ -18,7 +19,7 @@ test.describe("authentication forms", () => {
 
     await signUpAndVerify(page, email, password);
 
-    await page.getByLabel("Sign out").click();
+    await signOut(page);
     await expect(page).toHaveURL(/\/login$/);
 
     await page.getByLabel("Email").fill(email);

--- a/tests/e2e/authenticated-flows.pw.ts
+++ b/tests/e2e/authenticated-flows.pw.ts
@@ -49,7 +49,7 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
   );
   const rootEl = page.locator("html");
   const themeBefore = await rootEl.getAttribute("data-theme");
-  await page.getByRole("button", { name: /^Switch to (dark|light)$/ }).click();
+  await page.getByRole("switch", { name: "Dark mode" }).click();
   await expect(rootEl).not.toHaveAttribute("data-theme", themeBefore ?? "");
 
   const organizationName = page.getByLabel("Organization name");

--- a/tests/e2e/authenticated-flows.pw.ts
+++ b/tests/e2e/authenticated-flows.pw.ts
@@ -34,9 +34,9 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
 
   await page.goto("/settings");
 
-  // Account card: change your own display name and flip the theme.
+  // Account settings: change your own display name and flip the theme.
   await page.getByLabel("Your name").fill("Playwright Person");
-  await page.getByRole("button", { name: "Save", exact: true }).first().click();
+  await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(page.getByText("Name saved")).toBeVisible();
   await expect(page.getByRole("button", { name: "Account menu" })).toContainText(
     "Playwright Person",
@@ -52,9 +52,10 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
   await page.getByRole("switch", { name: "Dark mode" }).click();
   await expect(rootEl).not.toHaveAttribute("data-theme", themeBefore ?? "");
 
-  const organizationName = page.getByLabel("Organization name");
-  await organizationName.fill("Playwright Org Renamed");
-  await page.getByRole("button", { name: "Save", exact: true }).last().click();
+  // Organization settings live on their own page now.
+  await page.goto("/organization");
+  await page.getByLabel("Organization name").fill("Playwright Org Renamed");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(page.getByText("Organization renamed")).toBeVisible();
 
   // The theme item in the account menu toggles without closing the menu.
@@ -76,7 +77,7 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
   });
   await signOut(page);
   await expect(page.getByText("Sign-out service unavailable")).toBeVisible();
-  await expect(page).toHaveURL(/\/settings$/);
+  await expect(page).toHaveURL(/\/organization$/);
 
   await page.unroute(signOutUrl);
   await signOut(page);

--- a/tests/e2e/authenticated-flows.pw.ts
+++ b/tests/e2e/authenticated-flows.pw.ts
@@ -41,6 +41,11 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
   await expect(page.getByRole("button", { name: "Account menu" })).toContainText(
     "Playwright Person",
   );
+  // No uploaded image, so the footer shows a blobatar (inline SVG data URI).
+  await expect(page.locator('button[aria-label="Account menu"] img')).toHaveAttribute(
+    "src",
+    /^data:image\/svg\+xml/,
+  );
   const rootEl = page.locator("html");
   const themeBefore = await rootEl.getAttribute("data-theme");
   await page.getByRole("button", { name: /^Switch to (dark|light)$/ }).click();

--- a/tests/e2e/authenticated-flows.pw.ts
+++ b/tests/e2e/authenticated-flows.pw.ts
@@ -42,7 +42,8 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
     "Playwright Person",
   );
   // No uploaded image, so the footer shows a blobatar (inline SVG data URI).
-  await expect(page.locator('button[aria-label="Account menu"] img')).toHaveAttribute(
+  // The menu trigger renders as a div with role=button, not a <button> tag.
+  await expect(page.getByRole("button", { name: "Account menu" }).locator("img")).toHaveAttribute(
     "src",
     /^data:image\/svg\+xml/,
   );

--- a/tests/e2e/authenticated-flows.pw.ts
+++ b/tests/e2e/authenticated-flows.pw.ts
@@ -3,6 +3,7 @@ import { appUrl } from "./environment";
 import { signUpAndVerify } from "./resend";
 import { setPlan } from "./db";
 import { addCustomDomain, createQuickLink } from "./orgs";
+import { signOut } from "./pages";
 
 const password = "test-password-123";
 
@@ -32,9 +33,22 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
   await expect(page.getByText("Invite sent")).toBeVisible();
 
   await page.goto("/settings");
+
+  // Account card: change your own display name and flip the theme.
+  await page.getByLabel("Your name").fill("Playwright Person");
+  await page.getByRole("button", { name: "Save", exact: true }).first().click();
+  await expect(page.getByText("Name saved")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Account menu" })).toContainText(
+    "Playwright Person",
+  );
+  const rootEl = page.locator("html");
+  const themeBefore = await rootEl.getAttribute("data-theme");
+  await page.getByRole("button", { name: /^Switch to (dark|light)$/ }).click();
+  await expect(rootEl).not.toHaveAttribute("data-theme", themeBefore ?? "");
+
   const organizationName = page.getByLabel("Organization name");
   await organizationName.fill("Playwright Org Renamed");
-  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await page.getByRole("button", { name: "Save", exact: true }).last().click();
   await expect(page.getByText("Organization renamed")).toBeVisible();
 
   const signOutUrl = "**/api/auth/sign-out";
@@ -45,12 +59,12 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
       body: JSON.stringify({ message: "Sign-out service unavailable" }),
     });
   });
-  await page.getByLabel("Sign out").click();
+  await signOut(page);
   await expect(page.getByText("Sign-out service unavailable")).toBeVisible();
   await expect(page).toHaveURL(/\/settings$/);
 
   await page.unroute(signOutUrl);
-  await page.getByLabel("Sign out").click();
+  await signOut(page);
   await expect(page).toHaveURL(/\/login$/);
   await page.reload();
   await expect(page).toHaveURL(/\/login$/);

--- a/tests/e2e/authenticated-flows.pw.ts
+++ b/tests/e2e/authenticated-flows.pw.ts
@@ -57,6 +57,15 @@ test("a new owner can create an organization and a scheme-less quick link", asyn
   await page.getByRole("button", { name: "Save", exact: true }).last().click();
   await expect(page.getByText("Organization renamed")).toBeVisible();
 
+  // The theme item in the account menu toggles without closing the menu.
+  const beforeMenuTheme = await rootEl.getAttribute("data-theme");
+  await page.getByRole("button", { name: "Account menu" }).click();
+  const themeItem = page.getByRole("menuitem", { name: /theme$/ });
+  await themeItem.click();
+  await expect(rootEl).not.toHaveAttribute("data-theme", beforeMenuTheme ?? "");
+  await expect(themeItem).toBeVisible();
+  await page.keyboard.press("Escape");
+
   const signOutUrl = "**/api/auth/sign-out";
   await page.route(signOutUrl, async (route) => {
     await route.fulfill({

--- a/tests/e2e/first-run.pw.ts
+++ b/tests/e2e/first-run.pw.ts
@@ -46,7 +46,7 @@ test("deleting the last organization asks for a new one, not for a first link", 
 }) => {
   await signUpAndVerify(page, `lastorg-${Date.now()}@gmail.com`, password);
 
-  await page.goto("/settings");
+  await page.goto("/organization");
   const name = await page.getByLabel("Organization name").inputValue();
   await page.getByRole("button", { name: "Delete organization" }).first().click();
   const dialog = page.getByRole("dialog", { name: "Delete organization" });

--- a/tests/e2e/google-signin.pw.ts
+++ b/tests/e2e/google-signin.pw.ts
@@ -1,13 +1,17 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { signOut } from "./pages";
 
 // Drives the Google button against the local emulate google service (started
 // by the resend webServer, see playwright.config.ts). When Google isn't
 // configured the button doesn't render, so we skip rather than fail.
+async function requireGoogle(page: Page) {
+  const cfg = await (await page.request.get("/api/config")).json();
+  if (!cfg.googleEnabled) test.skip(true, "Google sign-in not configured");
+}
+
 test.describe("Google sign-in", () => {
   test("Continue with Google starts an OAuth session", async ({ page }) => {
-    const cfg = await (await page.request.get("/api/config")).json();
-    if (!cfg.googleEnabled) test.skip(true, "Google sign-in not configured");
+    await requireGoogle(page);
 
     let socialStarted = false;
     await page.route("**/api/auth/sign-in/social**", async (route) => {
@@ -27,8 +31,7 @@ test.describe("Google sign-in", () => {
   test("a full Google round trip signs in, and /login then offers 'continue as'", async ({
     page,
   }) => {
-    const cfg = await (await page.request.get("/api/config")).json();
-    if (!cfg.googleEnabled) test.skip(true, "Google sign-in not configured");
+    await requireGoogle(page);
 
     await page.goto("/login");
     await page.getByRole("button", { name: /Continue with Google/i }).click();
@@ -47,8 +50,7 @@ test.describe("Google sign-in", () => {
   });
 
   test("shows the Google button on signup too", async ({ page }) => {
-    const cfg = await (await page.request.get("/api/config")).json();
-    if (!cfg.googleEnabled) test.skip(true, "Google sign-in not configured");
+    await requireGoogle(page);
 
     await page.goto("/signup");
     await expect(page.getByRole("button", { name: /Continue with Google/i })).toBeVisible();

--- a/tests/e2e/google-signin.pw.ts
+++ b/tests/e2e/google-signin.pw.ts
@@ -21,6 +21,12 @@ test.describe("Google sign-in", () => {
 
     await button.click();
     await expect.poll(() => socialStarted).toBe(true);
+
+    // The method is remembered: a return visit flags the Google button.
+    await page.goto("/login");
+    await expect(
+      page.getByRole("button", { name: /Continue with Google/i }).getByText("Last used"),
+    ).toBeVisible();
   });
 
   test("shows the Google button on signup too", async ({ page }) => {

--- a/tests/e2e/google-signin.pw.ts
+++ b/tests/e2e/google-signin.pw.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "@playwright/test";
+import { signOut } from "./pages";
 
-// Drives the Google button. The button only renders when Google is configured
-// (GOOGLE_CLIENT_ID/SECRET in .dev.vars), so when it isn't we skip rather than
-// fail: the gating itself is covered by /api/config.
+// Drives the Google button against the local emulate google service (started
+// by the resend webServer, see playwright.config.ts). When Google isn't
+// configured the button doesn't render, so we skip rather than fail.
 test.describe("Google sign-in", () => {
   test("Continue with Google starts an OAuth session", async ({ page }) => {
     const cfg = await (await page.request.get("/api/config")).json();
@@ -21,12 +22,28 @@ test.describe("Google sign-in", () => {
 
     await button.click();
     await expect.poll(() => socialStarted).toBe(true);
+  });
 
-    // The method is remembered: a return visit flags the Google button.
+  test("a full Google round trip signs in, and /login then offers 'continue as'", async ({
+    page,
+  }) => {
+    const cfg = await (await page.request.get("/api/config")).json();
+    if (!cfg.googleEnabled) test.skip(true, "Google sign-in not configured");
+
     await page.goto("/login");
-    await expect(
-      page.getByRole("button", { name: /Continue with Google/i }).getByText("Last used"),
-    ).toBeVisible();
+    await page.getByRole("button", { name: /Continue with Google/i }).click();
+
+    // The emulate consent screen: pick the seeded test account.
+    await page.getByRole("button", { name: /testuser@gmail\.com/ }).click();
+    await expect(page).toHaveURL(/\/dashboard$/);
+
+    // Sign out, and the login page now leads with a one-click row for that
+    // account instead of the plain button.
+    await signOut(page);
+    await expect(page).toHaveURL(/\/login$/);
+    const resume = page.getByRole("button", { name: "Continue as testuser@gmail.com" });
+    await expect(resume).toBeVisible();
+    await expect(resume).toContainText("Last used");
   });
 
   test("shows the Google button on signup too", async ({ page }) => {

--- a/tests/e2e/pages.ts
+++ b/tests/e2e/pages.ts
@@ -1,5 +1,11 @@
 import { expect, type Page } from "@playwright/test";
 
+/** Sign out through the account menu in the app-shell sidebar footer. */
+export async function signOut(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Account menu" }).click();
+  await page.getByRole("menuitem", { name: "Sign out" }).click();
+}
+
 const LEGAL_PAGES = [
   { path: "/privacy", heading: "Privacy Policy" },
   { path: "/terms", heading: "Terms of Service" },

--- a/tests/e2e/production/seo.pw.ts
+++ b/tests/e2e/production/seo.pw.ts
@@ -103,6 +103,7 @@ test("robots.txt keeps the private routes out of the index", async ({ request })
     "/analytics",
     "/links",
     "/members",
+    "/organization",
     "/billing",
     "/domains",
     "/settings",

--- a/tests/e2e/public-pages.pw.ts
+++ b/tests/e2e/public-pages.pw.ts
@@ -331,13 +331,11 @@ test("the analytics preview ends on an ask", async ({ page }) => {
   await expect(page).toHaveURL(/\/signup/);
 });
 
-// Signup used to render the same card whether you arrived cold or clicked
-// "Keep this link" with a link waiting. The subtitle is what carries the
-// context across the door, and the default has to name the emailed code:
-// that is the step people abandon.
-test("signup says what happens next", async ({ page }) => {
+// A cold signup is bare (no subtitle), but arriving with context keeps it:
+// a link waiting to be claimed, or a checkout the visitor was mid-way into.
+test("signup carries context across the door", async ({ page }) => {
   await page.goto("/signup");
-  await expect(page.getByText(/6-digit code/i)).toBeVisible();
+  await expect(page.getByText(/then check out/i)).toBeHidden();
 
   await page.goto("/signup?next=%2Fbilling%3Fplan%3Dpro");
   await expect(page.getByText(/then check out/i)).toBeVisible();

--- a/tests/e2e/route-skeletons.pw.ts
+++ b/tests/e2e/route-skeletons.pw.ts
@@ -7,9 +7,12 @@ const password = "test-password-123";
 async function warmShell(page: Page, email: string) {
   // Let the shell persist its cache before the reload below. The regression
   // only exists when chrome paints from that cache while the page waits for a
-  // fresh /user response.
+  // fresh /user response. The footer shows the name, which signup derives
+  // from the email local-part.
   await page.goto("/dashboard");
-  await expect(page.getByText(email)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Account menu" })).toContainText(
+    email.split("@")[0],
+  );
 }
 
 test.describe.configure({ mode: "serial" });

--- a/tests/e2e/route-skeletons.pw.ts
+++ b/tests/e2e/route-skeletons.pw.ts
@@ -145,6 +145,17 @@ test("Settings waits for fresh ownership before showing destructive controls", a
   );
 });
 
+test("Organization waits for fresh ownership before showing destructive controls", async () => {
+  const page = sharedPage;
+  await warmShell(page, sharedEmail);
+  await expectFreshUserSkeleton(
+    page,
+    "/organization",
+    "organization-page-skeleton",
+    page.getByRole("button", { name: "Delete organization" }),
+  );
+});
+
 test("Domains keeps its paid upgrade path out until the current user arrives", async () => {
   const page = sharedPage;
   await warmShell(page, sharedEmail);

--- a/tests/e2e/shell-persistence.pw.ts
+++ b/tests/e2e/shell-persistence.pw.ts
@@ -14,10 +14,13 @@ const password = "test-password-123";
  */
 test("the sidebar survives a reload before /user answers", async ({ page }) => {
   const email = `playwright-shell-${Date.now()}@gmail.com`;
+  // The footer shows the name, derived from the email local-part at signup.
+  const shellName = email.split("@")[0];
+  const footer = page.getByRole("button", { name: "Account menu" });
   await signUpAndVerify(page, email, password);
 
   await page.goto("/links");
-  await expect(page.getByText(email)).toBeVisible();
+  await expect(footer).toContainText(shellName);
 
   let release = () => {};
   const held = new Promise<void>((resolve) => (release = resolve));
@@ -29,7 +32,7 @@ test("the sidebar survives a reload before /user answers", async ({ page }) => {
 
   await page.reload();
   // No answer to /user has been given, and the shell is already there.
-  await expect(page.getByText(email)).toBeVisible();
+  await expect(footer).toContainText(shellName);
   await expect(page.getByRole("link", { name: "Links" })).toBeVisible();
   // The chrome is cached; the page under it is not. A form offered from the
   // cache would carry settings one page load out of date, which is how a
@@ -45,7 +48,7 @@ test("the sidebar survives a reload before /user answers", async ({ page }) => {
 
   // Let the check land: the cache is a first frame, not a replacement for it.
   release();
-  await expect(page.getByText(email)).toBeVisible();
+  await expect(footer).toContainText(shellName);
   await expect(newLink).toBeVisible();
 });
 
@@ -53,6 +56,7 @@ test("the sidebar survives a reload before /user answers", async ({ page }) => {
  * stranger, and must not see the last person's name flash on screen. */
 test("signing out clears the cached shell", async ({ page }) => {
   const email = `playwright-signout-${Date.now()}@gmail.com`;
+  const shellName = email.split("@")[0];
   await signUpAndVerify(page, email, password);
 
   await signOut(page);
@@ -60,5 +64,5 @@ test("signing out clears the cached shell", async ({ page }) => {
 
   await page.goto("/dashboard");
   await expect(page).toHaveURL(/\/login/);
-  await expect(page.getByText(email)).toBeHidden();
+  await expect(page.getByText(shellName)).toBeHidden();
 });

--- a/tests/e2e/shell-persistence.pw.ts
+++ b/tests/e2e/shell-persistence.pw.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { signUpAndVerify } from "./resend";
+import { signOut } from "./pages";
 
 const password = "test-password-123";
 
@@ -54,7 +55,7 @@ test("signing out clears the cached shell", async ({ page }) => {
   const email = `playwright-signout-${Date.now()}@gmail.com`;
   await signUpAndVerify(page, email, password);
 
-  await page.getByLabel("Sign out").click();
+  await signOut(page);
   await expect(page).toHaveURL(/\/login$/);
 
   await page.goto("/dashboard");


### PR DESCRIPTION
Four small pieces on one branch.

## #204 — change your display name
"Your name" card at the top of `/settings`, saved through BetterAuth's `updateUser`, invalidates `["user"]` so the sidebar footer and org switcher repaint. Same card holds a Theme toggle.

## #206 — sidebar footer → account menu
Was avatar + name + email + theme button + sign-out button in one row. Now avatar + name only; the row opens a menu (email header, Settings, toggle theme, Sign out). Sign-out in three e2e specs now goes through a shared `signOut()` helper in `tests/e2e/pages.ts`.

## Real blobatar
The no-image avatar was a local gradient-initials circle named "Blobatar". Swapped in the [blobatar](https://blobatar.dev) package (MIT, no deps): deterministic geometric SVG creature, rendered as an inline `data:image/svg+xml` `<img>`. Seeded on the user id so a rename keeps the face.

## Last-used sign-in badge
A "Last used" badge on the Google button for a returning visitor whose last sign-in was Google. `localStorage` only (`src/app/lib/last-auth.ts`), recorded on a successful Google or password sign-in, read once on mount. Clears when a password sign-in succeeds.

## Also
Fixes `bun run db:seed:local`: migration 0028 made `account.issuer` NOT NULL and the seed still inserted account rows without it.

## Testing
- `bun run verify` green (format, lint incl. anti-slop, all three tsc projects, 414 unit + worker tests).
- fallow and react-doctor: no new findings in changed files (react-doctor 100/100).
- Ran the touched e2e specs locally: `authenticated-flows`, `shell-persistence`, `route-skeletons`, `auth`, `google-signin` all pass.
- Browser check on the dev URL: name change + toast + footer update, account menu opens with all three actions, Settings theme toggle flips `data-theme`, footer shows a blobatar creature, "Last used" badge renders on the Google button.

Closes #204, #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Organization page for renaming and deleting organizations, managing QR defaults, and viewing organization details.
  * Added account settings for display names, email viewing, and theme switching.
  * Added “Continue as” Google sign-in with a “Last used” indicator.
  * Improved default avatars with unique generated illustrations.
* **Bug Fixes**
  * Improved display-name validation and saving.
  * Updated local development and testing support for Google sign-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->