### PR TITLE
WebMCP: more link tools + logged-out marketing tools

### DIFF
--- a/src/app/components/marketing-page.tsx
+++ b/src/app/components/marketing-page.tsx
@@ -17,6 +17,7 @@ import { useSeo } from "../lib/seo";
 import { useMarketingScroll } from "../lib/marketing-scroll";
 import { useAudience } from "../lib/audience";
 import { LandingHeader } from "./landing-header";
+import { WebMcpMarketingTools } from "./webmcp-marketing-tools";
 import { Footer } from "../ui/footer";
 
 export function MarketingPage({
@@ -39,6 +40,7 @@ export function MarketingPage({
     <MotionConfig reducedMotion="user">
       <LazyMotion features={domAnimation}>
         <div className="relative mx-auto min-h-dvh max-w-5xl px-6">
+          <WebMcpMarketingTools />
           <LandingHeader authed={authed} />
 
           <main>

--- a/src/app/components/webmcp-link-tools.tsx
+++ b/src/app/components/webmcp-link-tools.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import * as v from "valibot";
-import type { LinkDTO, LinkInput, WithQuotaUsage } from "@/shared/types";
+import type { JsonValue, LinkDTO, LinkInput, WithQuotaUsage } from "@/shared/types";
 import { api } from "../lib/api";
 import { useCurrentOrg } from "../lib/current-org";
 import { useCurrentUser } from "../lib/hooks";
@@ -12,10 +12,24 @@ const findLinksInput = v.object({
   query: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(100))),
 });
 
+const slugField = v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(200));
+
 const createLinkInput = v.object({
   destination: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(2_000)),
   title: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200))),
 });
+
+const getLinkInput = v.object({ slug: slugField });
+
+const updateLinkInput = v.object({
+  slug: slugField,
+  destination: v.optional(v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(2_000))),
+  title: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200))),
+});
+
+const deleteLinkInput = v.object({ slug: slugField });
+
+type SlugSchema<T extends { slug: string }> = v.BaseSchema<unknown, T, v.BaseIssue<unknown>>;
 
 function inputError(): string {
   return "That tool input is not valid. Check the required fields and try again.";
@@ -45,6 +59,39 @@ export function WebMcpLinkTools() {
 
   useEffect(() => {
     if (!currentUser.data || !org) return;
+    const orgId = org.id;
+
+    const refreshLinks = () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["links", orgId] }),
+        queryClient.invalidateQueries({ queryKey: ["stats", orgId] }),
+        queryClient.invalidateQueries({ queryKey: ["linkQuotaUsage", orgId] }),
+      ]);
+
+    // Agents hold a slug, not the internal id the API keys on, so every
+    // per-link tool resolves one through the same search the list page uses.
+    const linkBySlug = async (slug: string, signal?: AbortSignal): Promise<LinkDTO | null> => {
+      const result = await api<{ items: LinkDTO[] }>(
+        `/orgs/${orgId}/links?${linkSearchParams(slug)}`,
+        { signal },
+      );
+      return result.items.find((link) => link.slug === slug) ?? null;
+    };
+
+    // Parse a slug-keyed input, resolve the link, and hand both to the tool
+    // body. Keeps get/update/delete free of the same three guard clauses.
+    const withLink = async <T extends { slug: string }>(
+      schema: SlugSchema<T>,
+      input: JsonValue,
+      signal: AbortSignal | undefined,
+      run: (link: LinkDTO, parsed: T) => Promise<string>,
+    ): Promise<string> => {
+      const parsed = v.safeParse(schema, input);
+      if (!parsed.success) return inputError();
+      const link = await linkBySlug(parsed.output.slug, signal);
+      if (!link) return "No link with that slug in the current organization.";
+      return run(link, parsed.output);
+    };
 
     const tools: WebMcpTool[] = [
       {
@@ -60,12 +107,29 @@ export function WebMcpLinkTools() {
           const parsed = v.safeParse(findLinksInput, input);
           if (!parsed.success) return inputError();
           const result = await api<{ items: LinkDTO[] }>(
-            `/orgs/${org.id}/links?${linkSearchParams(parsed.output.query)}`,
+            `/orgs/${orgId}/links?${linkSearchParams(parsed.output.query)}`,
             { signal: options?.signal },
           );
           if (result.items.length === 0) return "No matching links in the current organization.";
           return toolResult(result.items.map(conciseLink).join("\n"));
         },
+      },
+      {
+        name: "get_link",
+        description:
+          "Look up one link in the current organization by its exact slug. Returns its destination, title, click count, and address count as untrusted text.",
+        inputSchema: {
+          type: "object",
+          properties: { slug: { type: "string", minLength: 1, maxLength: 200 } },
+          required: ["slug"],
+        },
+        annotations: { readOnlyHint: true, untrustedContentHint: true },
+        execute: (input, options) =>
+          withLink(getLinkInput, input, options?.signal, async (link) =>
+            toolResult(
+              `${conciseLink(link)}. ${link.clicks} clicks, ${link.addressCount} addresses.`,
+            ),
+          ),
       },
       {
         name: "create_link",
@@ -84,19 +148,75 @@ export function WebMcpLinkTools() {
           const parsed = v.safeParse(createLinkInput, input);
           if (!parsed.success) return inputError();
           const body: LinkInput = { ...parsed.output, forceSeparateLink: true };
-          const link = await api<WithQuotaUsage<LinkDTO>>(`/orgs/${org.id}/links`, {
+          const link = await api<WithQuotaUsage<LinkDTO>>(`/orgs/${orgId}/links`, {
             method: "POST",
             body,
             signal: options?.signal,
           });
-          await Promise.all([
-            queryClient.invalidateQueries({ queryKey: ["links", org.id] }),
-            queryClient.invalidateQueries({ queryKey: ["stats", org.id] }),
-            queryClient.invalidateQueries({ queryKey: ["linkQuotaUsage", org.id] }),
-          ]);
+          await refreshLinks();
           await navigate({ to: "/links" });
           return toolResult(`Created ${conciseLink(link)}. The Links page now shows it.`);
         },
+      },
+      {
+        name: "update_link",
+        description:
+          "Change the destination and/or title of a link in the current organization, found by its exact slug. The slug itself does not change.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            slug: { type: "string", minLength: 1, maxLength: 200 },
+            destination: { type: "string", minLength: 1, maxLength: 2_000 },
+            title: { type: "string", maxLength: 200 },
+          },
+          required: ["slug"],
+        },
+        annotations: { readOnlyHint: false, untrustedContentHint: true },
+        execute: (input, options) =>
+          withLink(
+            updateLinkInput,
+            input,
+            options?.signal,
+            async (link, { destination, title }) => {
+              if (destination === undefined && title === undefined)
+                return "Give a new destination or title to change.";
+              // undefined keys drop out of the JSON body, so this is a true
+              // partial patch: an untouched field keeps its stored value.
+              const body: Partial<LinkInput> = { destination, title };
+              const updated = await api<WithQuotaUsage<LinkDTO>>(
+                `/orgs/${orgId}/links/${link.id}`,
+                {
+                  method: "PATCH",
+                  body,
+                  signal: options?.signal,
+                },
+              );
+              await refreshLinks();
+              await navigate({ to: "/links" });
+              return toolResult(`Updated ${conciseLink(updated)}.`);
+            },
+          ),
+      },
+      {
+        name: "delete_link",
+        description:
+          "Delete a link in the current organization, found by its exact slug. This stops the short link from redirecting, including any printed QR codes. It cannot be undone.",
+        inputSchema: {
+          type: "object",
+          properties: { slug: { type: "string", minLength: 1, maxLength: 200 } },
+          required: ["slug"],
+        },
+        annotations: { readOnlyHint: false, untrustedContentHint: true },
+        execute: (input, options) =>
+          withLink(deleteLinkInput, input, options?.signal, async (link) => {
+            await api(`/orgs/${orgId}/links/${link.id}`, {
+              method: "DELETE",
+              signal: options?.signal,
+            });
+            await refreshLinks();
+            await navigate({ to: "/links" });
+            return toolResult(`Deleted rdyrct.com/${link.slug}. It no longer redirects.`);
+          }),
       },
     ];
 

--- a/src/app/components/webmcp-link-tools.tsx
+++ b/src/app/components/webmcp-link-tools.tsx
@@ -126,8 +126,10 @@ export function WebMcpLinkTools() {
         annotations: { readOnlyHint: true, untrustedContentHint: true },
         execute: (input, options) =>
           withLink(getLinkInput, input, options?.signal, async (link) =>
+            // Counts first: a very long destination in conciseLink would
+            // otherwise push them past the toolResult length cap.
             toolResult(
-              `${conciseLink(link)}. ${link.clicks} clicks, ${link.addressCount} addresses.`,
+              `${link.clicks} clicks, ${link.addressCount} addresses. ${conciseLink(link)}`,
             ),
           ),
       },

--- a/src/app/components/webmcp-marketing-tools.tsx
+++ b/src/app/components/webmcp-marketing-tools.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+import { ORG_PLANS, PLAN_LIMITS, PLAN_PRICES, type OrgPlan } from "@/shared/types";
+import { registerWebMcpTools, type WebMcpTool } from "../lib/webmcp";
+
+/**
+ * Read-only WebMCP tools for the logged-out marketing pages. They hand a
+ * browser agent the same plan numbers and product summary the pages show,
+ * so it answers "what does rdyrct cost" from a value it was given rather
+ * than by scraping the layout. First-party static copy, no API, no auth.
+ */
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+function planLine(plan: OrgPlan): string {
+  const limits = PLAN_LIMITS[plan];
+  const name = plan[0].toUpperCase() + plan.slice(1);
+  const price = plan === "free" ? "$0" : `${PLAN_PRICES[plan]}/mo`;
+  const qr = limits.qrCustom ? "branded QR codes (logo and colors)" : "plain QR codes only";
+  return (
+    `${name} (${price}): ${plural(limits.links, "link")}, ${plural(limits.members, "team member")}, ` +
+    `${plural(limits.domains, "custom domain")}, ${limits.analyticsDays}-day click analytics, ` +
+    `${plural(limits.orgs, "organization")}, ${qr}.`
+  );
+}
+
+const PRICING = [
+  ...ORG_PLANS.map(planLine),
+  "Only the organization owner needs a paid plan; one subscription covers every organization they own.",
+  "rdyrct is open source and self-hosts on your own Cloudflare account with everything Pro has, minus email support.",
+].join("\n");
+
+const OVERVIEW = [
+  "rdyrct is a link shortener and QR code generator for teams, running entirely on Cloudflare.",
+  "The free plan is a working shortener: short links, click tracking (country, referrer, device, and time, never an IP address), and a QR code generator. No credit card.",
+  "Paid plans add a custom domain with your own slugs, branded QR codes, more links and team members, and a longer analytics history.",
+  "Links on the shared domain always get a random slug; chosen slugs need a custom domain.",
+].join(" ");
+
+function marketingResult(message: string): string {
+  return message.slice(0, 2_000);
+}
+
+/** Mounted on the landing page and every standalone marketing page. */
+export function WebMcpMarketingTools() {
+  useEffect(() => {
+    const tools: WebMcpTool[] = [
+      {
+        name: "get_rdyrct_pricing",
+        description:
+          "Get rdyrct's plans, prices, and per-plan limits (links, team members, custom domains, analytics history).",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+        execute: async () => marketingResult(PRICING),
+      },
+      {
+        name: "get_rdyrct_overview",
+        description:
+          "Get a short summary of what rdyrct is, what the free plan includes, and what paid plans add.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+        execute: async () => marketingResult(OVERVIEW),
+      },
+    ];
+
+    return registerWebMcpTools(tools);
+  }, []);
+
+  return null;
+}

--- a/src/app/routes/landing.tsx
+++ b/src/app/routes/landing.tsx
@@ -45,6 +45,7 @@ import { Footer, GITHUB_URL } from "../ui/footer";
 import { HeroShortener } from "../components/hero-shortener";
 import { HeroSignedIn } from "../components/hero-signed-in";
 import { LandingHeader } from "../components/landing-header";
+import { WebMcpMarketingTools } from "../components/webmcp-marketing-tools";
 import cloudflareLogo from "../assets/cloudflare.svg";
 /**
  * The mock pulls in the whole charts bundle (Plot, the renderer, the scales):
@@ -1404,6 +1405,7 @@ export function LandingPage() {
       <LazyMotion features={domAnimation}>
         <div className="relative mx-auto min-h-dvh max-w-5xl px-6">
           <FaqJsonLd faqs={faqs} />
+          <WebMcpMarketingTools />
           <style>{`@keyframes cursorBlink { 50% { opacity: 0; } }`}</style>
           {/* soft accent glow behind the hero */}
           <div

--- a/tests/e2e/webmcp.pw.ts
+++ b/tests/e2e/webmcp.pw.ts
@@ -100,6 +100,23 @@ test("a browser agent can fill the visible QR generator", async ({ page }) => {
     .toBe(false);
 });
 
+test("the logged-out landing page exposes marketing tools", async ({ page }) => {
+  await supportWebMcp(page);
+  await page.goto("/");
+  await toolNamed(page, "get_rdyrct_pricing");
+  await toolNamed(page, "get_rdyrct_overview");
+
+  const [pricing, overview] = await page.evaluate(async () => {
+    const run = (name: string) =>
+      window.webMcpTools.find((tool) => tool.name === name)?.execute({});
+    return Promise.all([run("get_rdyrct_pricing"), run("get_rdyrct_overview")]);
+  });
+
+  expect(pricing).toContain("Hobby ($4/mo)");
+  expect(pricing).toContain("Pro ($9/mo)");
+  expect(overview).toMatch(/link shortener and QR code generator/);
+});
+
 test("a browser without WebMCP leaves the QR generator working", async ({ page }) => {
   await page.goto("/qr-code-generator");
   await page.getByLabel("Link or text").fill("https://example.com/no-webmcp");
@@ -142,6 +159,37 @@ test("a signed-in browser agent can create and find a link", async ({ page }) =>
   });
   expect(analytics).toMatch(/Analytics for the current organization/);
   await expect(page).toHaveURL(/\/analytics$/);
+
+  const slug = created?.match(/rdyrct\.com\/(\S+)/)?.[1] ?? "";
+  expect(slug).not.toBe("");
+
+  await toolNamed(page, "get_link");
+  await toolNamed(page, "update_link");
+  await toolNamed(page, "delete_link");
+
+  const details = await page.evaluate(async (linkSlug) => {
+    const tool = window.webMcpTools.find((candidate) => candidate.name === "get_link");
+    return tool?.execute({ slug: linkSlug }, { signal: new AbortController().signal });
+  }, slug);
+  expect(details).toContain("0 clicks");
+
+  const updated = await page.evaluate(async (linkSlug) => {
+    const tool = window.webMcpTools.find((candidate) => candidate.name === "update_link");
+    return tool?.execute(
+      { slug: linkSlug, destination: "https://example.com/agent-moved", title: "Moved" },
+      { signal: new AbortController().signal },
+    );
+  }, slug);
+  expect(updated).toMatch(/Updated rdyrct\.com\//);
+  await expect(page).toHaveURL(/\/links$/);
+  await expect(page.getByText("https://example.com/agent-moved")).toBeVisible();
+
+  const deleted = await page.evaluate(async (linkSlug) => {
+    const tool = window.webMcpTools.find((candidate) => candidate.name === "delete_link");
+    return tool?.execute({ slug: linkSlug }, { signal: new AbortController().signal });
+  }, slug);
+  expect(deleted).toMatch(/no longer redirects/);
+  await expect(page.getByText("https://example.com/agent-moved")).toHaveCount(0);
 });
 
 function windowTextLength(value: string | undefined): number {


### PR DESCRIPTION
## New tools

**Signed-in** (`WebMcpLinkTools`):
- `get_link` — one link by exact slug, with click and address counts
- `update_link` — change destination and/or title by slug (partial patch; slug is unchanged)
- `delete_link` — remove a link by slug; description states it stops the redirect and any printed QR codes

A shared `withLink()` helper handles parse → resolve slug → not-found for all three.

**Logged out** (`WebMcpMarketingTools`, new; mounted on the landing page and every `MarketingPage` — `/pricing`, `/roadmap`, `/privacy`, `/terms`):
- `get_rdyrct_pricing` — plans, prices, per-plan caps, straight from `PLAN_LIMITS` / `PLAN_PRICES`
- `get_rdyrct_overview` — what rdyrct is and what each tier adds

Read-only, first-party constants, no API, no auth. Gives a browser agent the pricing numbers directly instead of leaving it to scrape the page. Absent browser support stays a no-op, as before.

## Tests

- `tests/e2e/webmcp.pw.ts`: marketing tools asserted on the logged-out landing page; the signed-in spec now runs get → update → delete against a freshly created link.
- Verified `get_rdyrct_pricing` / `get_rdyrct_overview` in a real browser against the dev server (register, execute, correct output, no page errors).
- `bun run verify` green; `fallow` clean on the 5 changed files (complexity 0 after the `withLink` refactor).

Full e2e suite runs in CI (local run blocked by a port clash with a running dev server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)