### PR TITLE
WebMCP QR: render PNG on a canvas instance (fixes intermittent export failure)

### DIFF
--- a/docs/webmcp-demo-script.md
+++ b/docs/webmcp-demo-script.md
@@ -20,10 +20,10 @@ First, let's ask the browser agent to make a QR code for the Devpost page for th
 
 That one call did two things. It rendered a QR code and handed the agent an image, and it moved us to the real generator with the value filled in. That matters, because this page has its own tools.
 
-Let's ask the agent to give the dots a dark green, and download it as an SVG.
+Let's ask the agent to give the dots a dark green, and download it as a PNG.
 
           - - - - - GAP: generate_qr_code recolors the visible generator,
-          then download_qr_code saves the SVG file. Stay silent. Resume once
+          then download_qr_code saves the PNG file. Stay silent. Resume once
           the file lands. - - - - -
 
 So the agent walked from a public page onto the generator and drove it like a person would. Recolored it, and downloaded a file. Next to these there's also a pricing tool that hands the agent the real plan numbers, so it never scrapes the page to answer what rdyrct costs.

--- a/docs/webmcp-demo-script.md
+++ b/docs/webmcp-demo-script.md
@@ -1,30 +1,50 @@
+▶ One continuous teleprompter scroll. Never pause it (Cap resets to the top).
+At each GAP: stop talking, run the tool call, keep your eyes on the page.
+The blank runway keeps the scroll drifting so you land on the next line
+when you resume. Cut the dead silence in the edit, and speed or jump-cut
+anything that shows a prompt being typed or text streaming in.
+
+---
+
 Hi, I'm baronunread, and this is my entry for the WebMCP challenge. I didn't build something new for it. I took something I already had, and handed it to the agents.
 
 That something is rdyrct, a link shortener and QR code generator for teams. It's been live for a while. There's no new backend here, no plugin. The tools are registered right from the pages.
 
-I'm driving this through the WebMCP Inspector. Let's start on the public site, before we go to the user dashboard.
+I'm driving this through the WebMCP Inspector. Let's start on the homepage, before we touch the dashboard.
 
-First, let's ask the browser agent to generate a QR code for the Devpost page for this challenge.
+First, let's ask the browser agent to make a QR code for the Devpost page for this challenge.
 
-⏸ PAUSE — fire create-QR-code in the Inspector, a real QR image comes back. Cut the entry, speed the render.
+          - - - - - GAP: create_qr_code fires. Stay silent. The app leaves
+          the homepage, lands on the full QR generator, the code is on
+          screen. Resume when you see it. - - - - -
 
-That's a WebMCP tool running on a logged-out marketing page. It generated a working code and handed back an image, and nothing left the browser. Right next to it there's a pricing tool that gives the agent the real plan numbers, so it never has to scrape the page to answer what rdyrct costs.
+That one call did two things. It rendered a QR code and handed the agent an image, and it moved us to the real generator with the value filled in. That matters, because this page has its own tools.
 
-Now let's go to the user dashboard. This is my own organization on production, so the click numbers are small, but they're real.
+Let's ask the agent to give the dots a dark green, and download it as an SVG.
+
+          - - - - - GAP: generate_qr_code recolors the visible generator,
+          then download_qr_code saves the SVG file. Stay silent. Resume once
+          the file lands. - - - - -
+
+So the agent walked from a public page onto the generator and drove it like a person would. Recolored it, and downloaded a file. Next to these there's also a pricing tool that hands the agent the real plan numbers, so it never scrapes the page to answer what rdyrct costs.
+
+Now the dashboard. This is my own organization on production, so the click numbers are small, but they're real.
 
 Let's ask the agent to shorten the Devpost challenge page and title it WebMCP Challenge.
 
-⏸ PAUSE — fire create-link, Links page opens with the new row. Cut and speed.
+          - - - - - GAP: create_link runs. Stay silent. The Links page
+          opens with the new row. Resume when it shows. - - - - -
 
-That's a real tracked link. The agent didn't fill out a form. rdyrct gave it a create-link tool, and the app jumped to the Links page on its own.
+A real tracked link. The agent didn't fill out a form. rdyrct gave it a create-link tool, and the app jumped to the Links page on its own.
 
 Next, let's ask it for my analytics over the last thirty days.
 
-⏸ PAUSE — fire get-analytics, Analytics page opens, numbers render. Cut and speed.
+          - - - - - GAP: get_analytics runs. Stay silent. The Analytics
+          page opens, the numbers render. Resume when they do. - - - - -
 
-That's the get-analytics tool. Total clicks, top links, countries, referrers, devices, and never an IP address. There are four more in the app: find-links, get-link, update-link, and delete-link. Six in total, and every one is scoped to your organization through the same API the interface uses.
+Total clicks, top links, countries, referrers, devices, and never an IP address. There are four more tools in the app: find-links, get-link, update-link, and delete-link. Every one is scoped to your organization through the same API the interface uses.
 
-All of this is registered with model context register tool, straight from React. There's no server and no plugin. If the browser supports WebMCP, the tools show up. If it doesn't, this is the same normal website it's always been.
+All of this is registered with model context register tool, straight from React. If the browser supports WebMCP, the tools show up. If it doesn't, this is the same normal website it's always been.
 
 WebMCP fits rdyrct because the work is small, and easy to say out loud. Make a link. Check how it's doing. Delete the dead ones. That's a sentence, not a dashboard you want to sit in. So now the same links and the same analytics are reachable two ways. You click when you want to look at something. You ask when you just want it done. Someone can tell their agent to clean up every link with no clicks in the last thirty days, and it'll run get-analytics, then delete-link, on their data, with their permissions.
 

--- a/src/app/components/qr.tsx
+++ b/src/app/components/qr.tsx
@@ -43,7 +43,12 @@ export async function qrDataUrl(
   look: QrLook,
   extension: "png" | "svg",
 ): Promise<string> {
-  const raw = await makeQR(url, DOWNLOAD_SIZE, look).getRawData(extension);
+  const raw = await makeQR(
+    url,
+    DOWNLOAD_SIZE,
+    look,
+    extension === "png" ? "canvas" : "svg",
+  ).getRawData(extension);
   if (!raw) throw new Error("Could not render the QR code.");
   const bytes = raw instanceof Blob ? new Uint8Array(await raw.arrayBuffer()) : new Uint8Array(raw);
   let binary = "";
@@ -84,7 +89,10 @@ export function QrDownloadButtons({
   const toast = useToast();
   const download = async (extension: "png" | "svg") => {
     try {
-      await makeQR(url, DOWNLOAD_SIZE, resolved).download({ name, extension });
+      await makeQR(url, DOWNLOAD_SIZE, resolved, extension === "png" ? "canvas" : "svg").download({
+        name,
+        extension,
+      });
       posthog.capture("qr_code_downloaded", { format: extension });
     } catch {
       // Drawing at 1024px can fail on a browser short of memory, and the
@@ -140,11 +148,17 @@ const MARGIN_RATIO = 8 / 208;
  */
 const PREVIEW_RENDER_SIZE = 1024;
 
-function makeQR(url: string, size: number, look: QrLook) {
+// A PNG asks for `canvas`: rasterizing an SVG instance goes SVG string -> img
+// decode -> drawImage -> toBlob, and that chain throws "the operation failed
+// for an unknown transient reason" intermittently. A canvas instance draws
+// straight to the bitmap. The seam merge below is an SVG-DOM rewrite and only
+// shows on a scaled SVG anyway, so a canvas render skips it with no visible
+// difference.
+function makeQR(url: string, size: number, look: QrLook, renderAs: "svg" | "canvas" = "svg") {
   const qr = new QRCodeStyling({
     width: size,
     height: size,
-    type: "svg",
+    type: renderAs,
     data: url,
     image: look.logo,
     margin: Math.round(size * MARGIN_RATIO),
@@ -154,7 +168,7 @@ function makeQR(url: string, size: number, look: QrLook) {
   });
   // Runs after every draw, on the same element the preview shows and the SVG
   // download serializes, so neither can ship the seams.
-  qr.applyExtension(fillSeams);
+  if (renderAs === "svg") qr.applyExtension(fillSeams);
   return qr;
 }
 

--- a/src/app/components/webmcp-marketing-tools.tsx
+++ b/src/app/components/webmcp-marketing-tools.tsx
@@ -81,7 +81,7 @@ export function WebMcpMarketingTools() {
       {
         name: "create_qr_code",
         description:
-          "Generate a free QR code for any link or text. Returns it as an SVG image data URL (pass format png to try a PNG) and opens the full generator at rdyrct.com/qr-code-generator with that value, where generate_qr_code and download_qr_code can change the colors, dot style, or logo and save a file. No account needed, and nothing is sent anywhere.",
+          "Generate a free QR code for any link or text. Returns it as an image data URL (PNG or SVG) and opens the full generator at rdyrct.com/qr-code-generator with that value, where generate_qr_code and download_qr_code can change the colors, dot style, or logo and save a file. No account needed, and nothing is sent anywhere.",
         inputSchema: {
           type: "object",
           properties: {
@@ -97,13 +97,11 @@ export function WebMcpMarketingTools() {
           const { qrDataUrl } = await import("./qr");
           const look = resolveLook({});
           const value = parsed.output.value;
-          // PNG needs a canvas raster, which some agent browsers can't do
-          // ("operation failed for an unknown transient reason"). SVG is a
-          // plain string and always works, so it's the default and the
-          // fallback. The generator page can still export a real PNG file.
+          // qrDataUrl renders a PNG through a canvas instance now, but keep a
+          // SVG fallback so a flaky raster still returns something usable.
           const render = (format: "png" | "svg") =>
             qrDataUrl(value, look, format).catch(() => null);
-          const dataUrl = (await render(parsed.output.format ?? "svg")) ?? (await render("svg"));
+          const dataUrl = (await render(parsed.output.format ?? "png")) ?? (await render("svg"));
           await navigate({ to: "/qr-code-generator", search: { value } });
           return (
             dataUrl ??

--- a/src/app/components/webmcp-marketing-tools.tsx
+++ b/src/app/components/webmcp-marketing-tools.tsx
@@ -81,7 +81,7 @@ export function WebMcpMarketingTools() {
       {
         name: "create_qr_code",
         description:
-          "Generate a free QR code for any link or text. Returns it as an image data URL (PNG or SVG) and opens the full generator at rdyrct.com/qr-code-generator with that value, where generate_qr_code and download_qr_code can change the colors, dot style, or logo and save a file. No account needed, and nothing is sent anywhere.",
+          "Generate a free QR code for any link or text. Returns it as an SVG image data URL (pass format png to try a PNG) and opens the full generator at rdyrct.com/qr-code-generator with that value, where generate_qr_code and download_qr_code can change the colors, dot style, or logo and save a file. No account needed, and nothing is sent anywhere.",
         inputSchema: {
           type: "object",
           properties: {
@@ -95,13 +95,20 @@ export function WebMcpMarketingTools() {
           const parsed = v.safeParse(qrInput, input);
           if (!parsed.success) return "Provide a non-empty link or text of up to 2000 characters.";
           const { qrDataUrl } = await import("./qr");
-          const dataUrl = qrDataUrl(
-            parsed.output.value,
-            resolveLook({}),
-            parsed.output.format ?? "png",
+          const look = resolveLook({});
+          const value = parsed.output.value;
+          // PNG needs a canvas raster, which some agent browsers can't do
+          // ("operation failed for an unknown transient reason"). SVG is a
+          // plain string and always works, so it's the default and the
+          // fallback. The generator page can still export a real PNG file.
+          const render = (format: "png" | "svg") =>
+            qrDataUrl(value, look, format).catch(() => null);
+          const dataUrl = (await render(parsed.output.format ?? "svg")) ?? (await render("svg"));
+          await navigate({ to: "/qr-code-generator", search: { value } });
+          return (
+            dataUrl ??
+            "Opened the QR generator with that value. Use download_qr_code there to save the file."
           );
-          await navigate({ to: "/qr-code-generator", search: { value: parsed.output.value } });
-          return dataUrl;
         },
       },
     ];


### PR DESCRIPTION
## Problem

`create_qr_code` (and the QR generator's PNG download) intermittently fail with:

> "The operation failed for an unknown transient reason (e.g. out of memory)."

`makeQR` builds an `svg`-type `QRCodeStyling` instance. Asking that for PNG bytes runs SVG string -> `<img>` decode -> `drawImage` -> `toBlob`, a chain that throws depending on decode timing / memory. Happens on full desktop Chrome (macOS included), not just constrained agent browsers.

## Fix

- `makeQR` takes a render type. `qrDataUrl` and the PNG download button use a `canvas` instance for PNG (straight to bitmap, no SVG raster), `svg` for SVG.
- The seam-merge extension is SVG-DOM only; a PNG rasterizes at native size where the seam is sub-pixel, so it's skipped for canvas with no visible change.
- `create_qr_code` defaults to PNG again, keeps an SVG fallback as insurance, and still hands off to the generator page.

## Verified

- `bun run check` + oxlint clean.
- In the dev browser: `qrDataUrl(..., "png")` returns a valid 109 KB `data:image/png` and `"svg"` a 20 KB `data:image/svg+xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)