### PR TITLE
Sync Google profile (name + avatar) when linking to an existing account

### DIFF
--- a/src/worker/better-auth.ts
+++ b/src/worker/better-auth.ts
@@ -357,6 +357,11 @@ function buildAuth(env: Env) {
       accountLinking: {
         enabled: true,
         trustedProviders: ["google"],
+        // Copy the Google profile's name and picture onto the local user on
+        // link (email/emailVerified are never touched). Without this, linking
+        // Google to an existing password account leaves user.image null, so
+        // the R2 avatar sync in session.create.after has nothing to pull.
+        updateUserInfoOnLink: true,
       },
     },
     emailAndPassword: {

--- a/tests/e2e/google-signin.pw.ts
+++ b/tests/e2e/google-signin.pw.ts
@@ -1,9 +1,14 @@
 import { expect, test, type Page } from "@playwright/test";
 import { signOut } from "./pages";
+import { signUpAndVerify } from "./resend";
 
 // Drives the Google button against the local emulate google service (started
 // by the resend webServer, see playwright.config.ts). When Google isn't
 // configured the button doesn't render, so we skip rather than fail.
+//
+// The emulator always signs in as testuser@gmail.com, so the tests that use
+// the real OAuth round trip share that one identity and run in order: the
+// linking test claims the password account first, the rest sign into it.
 async function requireGoogle(page: Page) {
   const cfg = await (await page.request.get("/api/config")).json();
   if (!cfg.googleEnabled) test.skip(true, "Google sign-in not configured");
@@ -28,6 +33,31 @@ test.describe("Google sign-in", () => {
     await expect.poll(() => socialStarted).toBe(true);
   });
 
+  test("shows the Google button on signup too", async ({ page }) => {
+    await requireGoogle(page);
+
+    await page.goto("/signup");
+    await expect(page.getByRole("button", { name: /Continue with Google/i })).toBeVisible();
+  });
+
+  test("linking Google to an existing account pulls in the Google profile", async ({ page }) => {
+    await requireGoogle(page);
+
+    // A password account under the address the emulator signs in as.
+    await signUpAndVerify(page, "testuser@gmail.com", "test-password-123");
+    const menu = page.getByRole("button", { name: "Account menu" });
+    await expect(menu).toContainText("testuser");
+
+    await signOut(page);
+    await page.goto("/login");
+    await page.getByRole("button", { name: /Continue with Google/i }).click();
+    await page.getByRole("button", { name: /testuser@gmail\.com/ }).click();
+    await expect(page).toHaveURL(/\/dashboard$/);
+
+    // updateUserInfoOnLink copied the Google display name onto the account.
+    await expect(menu).toContainText("Test User");
+  });
+
   test("a full Google round trip signs in, and /login then offers 'continue as'", async ({
     page,
   }) => {
@@ -47,12 +77,5 @@ test.describe("Google sign-in", () => {
     const resume = page.getByRole("button", { name: "Continue as testuser@gmail.com" });
     await expect(resume).toBeVisible();
     await expect(resume).toContainText("Last used");
-  });
-
-  test("shows the Google button on signup too", async ({ page }) => {
-    await requireGoogle(page);
-
-    await page.goto("/signup");
-    await expect(page.getByRole("button", { name: /Continue with Google/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Why

You logged in with your password account on prod, then signed in with Google, and your avatar stayed a blobatar instead of becoming your Google photo.

`accountLinking.updateUserInfoOnLink` defaults to **false**, so when Google is linked to an existing email/password account, BetterAuth links the provider row but doesn't copy the Google `image` (or `name`) onto the user. The R2 avatar sync in `session.create.after` only fires when `user.image` is a remote `http` URL, so it had nothing to pull. A brand-new Google signup works because BetterAuth sets `image` on user *creation*.

## Fix

`updateUserInfoOnLink: true` in the `accountLinking` config. On link, BetterAuth copies the Google `name` and `image` onto the local user (`email`/`emailVerified` are never touched, and undefined fields are dropped), then the existing sync stores the picture same-origin (`/api/user/avatar/...`) on that same sign-in.

Side effect: a custom display name gets overwritten by the Google name on link. Standard behavior for linked accounts, and #204 lets the user re-set it.

## Testing

- `bunx tsc -p tsconfig.worker.json` + lint clean.
- New `google-signin.pw.ts` case: sign up with a password, link Google, assert the display name flips from the email-derived name to the Google profile name ("Test User"). Reordered the Google tests so the linking one claims the shared `testuser@gmail.com` identity first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)