### PR TITLE
WebMCP: create_qr_code hands off to the full generator

### DIFF
--- a/docs/webmcp-demo-script.md
+++ b/docs/webmcp-demo-script.md
@@ -1,0 +1,33 @@
+Hi, I'm baronunread, and this is my entry for the WebMCP challenge. I didn't build something new for it. I took something I already had, and handed it to the agents.
+
+That something is rdyrct, a link shortener and QR code generator for teams. It's been live for a while. There's no new backend here, no plugin. The tools are registered right from the pages.
+
+I'm driving this through the WebMCP Inspector. Let's start on the public site, before we go to the user dashboard.
+
+First, let's ask the browser agent to generate a QR code for the Devpost page for this challenge.
+
+⏸ PAUSE — fire create-QR-code in the Inspector, a real QR image comes back. Cut the entry, speed the render.
+
+That's a WebMCP tool running on a logged-out marketing page. It generated a working code and handed back an image, and nothing left the browser. Right next to it there's a pricing tool that gives the agent the real plan numbers, so it never has to scrape the page to answer what rdyrct costs.
+
+Now let's go to the user dashboard. This is my own organization on production, so the click numbers are small, but they're real.
+
+Let's ask the agent to shorten the Devpost challenge page and title it WebMCP Challenge.
+
+⏸ PAUSE — fire create-link, Links page opens with the new row. Cut and speed.
+
+That's a real tracked link. The agent didn't fill out a form. rdyrct gave it a create-link tool, and the app jumped to the Links page on its own.
+
+Next, let's ask it for my analytics over the last thirty days.
+
+⏸ PAUSE — fire get-analytics, Analytics page opens, numbers render. Cut and speed.
+
+That's the get-analytics tool. Total clicks, top links, countries, referrers, devices, and never an IP address. There are four more in the app: find-links, get-link, update-link, and delete-link. Six in total, and every one is scoped to your organization through the same API the interface uses.
+
+All of this is registered with model context register tool, straight from React. There's no server and no plugin. If the browser supports WebMCP, the tools show up. If it doesn't, this is the same normal website it's always been.
+
+WebMCP fits rdyrct because the work is small, and easy to say out loud. Make a link. Check how it's doing. Delete the dead ones. That's a sentence, not a dashboard you want to sit in. So now the same links and the same analytics are reachable two ways. You click when you want to look at something. You ask when you just want it done. Someone can tell their agent to clean up every link with no clicks in the last thirty days, and it'll run get-analytics, then delete-link, on their data, with their permissions.
+
+And we didn't loosen anything to get here. Every tool that returns text is marked untrusted, so a destination URL is treated as data, not as an instruction. Writes are marked as writes. The agent gets exactly the API and the permissions a person has, nothing more.
+
+That's the integration. An existing product, unchanged, that a browser agent can now drive, because it hands out WebMCP tools from the page.

--- a/src/app/components/webmcp-marketing-tools.tsx
+++ b/src/app/components/webmcp-marketing-tools.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import * as v from "valibot";
 import { ORG_PLANS, PLAN_LIMITS, PLAN_PRICES, type OrgPlan } from "@/shared/types";
 import { resolveLook } from "../lib/qr-look";
@@ -57,6 +58,8 @@ function marketingResult(message: string): string {
 /** Mounted on the landing page and every standalone marketing page, including
  * the QR generator and the legal pages. */
 export function WebMcpMarketingTools() {
+  const navigate = useNavigate();
+
   useEffect(() => {
     const tools: WebMcpTool[] = [
       {
@@ -78,7 +81,7 @@ export function WebMcpMarketingTools() {
       {
         name: "create_qr_code",
         description:
-          "Generate a free QR code for any link or text and return it as an image data URL (PNG or SVG). No account needed, and nothing is sent anywhere. For colors, a logo, or dot styles, open rdyrct.com/qr-code-generator.",
+          "Generate a free QR code for any link or text. Returns it as an image data URL (PNG or SVG) and opens the full generator at rdyrct.com/qr-code-generator with that value, where generate_qr_code and download_qr_code can change the colors, dot style, or logo and save a file. No account needed, and nothing is sent anywhere.",
         inputSchema: {
           type: "object",
           properties: {
@@ -92,13 +95,19 @@ export function WebMcpMarketingTools() {
           const parsed = v.safeParse(qrInput, input);
           if (!parsed.success) return "Provide a non-empty link or text of up to 2000 characters.";
           const { qrDataUrl } = await import("./qr");
-          return qrDataUrl(parsed.output.value, resolveLook({}), parsed.output.format ?? "png");
+          const dataUrl = qrDataUrl(
+            parsed.output.value,
+            resolveLook({}),
+            parsed.output.format ?? "png",
+          );
+          await navigate({ to: "/qr-code-generator", search: { value: parsed.output.value } });
+          return dataUrl;
         },
       },
     ];
 
     return registerWebMcpTools(tools);
-  }, []);
+  }, [navigate]);
 
   return null;
 }

--- a/src/app/routes/qr-generator.tsx
+++ b/src/app/routes/qr-generator.tsx
@@ -290,7 +290,12 @@ export function QrGeneratorPage() {
   const { authed } = useAudience();
   useSeo("/qr-code-generator");
   useMarketingScroll();
-  const [value, setValue] = useState("");
+  // WebMCP's create_qr_code (on any marketing page) hands off to here by
+  // navigating with ?value=, so the code is already on screen when a browser
+  // agent follows up with generate_qr_code or download_qr_code.
+  const [value, setValue] = useState(
+    () => new URLSearchParams(window.location.search).get("value")?.trim().slice(0, 2_000) ?? "",
+  );
   const [values, setValues] = useState<QrValues>(EMPTY_QR);
   const qrState = useRef({ encoded: "", values: EMPTY_QR });
 


### PR DESCRIPTION
## What

`create_qr_code` (the marketing WebMCP tool on the landing page, legal pages, and the generator page) now navigates to `/qr-code-generator?value=<value>` after rendering the code. `QrGeneratorPage` seeds its input from that query param on mount.

## Why

A browser agent that starts on any marketing page could get a QR data URL but had no way to reach the richer, stateful generator tools (`generate_qr_code`, `download_qr_code`), which only register while the generator page is mounted. Now one call lands the agent on the real generator with the code already up, and it can follow up to recolor, restyle, add a logo, or download a file, matching how `get_analytics` navigates to `/analytics`.

## Notes

- Still returns the data URL, so the headless "any page, give me an image" use is unchanged.
- On the legal pages this means a `create_qr_code` call navigates away from the page. Acceptable: the agent explicitly asked for a QR code.
- No e2e added (time-boxed). Verified by hand: `/qr-code-generator?value=https://webmcp.devpost.com/` seeds the input and renders the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a WebMCP demonstration covering QR-code generation, link management, analytics, and available browser tools.
  * QR-code generation now opens the generator with the submitted value prefilled.
  * Added guidance on tool permissions and handling of untrusted results.

* **Documentation**
  * Added a script for showcasing WebMCP capabilities across public and dashboard experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->