### PR TITLE
Trim three helpers to their shorter forms

### DIFF
--- a/src/app/lib/plain-click.ts
+++ b/src/app/lib/plain-click.ts
@@ -3,8 +3,6 @@
  * take over, rather than one the browser keeps for itself (new tab, new
  * window, download) or one something else has already dealt with.
  */
-const MODIFIER_KEYS = ["metaKey", "ctrlKey", "shiftKey", "altKey"] as const;
-
 export function isPlainLeftClick(event: {
   defaultPrevented: boolean;
   button: number;
@@ -13,6 +11,6 @@ export function isPlainLeftClick(event: {
   shiftKey: boolean;
   altKey: boolean;
 }) {
-  const modified = MODIFIER_KEYS.some((key) => event[key]);
+  const modified = event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
   return !event.defaultPrevented && event.button === 0 && !modified;
 }

--- a/src/app/routes/dashboard.tsx
+++ b/src/app/routes/dashboard.tsx
@@ -265,7 +265,7 @@ function QuickCreateCard({
   const [picked, setPicked] = useState<string | null | undefined>(undefined);
   const domainId = picked === undefined ? defaultDomainId : picked;
 
-  const { register, handleSubmit, reset, watch, setValue, setFocus } = useForm({
+  const { register, handleSubmit, reset, watch, getValues, setValue, setFocus } = useForm({
     resolver: valibotResolver(destinationSchema),
     defaultValues: { destination: "" },
   });
@@ -277,10 +277,12 @@ function QuickCreateCard({
   useEffect(() => {
     const busyElsewhere = () => {
       const el = document.activeElement;
-      return (
-        el instanceof HTMLElement &&
-        (el.isContentEditable || ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName))
-      );
+      if (!(el instanceof HTMLElement)) return false;
+      return el.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(el.tagName);
+    };
+    const fill = (value: string) => {
+      setValue("destination", value, { shouldValidate: true });
+      setFocus("destination");
     };
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.ctrlKey || e.metaKey || e.altKey || e.key.length !== 1 || busyElsewhere()) return;
@@ -288,16 +290,14 @@ function QuickCreateCard({
       // so append it by hand. busyElsewhere() already excluded the field
       // itself, so there's no double-insert.
       e.preventDefault();
-      setValue("destination", (watch("destination") ?? "") + e.key, { shouldValidate: true });
-      setFocus("destination");
+      fill((getValues("destination") ?? "") + e.key);
     };
     const onPaste = (e: ClipboardEvent) => {
       if (busyElsewhere()) return;
       const text = e.clipboardData?.getData("text")?.trim();
       if (!text) return;
       e.preventDefault();
-      setValue("destination", text, { shouldValidate: true });
-      setFocus("destination");
+      fill(text);
     };
     document.addEventListener("keydown", onKeyDown);
     document.addEventListener("paste", onPaste);
@@ -305,7 +305,7 @@ function QuickCreateCard({
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("paste", onPaste);
     };
-  }, [setFocus, setValue, watch]);
+  }, [getValues, setFocus, setValue]);
 
   const submit = handleSubmit(
     (data) => {

--- a/src/app/ui/cn.ts
+++ b/src/app/ui/cn.ts
@@ -1,8 +1,4 @@
-import { twMerge, type ClassNameValue } from "tailwind-merge";
-
 /** Joins class names, with later Tailwind utilities beating earlier ones.
- * `twMerge` is already variadic and drops falsy values, so nothing else is
- * needed: no call site passes the object form. */
-export function cn(...inputs: ClassNameValue[]): string {
-  return twMerge(inputs);
-}
+ * `twMerge` is already variadic and drops falsy values, so `cn` is just its
+ * name in this codebase: no call site passes the object form. */
+export { twMerge as cn } from "tailwind-merge";


### PR DESCRIPTION
Three small simplifications, no behaviour change.

- **`cn`**: re-export `twMerge` under the name instead of wrapping it. It is already variadic and drops falsy values, and no call site passes the object form.
- **`isPlainLeftClick`**: read the four modifier flags directly instead of iterating a key-name array.
- **`QuickCreateCard` keydown/paste**: share a `fill()` for the `setValue` + `setFocus` tail, and read the current value with `getValues()` rather than the `watch()` subscription inside the handler.

Local: `verify` (no e2e) green, `plain-click.test.ts` green, react-doctor and fallow clean on the changed files. e2e not run locally (a foreign process is squatting the emulator port); relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard destination-field handling for keyboard input and pasted content.
  * Destination values are now validated consistently, and the field receives focus after being filled.
  * Prevented input capture from interfering when another dashboard action is already in progress.

* **Refactor**
  * Simplified internal click and styling utilities without changing visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->