### PR TITLE
CI: gate prose health with style-doctor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,13 @@ jobs:
       # introduced, not inherited debt. See AGENTS.md.
       - name: Fallow audit
         run: bun run fallow
+      # Prose health for the docs this branch touched (AGENTS.md, README,
+      # docs/**). Default --blocking error: the strong LLM tells and
+      # filler openers fail CI; passive-voice and hedge words stay
+      # advisory. Generated and vendored files are excluded in
+      # .style-doctor.json.
+      - name: Style Doctor
+        run: bun run style
 
   unit:
     runs-on: ubuntu-latest

--- a/.style-doctor.json
+++ b/.style-doctor.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["video-hf/**", "THIRD_PARTY_LICENSES.md", "public/llms-full.txt", "public/robots.txt"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ suite.** `bun run verify:e2e` is the gate CI runs, unscoped, before a PR
 merges — that stays mandatory, and the full `e2e:smoke` run only happens
 there, never as a local default. Re-running every unit test, worker test and
 e2e spec after every edit is not extra safety, it's noise that hides which
-check actually matters: a change to QR-logo storage doesn't need the billing
+check matters: a change to QR-logo storage doesn't need the billing
 or short-link-creation specs to pass again, it needs the ones that touch R2,
 the qr-logo routes, and whatever renders the logo. Find the blast radius
 first (`codegraph_explore`'s blast-radius summary, or `git diff` against
@@ -141,7 +141,7 @@ Shell writes to repo files are sandboxed; edit through the editor tools, not
   `/login`, `/signup`, `/privacy`, `/terms`, `/reset-password`,
   `/invite/:token`. The app lives at root keywords: `/dashboard` (quick link
   creation, quick stats, recent activity), `/analytics` (the full stats page), `/links`,
-  `/domains`, `/members`, `/billing`, `/settings`, `/admin`. There is **no org id
+  `/domains`, `/members`, `/billing`, `/settings`, `/admin`. **No org id
   in URLs**: the current org is a localStorage-backed store, `useCurrentOrg`
   (`src/app/lib/current-org.ts`). Those keywords are reserved from custom slugs
   via `RESERVED_SLUGS` in `src/worker/util.ts` (the Worker also guards `/:slug`).
@@ -166,7 +166,7 @@ analyticsDays }`). Slugs on the **shared** domain are always random (every
   can't be squatted. Every account gets an org at
   sign-up (#65), named from the email domain (`src/shared/org-name.ts`) and
   renameable in Settings, so nobody meets a dead app behind a form asking
-  for a company name. The dashboard asks for a **link** until there is one,
+  for a company name. The dashboard asks for a **link** until one exists,
   then goes back to being a dashboard. `NoOrgState`
   (`src/app/components/no-org.tsx`) is still there for the account that has
   no org left (it deleted the only one), and `/billing` still works org-less,

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "oxlint": "1.79.0",
         "portless": "^0.15.5",
         "react-doctor": "^0.9.12",
+        "style-doctor": "0.2.0",
         "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
@@ -1501,6 +1502,8 @@
     "stubborn-fs": ["stubborn-fs@2.0.0", "", { "dependencies": { "stubborn-utils": "^1.0.1" } }, "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA=="],
 
     "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
+
+    "style-doctor": ["style-doctor@0.2.0", "", { "bin": { "style-doctor": "cli.js" } }, "sha512-DU2ehd9HZUm06KxpHqa2XwWeS1wLo+4nVdWMnuDvQA19dU8YK5jzXdJgTFpqSWbyQjrgF3eD3NXIm5RdogmQzw=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,7 +141,7 @@ one key, and its consumer reads current D1 state before it changes KV. This make
 duplicate and out-of-order messages safe. R2 deletes and Workflow steps are also
 designed to run more than once.
 
-There are two distinct consistency promises:
+Two distinct consistency promises:
 
 - D1 is the product truth. API reads after a successful write use D1.
 - KV is a fast, eventually consistent redirect index. Cloudflare states that a

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "check:contrast": "bun scripts/check-contrast.ts",
     "doctor": "react-doctor",
     "fallow": "fallow audit --base origin/main",
-    "check:observability": "evlog map --min-score 100"
+    "check:observability": "evlog map --min-score 100",
+    "style": "style-doctor --scope changed --base origin/main"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
@@ -102,6 +103,7 @@
     "oxlint": "1.79.0",
     "portless": "^0.15.5",
     "react-doctor": "^0.9.12",
+    "style-doctor": "0.2.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
     "vite": "^8.2.2",


### PR DESCRIPTION
## What

- `style-doctor@0.2.0` as a dev dep + `bun run style` (`--scope changed --base origin/main`).
- New step in the `static` CI job, after fallow.
- `.style-doctor.json` excludes the vendored `video-hf/**` subproject and the generated `THIRD_PARTY_LICENSES.md`, `public/llms-full.txt`, `public/robots.txt`.
- Folds in four prose fixes from an earlier pass (cut `actually`, two `there is/are` openers in AGENTS.md, one in `docs/architecture.md`).

## Blocking level

Default `--blocking error`: the strong LLM tells (`delve`, `not just X but Y`, `rich tapestry`, …) and filler openers (`it's important to note`) fail CI. Passive-voice and hedge-word findings stay advisory — blocking on warnings would fail today without rewriting 50+ lines of otherwise-fine reference docs.

## Tested

- `bun run style` on this branch: score 98, exit 0 (2 changed docs, warnings only).
- Error path: a file with `delve` / `rich tapestry` / `it's important to note` → exit 1.
- `format:check`, `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated style checks for changed files.
  * Excluded generated, third-party, and video-related files from style analysis.

* **Documentation**
  * Improved wording in contributor guidance and architecture documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->