### PR TITLE
Stale chunk: reload once onto the current build, then a notice

### DIFF
--- a/src/app/components/error-boundary.tsx
+++ b/src/app/components/error-boundary.tsx
@@ -1,7 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import posthog from "../lib/posthog";
 import { captureClientException } from "../lib/sentry";
-import { reloadForNewVersion } from "../lib/new-version";
+import { dismissNewVersion, reloadForNewVersion } from "../lib/new-version";
 
 type Props = {
   children: ReactNode;
@@ -40,16 +40,17 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    if (isChunkLoadError(error)) {
-      // A stale tab after a deploy. The route the visitor navigated to can't
-      // render, so reload onto the current build: that fixes it and lands
-      // them where they were going. `reloadForNewVersion` returns false if
-      // we already reloaded once this session and the chunk is still
-      // failing (a broken deploy), in which case we fall through to the
-      // notice below rather than loop.
-      if (reloadForNewVersion()) return;
-      return;
-    }
+    // A stale tab after a deploy: the route the visitor navigated to can't
+    // render, so reload onto the current build. That fixes it and lands them
+    // where they were going. Latched per failure, so if it returns false the
+    // chunk is genuinely gone, not stale, and we fall through.
+    if (isChunkLoadError(error) && reloadForNewVersion(error.message)) return;
+    // Clear the top banner the failed import queued via `vite:preloadError`:
+    // the full-page notice `render()` is about to show says the same thing,
+    // and two stacked copies is the blank-page-behind-a-banner problem again.
+    if (isChunkLoadError(error)) dismissNewVersion();
+    // A chunk error that got here without reloading is a broken deploy, worth
+    // reporting; anything else is the crash the boundary exists for.
     posthog.captureException(error, { componentStack: info.componentStack });
     captureClientException(error, info.componentStack);
   }

--- a/src/app/components/error-boundary.tsx
+++ b/src/app/components/error-boundary.tsx
@@ -1,7 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import posthog from "../lib/posthog";
 import { captureClientException } from "../lib/sentry";
-import { signalNewVersionAvailable } from "../lib/new-version";
+import { reloadForNewVersion } from "../lib/new-version";
 
 type Props = {
   children: ReactNode;
@@ -41,11 +41,13 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     if (isChunkLoadError(error)) {
-      // A stale tab after a deploy: surface the "new version available"
-      // banner and let the visitor reload. The app can't render the failed
-      // chunk, so we stay blank behind the banner rather than flash the
-      // crash notice.
-      signalNewVersionAvailable();
+      // A stale tab after a deploy. The route the visitor navigated to can't
+      // render, so reload onto the current build: that fixes it and lands
+      // them where they were going. `reloadForNewVersion` returns false if
+      // we already reloaded once this session and the chunk is still
+      // failing (a broken deploy), in which case we fall through to the
+      // notice below rather than loop.
+      if (reloadForNewVersion()) return;
       return;
     }
     posthog.captureException(error, { componentStack: info.componentStack });
@@ -55,19 +57,20 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (!this.state.crashed) return this.props.children;
     if (this.props.fallback !== undefined) return this.props.fallback;
-    // A chunk-load failure renders blank behind the banner; everything else
-    // gets the crash notice.
-    if (this.state.chunkError) return null;
-    return <FullPageError />;
+    return <FullPageError chunk={this.state.chunkError} />;
   }
 }
 
-function FullPageError() {
+function FullPageError({ chunk }: { chunk?: boolean }) {
   return (
     <div className="grid min-h-screen place-items-center bg-bg px-6 text-center">
       <div className="flex max-w-md flex-col items-center gap-4">
-        <h1 className="text-lg font-bold">Something broke on this page.</h1>
-        <p className="text-sm text-muted">Reload to try again.</p>
+        <h1 className="text-lg font-bold">
+          {chunk ? "A new version is available." : "Something broke on this page."}
+        </h1>
+        <p className="text-sm text-muted">
+          {chunk ? "Reload to get the latest version." : "Reload to try again."}
+        </p>
         <button
           type="button"
           onClick={() => window.location.reload()}

--- a/src/app/components/new-version-banner.tsx
+++ b/src/app/components/new-version-banner.tsx
@@ -23,7 +23,7 @@ export function NewVersionBanner() {
       role="alert"
       className="fixed inset-x-0 top-0 z-[100] flex items-center justify-center gap-3 border-b border-border bg-surface px-4 py-2.5 text-sm"
     >
-      <span className="text-text">A new version of the app is available.</span>
+      <span className="text-text">A new version is available.</span>
       <Button variant="primary" size="sm" onClick={reloadNow}>
         Reload
       </Button>

--- a/src/app/lib/new-version.ts
+++ b/src/app/lib/new-version.ts
@@ -1,9 +1,11 @@
 // A code-split chunk failing to load almost always means a stale tab: a
 // visitor has a tab open whose hashed asset filenames no longer exist after a
-// deploy. Rather than reload (which flashes and can loop on a broken deploy)
-// or crash, we surface an in-app "new version available" banner and let the
-// visitor reload when they choose. This store is the bridge between the
-// non-React `vite:preloadError` handler and the React banner.
+// deploy. When it fails in the background (`vite:preloadError`, the visitor
+// still on a working page) we surface this "new version available" banner and
+// let them reload when they choose. When it fails while rendering a route
+// they just navigated to, the old UI is already gone, so the error boundary
+// forces one reload instead (`reloadForNewVersion`). This store is the bridge
+// between the non-React `vite:preloadError` handler and the React banner.
 
 let available = false;
 const listeners = new Set<() => void>();
@@ -35,4 +37,27 @@ export function getNewVersion(): boolean {
 
 export function reloadNow() {
   window.location.reload();
+}
+
+const RELOADED_KEY = "rdyrct:chunk-reloaded";
+
+/**
+ * One forced reload onto the current build, for when a chunk failed while
+ * rendering a route the visitor just navigated to: the old UI is already
+ * gone, so a reload is the fix, not a banner over a blank page. Guarded by a
+ * session flag so a genuinely broken deploy (reload doesn't fix the chunk)
+ * can't loop: the second chunk failure in a session returns false and the
+ * caller falls back to the notice.
+ */
+export function reloadForNewVersion(): boolean {
+  try {
+    if (sessionStorage.getItem(RELOADED_KEY)) return false;
+    sessionStorage.setItem(RELOADED_KEY, "1");
+  } catch {
+    // No sessionStorage (some private-mode configs): reload anyway. One
+    // unguarded reload still beats a blank page; a loop needs the chunk to
+    // keep failing, which is the rare broken-deploy case.
+  }
+  window.location.reload();
+  return true;
 }

--- a/src/app/lib/new-version.ts
+++ b/src/app/lib/new-version.ts
@@ -39,23 +39,30 @@ export function reloadNow() {
   window.location.reload();
 }
 
-const RELOADED_KEY = "rdyrct:chunk-reloaded";
+const RELOADED_PREFIX = "rdyrct:chunk-reloaded:";
 
 /**
  * One forced reload onto the current build, for when a chunk failed while
  * rendering a route the visitor just navigated to: the old UI is already
- * gone, so a reload is the fix, not a banner over a blank page. Guarded by a
- * session flag so a genuinely broken deploy (reload doesn't fix the chunk)
- * can't loop: it returns false on the second chunk failure in a session, or
- * when there's no sessionStorage to remember the first one, and the caller
- * falls back to the notice.
+ * gone, so a reload is the fix, not a banner over a blank page.
+ *
+ * `key` names the specific failure (the error message, which carries the
+ * missing hashed chunk's name). The reload is latched per key in
+ * sessionStorage, so a broken deploy that keeps 404ing the same chunk falls
+ * through to the notice instead of looping, while the next deploy (new chunk
+ * names, so new messages) still gets its own retry. Returns false when the
+ * latch is already set, when TanStack Router already reloaded for this same
+ * failure (`lazyRouteComponent` has its own one-shot reload), or when there's
+ * no sessionStorage to latch with.
  */
-export function reloadForNewVersion(): boolean {
+export function reloadForNewVersion(key: string): boolean {
+  const mine = RELOADED_PREFIX + key;
   try {
-    if (sessionStorage.getItem(RELOADED_KEY)) return false;
-    sessionStorage.setItem(RELOADED_KEY, "1");
+    if (sessionStorage.getItem(`tanstack_router_reload:${key}`)) return false;
+    if (sessionStorage.getItem(mine)) return false;
+    sessionStorage.setItem(mine, "1");
   } catch {
-    // No sessionStorage to guard the reload with (some locked-down privacy
+    // No sessionStorage to latch the reload with (some locked-down privacy
     // configs): show the notice instead, so a still-missing chunk can't loop.
     return false;
   }

--- a/src/app/lib/new-version.ts
+++ b/src/app/lib/new-version.ts
@@ -46,17 +46,18 @@ const RELOADED_KEY = "rdyrct:chunk-reloaded";
  * rendering a route the visitor just navigated to: the old UI is already
  * gone, so a reload is the fix, not a banner over a blank page. Guarded by a
  * session flag so a genuinely broken deploy (reload doesn't fix the chunk)
- * can't loop: the second chunk failure in a session returns false and the
- * caller falls back to the notice.
+ * can't loop: it returns false on the second chunk failure in a session, or
+ * when there's no sessionStorage to remember the first one, and the caller
+ * falls back to the notice.
  */
 export function reloadForNewVersion(): boolean {
   try {
     if (sessionStorage.getItem(RELOADED_KEY)) return false;
     sessionStorage.setItem(RELOADED_KEY, "1");
   } catch {
-    // No sessionStorage (some private-mode configs): reload anyway. One
-    // unguarded reload still beats a blank page; a loop needs the chunk to
-    // keep failing, which is the rare broken-deploy case.
+    // No sessionStorage to guard the reload with (some locked-down privacy
+    // configs): show the notice instead, so a still-missing chunk can't loop.
+    return false;
   }
   window.location.reload();
   return true;

--- a/tests/new-version.test.ts
+++ b/tests/new-version.test.ts
@@ -40,7 +40,7 @@ test("reloads once, then refuses so the tab can't loop", () => {
   expect(reloads).toBe(1);
 });
 
-test("reloads anyway when sessionStorage is unavailable", () => {
+test("shows the notice instead of reloading when sessionStorage is unavailable", () => {
   Object.assign(globalThis, {
     sessionStorage: {
       getItem() {
@@ -52,6 +52,8 @@ test("reloads anyway when sessionStorage is unavailable", () => {
     },
   });
 
-  expect(reloadForNewVersion()).toBe(true);
-  expect(reloads).toBe(1);
+  // No way to remember a reload happened, so an unguarded reload could loop:
+  // fall back to the notice.
+  expect(reloadForNewVersion()).toBe(false);
+  expect(reloads).toBe(0);
 });

--- a/tests/new-version.test.ts
+++ b/tests/new-version.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The stale-chunk recovery rule: when a lazy route chunk 404s after a deploy,
+ * the error boundary forces exactly one reload onto the current build. If the
+ * chunk is still missing after that (a genuinely broken deploy), it must stop
+ * reloading so the tab doesn't loop, and fall through to the notice instead.
+ *
+ * `vite dev` masks this in the browser: its own error overlay catches the
+ * failed dynamic import before React does, so an e2e can't see the boundary.
+ * This tests the guard, which is the whole of the new logic.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { reloadForNewVersion } from "../src/app/lib/new-version";
+
+let reloads: number;
+let store: Map<string, string>;
+
+beforeEach(() => {
+  reloads = 0;
+  store = new Map();
+  Object.assign(globalThis, {
+    sessionStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+    },
+    window: { location: { reload: () => void (reloads += 1) } },
+  });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "sessionStorage");
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+test("reloads once, then refuses so the tab can't loop", () => {
+  expect(reloadForNewVersion()).toBe(true);
+  expect(reloads).toBe(1);
+
+  // Same session, chunk still missing: no second reload, caller told to fall back.
+  expect(reloadForNewVersion()).toBe(false);
+  expect(reloads).toBe(1);
+});
+
+test("reloads anyway when sessionStorage is unavailable", () => {
+  Object.assign(globalThis, {
+    sessionStorage: {
+      getItem() {
+        throw new Error("blocked");
+      },
+      setItem() {
+        throw new Error("blocked");
+      },
+    },
+  });
+
+  expect(reloadForNewVersion()).toBe(true);
+  expect(reloads).toBe(1);
+});

--- a/tests/new-version.test.ts
+++ b/tests/new-version.test.ts
@@ -1,8 +1,9 @@
 /**
  * The stale-chunk recovery rule: when a lazy route chunk 404s after a deploy,
- * the error boundary forces exactly one reload onto the current build. If the
- * chunk is still missing after that (a genuinely broken deploy), it must stop
- * reloading so the tab doesn't loop, and fall through to the notice instead.
+ * the error boundary forces one reload onto the current build, latched per
+ * failure. If the same chunk is still missing after that (a genuinely broken
+ * deploy), it stops reloading so the tab doesn't loop and falls through to the
+ * notice; the next deploy, with new chunk names, gets its own retry.
  *
  * `vite dev` masks this in the browser: its own error overlay catches the
  * failed dynamic import before React does, so an e2e can't see the boundary.
@@ -10,6 +11,9 @@
  */
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { reloadForNewVersion } from "../src/app/lib/new-version";
+
+const A = "Failed to fetch dynamically imported module: /assets/links-a1b2c3.js";
+const B = "Failed to fetch dynamically imported module: /assets/domains-d4e5f6.js";
 
 let reloads: number;
 let store: Map<string, string>;
@@ -31,13 +35,25 @@ afterEach(() => {
   Reflect.deleteProperty(globalThis, "window");
 });
 
-test("reloads once, then refuses so the tab can't loop", () => {
-  expect(reloadForNewVersion()).toBe(true);
+test("reloads once per failure, then refuses so the tab can't loop", () => {
+  expect(reloadForNewVersion(A)).toBe(true);
   expect(reloads).toBe(1);
 
-  // Same session, chunk still missing: no second reload, caller told to fall back.
-  expect(reloadForNewVersion()).toBe(false);
+  // Same failure, chunk still missing: no second reload, caller falls back.
+  expect(reloadForNewVersion(A)).toBe(false);
   expect(reloads).toBe(1);
+});
+
+test("a different missing chunk gets its own reload", () => {
+  reloadForNewVersion(A);
+  expect(reloadForNewVersion(B)).toBe(true);
+  expect(reloads).toBe(2);
+});
+
+test("refuses when TanStack Router already reloaded for this failure", () => {
+  store.set(`tanstack_router_reload:${A}`, "1");
+  expect(reloadForNewVersion(A)).toBe(false);
+  expect(reloads).toBe(0);
 });
 
 test("shows the notice instead of reloading when sessionStorage is unavailable", () => {
@@ -52,8 +68,7 @@ test("shows the notice instead of reloading when sessionStorage is unavailable",
     },
   });
 
-  // No way to remember a reload happened, so an unguarded reload could loop:
-  // fall back to the notice.
-  expect(reloadForNewVersion()).toBe(false);
+  // No way to latch the reload, so an unguarded one could loop: fall back.
+  expect(reloadForNewVersion(A)).toBe(false);
   expect(reloads).toBe(0);
 });


### PR DESCRIPTION
## Problem

A lazy route chunk that 404s after a deploy left the visitor on a **blank page** with only a top banner. The error boundary rendered `null` for a chunk-load error on the theory that the banner would sit above it, but the banner over nothing just looks broken.

## Change

- The error boundary forces **one** reload onto the current build when it catches a chunk-load error, then lands the visitor on the route they were navigating to.
- The reload is **latched per failure** in `sessionStorage` (keyed by the error message, which carries the missing chunk's hashed name). A broken deploy that keeps 404ing the same chunk falls through to the notice instead of looping; the next deploy, with new chunk names, gets its own retry.
- It also bails when TanStack Router's own `lazyRouteComponent` one-shot reload (`tanstack_router_reload:<message>`) already fired for the same failure, so the six marketing routes don't reload twice.
- The fallthrough shows a full-page **"A new version is available"** notice with a Reload button, never a blank page. It clears the top banner the failed import queued via `vite:preloadError` (so the two don't stack) and reports the error: a chunk failure that reaches the notice is a broken deploy, not stale-tab noise.
- The background case (`vite:preloadError` on an otherwise-working page) still shows the dismissible top banner, unchanged. Banner and notice copy aligned.

## Tests

`tests/new-version.test.ts` covers the guard: reloads once per failure then refuses; a different missing chunk gets its own reload; refuses when the router already reloaded; falls back to the notice when `sessionStorage` throws. No browser e2e: `vite dev`'s error overlay catches the failed dynamic import before React does, so the boundary path isn't observable against the dev server (same reason `tests/cap-loader.test.ts` tests its deploy-chunk-404 case as a logic shape; `tests/e2e/production/assets.pw.ts` covers the server side).

`bun run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)